### PR TITLE
1-org Separate IAM resources and add monitoring workspace permissions

### DIFF
--- a/1-org/README.md
+++ b/1-org/README.md
@@ -42,6 +42,7 @@ The purpose of this step is to setup top level shared folders, monitoring & netw
 | data\_access\_table\_expiration\_ms | Period before tables expire for data access logs in milliseconds. Default is 30 days. | number | `"2592000000"` | no |
 | default\_region | Default region for BigQuery resources. | string | n/a | yes |
 | domains\_to\_allow | The list of domains to allow users from in IAM. | list(string) | n/a | yes |
+| monitoring\_workspace\_users | Gsuite or Cloud Identity group that have access to Monitoring Workspaces. | string | n/a | yes |
 | org\_id | The organization id for the associated services | string | n/a | yes |
 | system\_event\_table\_expiration\_ms | Period before tables expire for system event logs in milliseconds. Default is 400 days. | number | `"34560000000"` | no |
 | terraform\_service\_account | Service account email of the account to impersonate to run Terraform. | string | n/a | yes |

--- a/1-org/iam.tf
+++ b/1-org/iam.tf
@@ -20,14 +20,14 @@
 
 resource "google_project_iam_member" "monitoring_prod_editor" {
   project = module.org_monitoring_prod.project_id
-  role   = "roles/monitoring.editor"
-  member = "group:${var.monitoring_workspace_users}"
+  role    = "roles/monitoring.editor"
+  member  = "group:${var.monitoring_workspace_users}"
 }
 
 resource "google_project_iam_member" "monitoring_nonprod_editor" {
   project = module.org_monitoring_nonprod.project_id
-  role   = "roles/monitoring.editor"
-  member = "group:${var.monitoring_workspace_users}"
+  role    = "roles/monitoring.editor"
+  member  = "group:${var.monitoring_workspace_users}"
 }
 
 /******************************************

--- a/1-org/iam.tf
+++ b/1-org/iam.tf
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/******************************************
+  Monitoring - IAM
+*****************************************/
+
+resource "google_project_iam_member" "monitoring_prod_editor" {
+  project = module.org_monitoring_prod.project_id
+  role   = "roles/monitoring.editor"
+  member = "group:${var.monitoring_workspace_users}"
+}
+
+resource "google_project_iam_member" "monitoring_nonprod_editor" {
+  project = module.org_monitoring_nonprod.project_id
+  role   = "roles/monitoring.editor"
+  member = "group:${var.monitoring_workspace_users}"
+}
+
+/******************************************
+  Audit Logs - IAM
+*****************************************/
+
+resource "google_project_iam_member" "audit_log_bq_user" {
+  project = module.org_audit_logs.project_id
+  role    = "roles/bigquery.user"
+  member  = "group:${var.audit_data_users}"
+}
+
+resource "google_project_iam_member" "audit_log_bq_data_viewer" {
+  project = module.org_audit_logs.project_id
+  role    = "roles/bigquery.dataViewer"
+  member  = "group:${var.audit_data_users}"
+}
+
+/******************************************
+  Billing BigQuery - IAM
+*****************************************/
+
+resource "google_project_iam_member" "billing_bq_user" {
+  project = module.org_billing_logs.project_id
+  role    = "roles/bigquery.user"
+  member  = "group:${var.billing_data_users}"
+}
+
+resource "google_project_iam_member" "billing_bq_viewer" {
+  project = module.org_billing_logs.project_id
+  role    = "roles/bigquery.dataViewer"
+  member  = "group:${var.billing_data_users}"
+}

--- a/1-org/log_sinks.tf
+++ b/1-org/log_sinks.tf
@@ -89,22 +89,6 @@ module "bq_data_access_logs" {
 }
 
 /******************************************
-  Audit Logs - IAM
-*****************************************/
-
-resource "google_project_iam_member" "audit_log_bq_user" {
-  project = module.org_audit_logs.project_id
-  role    = "roles/bigquery.user"
-  member  = "group:${var.audit_data_users}"
-}
-
-resource "google_project_iam_member" "audit_log_bq_data_viewer" {
-  project = module.org_audit_logs.project_id
-  role    = "roles/bigquery.dataViewer"
-  member  = "group:${var.audit_data_users}"
-}
-
-/******************************************
   Billing logs (Export configured manually)
 *****************************************/
 
@@ -114,16 +98,3 @@ resource "google_bigquery_dataset" "billing_dataset" {
   friendly_name = "GCP Billing Data"
   location      = var.default_region
 }
-
-resource "google_project_iam_member" "billing_bq_user" {
-  project = module.org_billing_logs.project_id
-  role    = "roles/bigquery.user"
-  member  = "group:${var.billing_data_users}"
-}
-
-resource "google_project_iam_member" "billing_bq_viewer" {
-  project = module.org_billing_logs.project_id
-  role    = "roles/bigquery.dataViewer"
-  member  = "group:${var.billing_data_users}"
-}
-

--- a/1-org/terraform.example.tfvars
+++ b/1-org/terraform.example.tfvars
@@ -20,6 +20,8 @@ billing_data_users = "gcp-billing-admins@example.com"
 
 audit_data_users = "gcp-security-admins@example.com"
 
+monitoring_workspace_users = "gcp-monitoring-admins@example.com"
+
 org_id = "000000000000"
 
 billing_account = "000000-000000-000000"

--- a/1-org/variables.tf
+++ b/1-org/variables.tf
@@ -44,6 +44,11 @@ variable "audit_data_users" {
   type        = string
 }
 
+variable "monitoring_workspace_users" {
+  description = "Gsuite or Cloud Identity group that have access to Monitoring Workspaces."
+  type        = string
+}
+
 variable "domains_to_allow" {
   description = "The list of domains to allow users from in IAM."
   type        = list(string)


### PR DESCRIPTION
Separate out the IAM resources for clarity, and add a IAM Member with `roles/monitoring.editor` to the Monitoring Projects