### PR TITLE
New jenkins Module:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,29 @@
+# OSX leaves these everywhere on SMB shares
+._*
 
-# Created by https://www.gitignore.io/api/terraform
-# Edit at https://www.gitignore.io/?templates=terraform
+# OSX trash
+.DS_Store
 
-### Terraform ###
+# Python
+*.pyc
+
+# Emacs save files
+*~
+\#*\#
+.\#*
+
+# Vim-related files
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+
+# IntelliJ IDEA files:
+.idea/
+
+### https://raw.github.com/github/gitignore/90f149de451a5433aebd94d02d11b0e28843a1af/Terraform.gitignore
+
 # Local .terraform directories
 **/.terraform/*
 
@@ -13,24 +34,19 @@
 # Crash log files
 crash.log
 
-# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
-# .tfvars files are managed as part of configuration and so should be included in
-# version control.
-#
-# example.tfvars
+# Kitchen files
+**/inspec.lock
+**.gem
+**/.kitchen
+**/.kitchen.local.yml
+**/Gemfile.lock
 
-# Ignore override files as they are usually used to override resources locally and so
-# are not checked in
-override.tf
-override.tf.json
-*_override.tf
-*_override.tf.json
-.idea/
+test/fixtures/shared/terraform.tfvars
 
-# Include override files you do wish to add to version control using negated pattern
-# !example_override.tf
+test/integration/gcloud/config.sh
+test/integration/tmp
 
-# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
-# example: *tfplan*
+credentials.json
 
-# End of https://www.gitignore.io/api/terraform
+# File to populate env vars used by Docker test runs
+.envrc

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,59 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+driver:
+  name: terraform
+  command_timeout: 2700
+
+provisioner:
+  name: terraform
+
+verifier:
+  name: terraform
+
+platforms:
+  - name: default
+
+suites:
+  - name: bootstrap
+    driver:
+      root_module_directory: test/fixtures/bootstrap/
+    verifier:
+      color: false
+      systems:
+        - name: bootstrap
+          backend: local
+          controls:
+            - bootstrap
+  - name: org
+    driver:
+      root_module_directory: test/fixtures/org/
+    verifier:
+      color: false
+      systems:
+        - name: org
+          backend: local
+          controls:
+            - org
+  - name: envs
+    driver:
+      root_module_directory: test/fixtures/envs/
+    verifier:
+      color: false
+      systems:
+        - name: envs
+          backend: local
+          controls:
+            - envs

--- a/0-bootstrap/README.md
+++ b/0-bootstrap/README.md
@@ -31,6 +31,8 @@ Further details of permissions required and resources created, can be found in t
 | default\_region | Default region to create resources where applicable. | string | `"us-central1"` | no |
 | group\_billing\_admins | Google Group for GCP Billing Administrators | string | n/a | yes |
 | group\_org\_admins | Google Group for GCP Organization Administrators | string | n/a | yes |
+| jenkins\_master\_ip\_addresses | A list of IP Addresses and masks of the Jenkins Master in the form ['0.0.0.0/0']. Needed to create a FW rule that allows communication with the Jenkins Agent GCE Instance. | list(string) | n/a | yes |
+| jenkins\_sa\_email | Email for Jenkins Agent service account. | string | `"jenkins-agent-gce-sa"` | no |
 | org\_id | GCP Organization ID | string | n/a | yes |
 | parent\_folder | Optional - if using a folder for testing. | string | `""` | no |
 
@@ -38,12 +40,7 @@ Further details of permissions required and resources created, can be found in t
 
 | Name | Description |
 |------|-------------|
-| cloudbuild\_project\_id | Project where CloudBuild configuration and terraform container image will reside. |
-| csr\_repos | List of Cloud Source Repos created by the module, linked to Cloud Build triggers. |
-| gcs\_bucket\_cloudbuild\_artifacts | Bucket used to store Cloud/Build artefacts in CloudBuild project. |
 | gcs\_bucket\_tfstate | Bucket used for storing terraform state for foundations pipelines in seed project. |
-| kms\_crypto\_key | KMS key created by the module. |
-| kms\_keyring | KMS Keyring created by the module. |
 | seed\_project\_id | Project where service accounts and core APIs will be enabled. |
 | terraform\_sa\_email | Email for privileged service account for Terraform. |
 | terraform\_sa\_name | Fully qualified name for privileged service account for Terraform. |
@@ -56,3 +53,26 @@ Further details of permissions required and resources created, can be found in t
 
 -   [gcloud sdk](https://cloud.google.com/sdk/install) >= 206.0.0
 -   [Terraform](https://www.terraform.io/downloads.html) >= 0.12.6
+
+### Configuration
+
+Use gcloud before running the terraform scripts to crate an application-default login configuration with GCP.
+
+## Troubleshooting
+
+If you don't crate an application-default login configuration with GCP, you might see errors about not having permissions to add projects to Billing account.
+
+```
+Error: Error setting billing account "aaaaaa-bbbbbb-cccccc" for project "projects/cft-jenkins-dc3a": googleapi: Error 400: Precondition check failed., failedPrecondition
+      on .terraform/modules/jenkins_project/terraform-google-project-factory-7.1.0/modules/core_project_factory/main.tf line 96, in resource "google_project" "main":
+      96: resource "google_project" "main" {
+```
+ or
+
+ ```
+Error: failed pre-requisites: missing permission on "billingAccounts/aaaaaa-bbbbbb-cccccc": billing.resourceAssociations.create
+  on .terraform/modules/jenkins_project/terraform-google-project-factory-7.1.0/modules/core_project_factory/main.tf line 96, in resource "google_project" "main":
+  96: resource "google_project" "main" {
+```
+
+**Solution:** run this in your command line `$ gcloud auth application-default login`

--- a/0-bootstrap/main.tf
+++ b/0-bootstrap/main.tf
@@ -83,16 +83,35 @@ module "seed_bootstrap" {
   ]
 }
 
-module "cloudbuild_bootstrap" {
-  source                  = "terraform-google-modules/bootstrap/google//modules/cloudbuild"
-  version                 = "~> 1.0"
-  org_id                  = var.org_id
-  folder_id               = google_folder.seed.id
-  billing_account         = var.billing_account
-  group_org_admins        = var.group_org_admins
-  default_region          = var.default_region
-  terraform_sa_email      = module.seed_bootstrap.terraform_sa_email
-  terraform_sa_name       = module.seed_bootstrap.terraform_sa_name
-  terraform_state_bucket  = module.seed_bootstrap.gcs_bucket_tfstate
-  sa_enable_impersonation = true
+// Choose between cloudbuild_bootstrap and jenkins_bootstrap by commenting / deleting the module you do not want to use
+// If you want to use the cloudbuild_bootstrap module, un-comment it and delete / comment the Jenkins_bootstrap module
+//module "cloudbuild_bootstrap" {
+//  source                  = "terraform-google-modules/bootstrap/google//modules/cloudbuild"
+//  version                 = "~> 1.0"
+//  org_id                  = var.org_id
+//  folder_id               = google_folder.seed.id
+//  billing_account         = var.billing_account
+//  group_org_admins        = var.group_org_admins
+//  default_region          = var.default_region
+//  terraform_sa_email      = module.seed_bootstrap.terraform_sa_email
+//  terraform_sa_name       = module.seed_bootstrap.terraform_sa_name
+//  terraform_state_bucket  = module.seed_bootstrap.gcs_bucket_tfstate
+//  sa_enable_impersonation = true
+//
+//  cloud_source_repos = [
+//    "gcp-org",
+//    "gcp-environments",
+//    "gcp-networks",
+//    "gcp-projects",
+//  ]
+//}
+
+module "jenkins_bootstrap" {
+  source                      = "./modules/jenkins"
+  org_id                      = var.org_id
+  folder_id                   = google_folder.seed.id
+  billing_account             = var.billing_account
+  default_region              = var.default_region
+  jenkins_sa_email            = var.jenkins_sa_email
+  jenkins_master_ip_addresses = var.jenkins_master_ip_addresses
 }

--- a/0-bootstrap/modules/jenkins/README.md
+++ b/0-bootstrap/modules/jenkins/README.md
@@ -1,0 +1,133 @@
+## Overview
+
+The objective of this module is to deploy a Google Cloud Platform project `prj-cicd` to host a Jenkins Agent that can be used to deploy your infrastructure changes. This module is a replica of the [cloudbuild module](https://github.com/terraform-google-modules/terraform-google-bootstrap/tree/master/modules/cloudbuild), but re-purposed to use jenkins instead of Cloud Build. This module creates:
+- The `prj-cicd` project to hold the Jenkins Agent
+- GCE Instance for the Jenkins Agent, assigning SSH public keys in the metadata to allow connectivity from the Jenkins Master.
+- FW rules to allow communication over port 22
+  - TODO: use a fixed IP or no public IP at all
+-  Custom Service account to run the Jenkins Agent's GCE Instance
+
+## Usage
+
+1. Add the SSH public keys of your Jenkins Agent in the file `./jenkins-agent-ssh-pub-keys/metadata-ssh-pub-keys`
+
+1. While developing only - Run `$ gcloud auth application-default login` before running `$ terraform plan` to avoid the errors below:
+```
+Error: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
+   on <empty> line 0:
+  (source code not available)
+```
+
+```
+Error: Error setting billing account "aaaaaa-bbbbbb-cccccc" for project "projects/cft-jenkins-dc3a": googleapi: Error 400: Precondition check failed., failedPrecondition
+      on .terraform/modules/jenkins/terraform-google-project-factory-7.1.0/modules/core_project_factory/main.tf line 96, in resource "google_project" "main":
+      96: resource "google_project" "main" {
+```
+
+```
+Error: failed pre-requisites: missing permission on "billingAccounts/aaaaaa-bbbbbb-cccccc": billing.resourceAssociations.create
+  on .terraform/modules/jenkins/terraform-google-project-factory-7.1.0/modules/core_project_factory/main.tf line 96, in resource "google_project" "main":
+  96: resource "google_project" "main" {
+```
+
+Run `$ gcloud auth application-default login` before running `$ terraform plan` to avoid the error below:
+```
+Error: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
+   on <empty> line 0:
+  (source code not available)
+```
+
+Run `$ gcloud auth application-default login` before running `$ terraform plan` to avoid the error below:
+```
+Error: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
+   on <empty> line 0:
+  (source code not available)
+```
+
+## Features
+
+1. Create a new GCP project using `project_prefix`
+1. Enable APIs in the project using `activate_apis`
+1. Create a GCE Instance to run the Jenkins Agent with SSH access using the supplied public key
+1. TODO:
+    1. Create a GCS bucket for Jenkins Artifacts using `project_prefix`
+    1. Create KMS Keyring and key for encryption
+        1. Grant access to decrypt to `terraform_sa_email` and to `jenkins_sa_email` (Jenkins GCE Instance custom service account)
+        1. Grant access to encrypt to `group_org_admins`
+    1. Optionally give `jenkins_sa_email` service account permissions to impersonate terraform service account using `sa_enable_impersonation` and supplied value for `terraform_sa_name`
+
+
+
+## Resources created
+
+- TODO
+    - KMS Keyring and key for secrets, including IAM for Cloudbuild, Org Admins and Terraform service account
+    - (optional) Cloudbuild impersonation permissions for a service account
+    - (optional) Cloud Source Repos, with triggers for terraform plan (all other branches) & terraform apply (master)
+
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| activate\_apis | List of APIs to enable in the Cloudbuild project. | list(string) | `<list>` | no |
+| billing\_account | The ID of the billing account to associate projects with. | string | n/a | yes |
+| default\_region | Default region to create resources where applicable. | string | `"us-central1"` | no |
+| folder\_id | The ID of a folder to host this project | string | `""` | no |
+| jenkins\_agent\_gce\_machine\_type | Jenkins Agent GCE Instance type. | string | `"n1-standard-1"` | no |
+| jenkins\_agent\_gce\_name | Jenkins Agent GCE Instance name. | string | `"jenkins-agent-01"` | no |
+| jenkins\_agent\_gce\_ssh\_pub\_key\_file | File with the SSH public key needed by the Jenkins Agent GCE Instance. The Jenkins Master holds the SSH private key. | string | `"./jenkins-agent-ssh-pub-keys/metadata-ssh-pub-keys"` | no |
+| jenkins\_agent\_gce\_ssh\_user | Jenkins Agent GCE Instance SSH username. | string | `"jenkins"` | no |
+| jenkins\_master\_ip\_addresses | A list of IP Addresses and masks of the Jenkins Master in the form ['0.0.0.0/0']. Needed to create a FW rule that allows communication with the Jenkins Agent GCE Instance. | list(string) | n/a | yes |
+| jenkins\_sa\_email | Email for Jenkins Agent service account. | string | `"jenkins-agent-gce-sa"` | no |
+| org\_id | GCP Organization ID | string | n/a | yes |
+| project\_labels | Labels to apply to the project. | map(string) | `<map>` | no |
+| project\_prefix | Name prefix to use for projects created. | string | `"prj"` | no |
+| sa\_enable\_impersonation | Allow org_admins group to impersonate service account & enable APIs required. | bool | `"false"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| cicd\_project\_id | Project where the cicd pipeline (Jenkins Agents and terraform builder container image) reside. |
+| jenkins\_agent\_gce\_instance\_id | Jenkins Agent GCE Instance id. |
+| jenkins\_sa\_email | Email for privileged custom service account for Jenkins Agent GCE instance. |
+| jenkins\_sa\_name | Fully qualified name for privileged custom service account for Jenkins Agent GCE instance. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Requirements
+
+### Software
+
+-   [gcloud sdk](https://cloud.google.com/sdk/install) >= 206.0.0
+-   [Terraform](https://www.terraform.io/downloads.html) >= 0.12.6
+-   [terraform-provider-google] plugin 2.1.x
+-   [terraform-provider-google-beta] plugin 2.1.x
+
+### Permissions
+
+- `roles/billing.user` on supplied billing account
+- `roles/resourcemanager.organizationAdmin` on GCP Organization
+- `roles/resourcemanager.projectCreator` on GCP Organization or folder
+
+### APIs
+
+A project with the following APIs enabled must be used to host the
+resources of this module:
+
+- Google Cloud Resource Manager API: `cloudresourcemanager.googleapis.com`
+- Google Cloud Billing API: `cloudbilling.googleapis.com`
+- Google Cloud IAM API: `iam.googleapis.com`
+- Google Cloud Storage API `storage-api.googleapis.com`
+- Google Cloud Service Usage API: `serviceusage.googleapis.com`
+- Google Cloud Compute API: `compute.googleapis.com`
+- Google Cloud KMS API: `cloudkms.googleapis.com`
+
+This API can be enabled in the default project created during establishing an organization.
+
+## Contributing
+
+Refer to the [contribution guidelines](../../../CONTRIBUTING.md) for
+information on contributing to this module.

--- a/0-bootstrap/modules/jenkins/main.tf
+++ b/0-bootstrap/modules/jenkins/main.tf
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  cicd_project_name           = format("%s-%s", var.project_prefix, "cicd")
+  impersonation_enabled_count = var.sa_enable_impersonation ? 1 : 0
+  activate_apis               = distinct(var.activate_apis)
+  jenkins_gce_fw_tags         = ["ssh-jenkins-agent"]
+}
+
+/******************************************
+  CICD project
+*******************************************/
+module "cicd_project" {
+  source                      = "terraform-google-modules/project-factory/google"
+  version                     = "~> 7.0" // TODO(caleonardo): use latest current versions so that we are up to date
+  name                        = local.cicd_project_name
+  random_project_id           = true
+  disable_services_on_destroy = false
+  folder_id                   = var.folder_id
+  org_id                      = var.org_id
+  billing_account             = var.billing_account
+  activate_apis               = local.activate_apis
+  labels                      = var.project_labels
+}
+
+/******************************************
+  Jenkins Agent GCE instance
+*******************************************/
+resource "google_service_account" "jenkins_agent_gce_sa" {
+  project      = module.cicd_project.project_id
+  account_id   = var.jenkins_sa_email
+  display_name = "CFT Jenkins Agent GCE custom Service Account"
+}
+
+resource "google_compute_instance" "jenkins_agent_gce_instance" {
+  project      = module.cicd_project.project_id
+  name         = var.jenkins_agent_gce_name
+  machine_type = var.jenkins_agent_gce_machine_type
+  zone         = "${var.default_region}-a"
+
+  tags = local.jenkins_gce_fw_tags
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    network = google_compute_network.jenkins_agents.self_link
+
+    access_config {
+      // Ephemeral IP
+      // TODO(caleonardo): This must not have an external IP at all - Only use for testing while developing
+    }
+  }
+
+  // Adding ssh public keys to the metadata, so the Jenkins Master can connect
+  metadata = {
+    enable-oslogin = "false"
+    ssh-keys       = "${var.jenkins_agent_gce_ssh_user}:${file(var.jenkins_agent_gce_ssh_pub_key_file)}"
+  }
+
+  // TODO(caleonardo): Setup the Java installation here for the Jenkins Agent
+  metadata_startup_script = "echo hi > /test.txt"
+
+  service_account {
+    email = google_service_account.jenkins_agent_gce_sa.email
+    scopes = [
+      // TODO(caleonardo): These scopes will need to change.
+      "https://www.googleapis.com/auth/compute.readonly",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/userinfo.email",
+    ]
+  }
+
+  // allow stopping the GCE instance to update some of its values
+  allow_stopping_for_update = true
+}
+
+/******************************************
+  Jenkins Agent GCE Firewall rules
+*******************************************/
+
+resource "google_compute_firewall" "allow_ssh_to_jenkins_agent_fw" {
+  project       = module.cicd_project.project_id
+  name          = "allow-ssh-to-jenkins-agents"
+  description   = "Allow the Jenkins Master (Client) to connect to the Jenkins Agents (Servers) using SSH."
+  network       = google_compute_network.jenkins_agents.name
+  source_ranges = var.jenkins_master_ip_addresses
+  target_tags   = local.jenkins_gce_fw_tags
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+}
+
+resource "google_compute_network" "jenkins_agents" {
+  project = module.cicd_project.project_id
+  name    = "jenkins-agents-network"
+}
+
+// TODO(caleonardo): add an option to create a Jenkins Master in GCP, in case the user doesn't have one on-prem

--- a/0-bootstrap/modules/jenkins/outputs.tf
+++ b/0-bootstrap/modules/jenkins/outputs.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "cicd_project_id" {
+  description = "Project where the cicd pipeline (Jenkins Agents and terraform builder container image) reside."
+  value       = module.cicd_project.project_id
+}
+
+output "jenkins_agent_gce_instance_id" {
+  description = "Jenkins Agent GCE Instance id."
+  value       = google_compute_instance.jenkins_agent_gce_instance.id
+}
+
+output "jenkins_sa_email" {
+  description = "Email for privileged custom service account for Jenkins Agent GCE instance."
+  value       = google_service_account.jenkins_agent_gce_sa.email
+}
+
+output "jenkins_sa_name" {
+  description = "Fully qualified name for privileged custom service account for Jenkins Agent GCE instance."
+  value       = google_service_account.jenkins_agent_gce_sa.name
+}

--- a/0-bootstrap/modules/jenkins/variables.tf
+++ b/0-bootstrap/modules/jenkins/variables.tf
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/******************************************
+  Required variables
+*******************************************/
+
+variable "org_id" {
+  description = "GCP Organization ID"
+  type        = string
+}
+
+variable "billing_account" {
+  description = "The ID of the billing account to associate projects with."
+  type        = string
+}
+
+variable "default_region" {
+  description = "Default region to create resources where applicable."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "jenkins_agent_gce_name" {
+  description = "Jenkins Agent GCE Instance name."
+  type        = string
+  default     = "jenkins-agent-01"
+}
+
+variable "jenkins_agent_gce_machine_type" {
+  description = "Jenkins Agent GCE Instance type."
+  type        = string
+  default     = "n1-standard-1"
+}
+
+variable "jenkins_agent_gce_ssh_user" {
+  description = "Jenkins Agent GCE Instance SSH username."
+  type        = string
+  default     = "jenkins"
+}
+
+// TODO(caleonardo): change this variable so it is a list of Strings instead of a separate file
+variable "jenkins_agent_gce_ssh_pub_key_file" {
+  description = "File with the SSH public key needed by the Jenkins Agent GCE Instance. The Jenkins Master holds the SSH private key."
+  type        = string
+  default     = "./jenkins-agent-ssh-pub-keys/metadata-ssh-pub-keys"
+}
+
+variable "jenkins_sa_email" {
+  description = "Email for Jenkins Agent service account."
+  type        = string
+  default     = "jenkins-agent-gce-sa"
+}
+
+variable "jenkins_master_ip_addresses" {
+  description = "A list of IP Addresses and masks of the Jenkins Master in the form ['0.0.0.0/0']. Needed to create a FW rule that allows communication with the Jenkins Agent GCE Instance."
+  type        = list(string)
+}
+
+/******************************************
+  Optional variables
+*******************************************/
+
+variable "project_labels" {
+  description = "Labels to apply to the project."
+  type        = map(string)
+  default     = {}
+}
+
+variable "project_prefix" {
+  description = "Name prefix to use for projects created."
+  type        = string
+  default     = "prj"
+}
+
+variable "activate_apis" {
+  description = "List of APIs to enable in the Cloudbuild project."
+  type        = list(string)
+
+  default = [
+    "serviceusage.googleapis.com",
+    "servicenetworking.googleapis.com",
+    "compute.googleapis.com",
+    "logging.googleapis.com",
+    "bigquery.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "cloudbilling.googleapis.com",
+    "iam.googleapis.com",
+    "admin.googleapis.com",
+    "appengine.googleapis.com",
+    "storage-api.googleapis.com",
+    "cloudkms.googleapis.com"
+  ]
+}
+
+variable "sa_enable_impersonation" {
+  description = "Allow org_admins group to impersonate service account & enable APIs required."
+  type        = bool
+  default     = false
+}
+
+variable "folder_id" {
+  description = "The ID of a folder to host this project"
+  type        = string
+  default     = ""
+}

--- a/0-bootstrap/modules/jenkins/versions.tf
+++ b/0-bootstrap/modules/jenkins/versions.tf
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = "~> 0.12.6"
+
+  required_providers {
+    google      = "~> 3.5"
+    google-beta = "~> 3.5"
+  }
+}

--- a/0-bootstrap/outputs.tf
+++ b/0-bootstrap/outputs.tf
@@ -34,28 +34,30 @@ output "gcs_bucket_tfstate" {
   value       = module.seed_bootstrap.gcs_bucket_tfstate
 }
 
-output "cloudbuild_project_id" {
-  description = "Project where CloudBuild configuration and terraform container image will reside."
-  value       = module.cloudbuild_bootstrap.cloudbuild_project_id
-}
-
-output "gcs_bucket_cloudbuild_artifacts" {
-  description = "Bucket used to store Cloud/Build artefacts in CloudBuild project."
-  value       = module.cloudbuild_bootstrap.gcs_bucket_cloudbuild_artifacts
-}
-
-output "csr_repos" {
-  description = "List of Cloud Source Repos created by the module, linked to Cloud Build triggers."
-  value       = module.cloudbuild_bootstrap.csr_repos
-}
-
-output "kms_keyring" {
-  description = "KMS Keyring created by the module."
-  value       = module.cloudbuild_bootstrap.kms_keyring
-}
-
-output "kms_crypto_key" {
-  description = "KMS key created by the module."
-  value       = module.cloudbuild_bootstrap.kms_crypto_key
-}
+// TODO(caleonardo / bharathkkb): Choose between cloudbuild_bootstrap and jenkins_bootstrap with an "enabled" variable
+// Un-comment the cloudbuild_bootstrap module and the outputs if you want to use Cloud Build instead of Jenkins
+//output "cloudbuild_project_id" {
+//  description = "Project where CloudBuild configuration and terraform container image will reside."
+//  value       = module.cloudbuild_bootstrap.cloudbuild_project_id
+//}
+//
+//output "gcs_bucket_cloudbuild_artifacts" {
+//  description = "Bucket used to store Cloud/Build artefacts in CloudBuild project."
+//  value       = module.cloudbuild_bootstrap.gcs_bucket_cloudbuild_artifacts
+//}
+//
+//output "csr_repos" {
+//  description = "List of Cloud Source Repos created by the module, linked to Cloud Build triggers."
+//  value       = module.cloudbuild_bootstrap.csr_repos
+//}
+//
+//output "kms_keyring" {
+//  description = "KMS Keyring created by the module."
+//  value       = module.cloudbuild_bootstrap.kms_keyring
+//}
+//
+//output "kms_crypto_key" {
+//  description = "KMS key created by the module."
+//  value       = module.cloudbuild_bootstrap.kms_crypto_key
+//}
 

--- a/0-bootstrap/variables.tf
+++ b/0-bootstrap/variables.tf
@@ -45,3 +45,14 @@ variable "parent_folder" {
   type        = string
   default     = ""
 }
+
+variable "jenkins_sa_email" {
+  description = "Email for Jenkins Agent service account."
+  type        = string
+  default     = "jenkins-agent-gce-sa"
+}
+
+variable "jenkins_master_ip_addresses" {
+  description = "A list of IP Addresses and masks of the Jenkins Master in the form ['0.0.0.0/0']. Needed to create a FW rule that allows communication with the Jenkins Agent GCE Instance."
+  type        = list(string)
+}

--- a/1-org/README.md
+++ b/1-org/README.md
@@ -46,6 +46,7 @@ The purpose of this step is to setup top level shared folders, monitoring & netw
 | domains\_to\_allow | The list of domains to allow users from in IAM. | list(string) | n/a | yes |
 | org\_id | The organization id for the associated services | string | n/a | yes |
 | parent\_folder | Optional - if using a folder for testing. | string | `""` | no |
+| skip\_gcloud\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
 | system\_event\_table\_expiration\_ms | Period before tables expire for system event logs in milliseconds. Default is 400 days. | number | `"34560000000"` | no |
 | terraform\_service\_account | Service account email of the account to impersonate to run Terraform. | string | n/a | yes |
 

--- a/1-org/projects.tf
+++ b/1-org/projects.tf
@@ -20,7 +20,7 @@
 
 module "org_audit_logs" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 7.0"
+  version                     = "~> 8.0"
   random_project_id           = "true"
   impersonate_service_account = var.terraform_service_account
   default_service_account     = "depriviledge"
@@ -28,6 +28,7 @@ module "org_audit_logs" {
   org_id                      = var.org_id
   billing_account             = var.billing_account
   folder_id                   = google_folder.logs.id
+  skip_gcloud_download        = var.skip_gcloud_download
   activate_apis               = ["logging.googleapis.com", "bigquery.googleapis.com"]
 
   labels = {
@@ -38,7 +39,7 @@ module "org_audit_logs" {
 
 module "org_billing_logs" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 7.0"
+  version                     = "~> 8.0"
   random_project_id           = "true"
   impersonate_service_account = var.terraform_service_account
   default_service_account     = "depriviledge"
@@ -46,6 +47,7 @@ module "org_billing_logs" {
   org_id                      = var.org_id
   billing_account             = var.billing_account
   folder_id                   = google_folder.logs.id
+  skip_gcloud_download        = var.skip_gcloud_download
   activate_apis               = ["logging.googleapis.com", "bigquery.googleapis.com"]
 
   labels = {
@@ -60,7 +62,7 @@ module "org_billing_logs" {
 
 module "org_secrets" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 7.0"
+  version                     = "~> 8.0"
   random_project_id           = "true"
   impersonate_service_account = var.terraform_service_account
   default_service_account     = "depriviledge"
@@ -68,6 +70,7 @@ module "org_secrets" {
   org_id                      = var.org_id
   billing_account             = var.billing_account
   folder_id                   = google_folder.logs.id
+  skip_gcloud_download        = var.skip_gcloud_download
   activate_apis               = ["logging.googleapis.com", "secretmanager.googleapis.com"]
 
   labels = {

--- a/1-org/variables.tf
+++ b/1-org/variables.tf
@@ -72,3 +72,9 @@ variable "parent_folder" {
   type        = string
   default     = ""
 }
+
+variable "skip_gcloud_download" {
+  description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"
+  type        = bool
+  default     = true
+}

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,51 @@ docker_generate_docs:
 # Alias for backwards compatibility
 .PHONY: generate_docs
 generate_docs: docker_generate_docs
+
+# Enter docker container for local development
+.PHONY: docker_run
+docker_run:
+	docker run --rm -it \
+		-e SERVICE_ACCOUNT_JSON \
+		-e TF_VAR_org_id \
+		-e TF_VAR_folder_id \
+		-e TF_VAR_billing_account \
+		-e TF_VAR_group_email \
+		-e TF_VAR_domain_to_allow \
+		-v "$(CURDIR)":/workspace \
+		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
+		/bin/bash
+
+# Execute prepare tests within the docker container
+.PHONY: docker_test_prepare
+docker_test_prepare:
+	docker run --rm -it \
+		-e SERVICE_ACCOUNT_JSON \
+		-e TF_VAR_org_id \
+		-e TF_VAR_folder_id \
+		-e TF_VAR_billing_account \
+		-e TF_VAR_group_email \
+		-v "$(CURDIR)":/workspace \
+		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
+		/usr/local/bin/execute_with_credentials.sh prepare_environment
+
+# Clean up test environment within the docker container
+.PHONY: docker_test_cleanup
+docker_test_cleanup:
+	docker run --rm -it \
+		-e SERVICE_ACCOUNT_JSON \
+		-e TF_VAR_org_id \
+		-e TF_VAR_folder_id \
+		-e TF_VAR_billing_account \
+		-v "$(CURDIR)":/workspace \
+		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
+		/usr/local/bin/execute_with_credentials.sh cleanup_environment
+
+# Execute integration tests within the docker container
+.PHONY: docker_test_integration
+docker_test_integration:
+	docker run --rm -it \
+		-e SERVICE_ACCOUNT_JSON \
+		-v "$(CURDIR)":/workspace \
+		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
+		/usr/local/bin/test_integration.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # terraform-example-foundation
 This is an example repo showing how the CFT Terraform modules can be composed to build a secure GCP foundation.
-The supplied structure and code is intended to form a starting point for building your own foundation with pragmatic defaults you can customize to meet your own requirements. Currently, the code leverages Google Cloud Build for deployment of the Terraform from step 1 onwards.
-Cloud Build has been chosen to allow teams to quickly get started without needing to deploy a CI/CD tool, although it is worth noting the code can easily be executed by your preferred tool.
+The supplied structure and code is intended to form a starting point for building your own foundation with pragmatic defaults you can customize to meet your own requirements. Currently, the code leverages Google Cloud Build for deployment of the Terraform from step 1 onwards. An option to use Jenkins is also available.
+Cloud Build has been chosen by default to allow teams to quickly get started without needing to deploy a CI/CD tool, although it is worth noting the code can easily be executed by your preferred tool. An example using Jenkins is also provided.
 
 ## Overview
 This repo contains several distinct Terraform projects each within their own directory that must be applied separately, but in sequence.
@@ -10,7 +10,20 @@ Each of these Terraform projects are to be layered on top of each other, running
 ### [0. bootstrap](./0-bootstrap/)
 
 This stage executes the [CFT Bootstrap module](https://github.com/terraform-google-modules/terraform-google-bootstrap) which bootstraps an existing GCP organization, creating all the required GCP resources & permissions to start using the Cloud Foundation Toolkit (CFT).
-This includes; projects, service accounts and a Terraform state bucket. After executing this step, you will have the following structure:
+- The `cft-cloudbuild` project, which contains:
+  - Cloud Build implementation
+  - Cloud Source Repository
+  - Build pipeline
+  - Other resources
+- The `cft-seed` project, which contains:
+  - Terraform state bucket
+  - KMS configuration to encrypt the state bucket's content
+  - Custom Service Account used by Terraform to create new resources in GCP
+  - Other resources
+
+A Best practice is to use custom service accounts instead of default ones. However, Cloud Build doesn't support custom service accounts yet. To avoid using the default Cloud Build service account `@cloudbuild.gserviceaccount.com` for deploying new infrastructure, this default service account is instead granted access to generate tokens over the Terraform custom service account. If using Jenkins, this limitation does not exist, because we can assign a custom service account directly to the GCE instance that runs as a Jenkins Agent.
+
+After executing this step, you will have the following structure:
 
 ```
 example-organization/

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+timeout: 3600s
 steps:
-- name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  id: 'placeholder'
-  args: ['/bin/bash', '--version']
+- id: prepare
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && prepare_environment']
+  env:
+  - 'TF_VAR_org_id=$_ORG_ID'
+  - 'TF_VAR_folder_id=$_FOLDER_ID'
+  - 'TF_VAR_billing_account=$_BILLING_ACCOUNT'
+  - 'TF_VAR_group_email=test-gcp-org-admins@test.infra.cft.tips'
+- id: create
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do create']
+- id: converge-bootstrap
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge bootstrap-default']
+- id: verify-bootstrap
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify bootstrap-default']
+- id: destroy-bootstrap
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy bootstrap-default']
+#   # Required to rerun to reinstate ci-integration account as project creator as not member of group_org_admins.
+# - id: prepare-rerun-cloudbuild-enabled
+#   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+#   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && prepare_environment']
+#   env:
+#   - 'TF_VAR_org_id=$_ORG_ID'
+#   - 'TF_VAR_folder_id=$_FOLDER_ID'
+#   - 'TF_VAR_billing_account=$_BILLING_ACCOUNT'
+#   - 'TF_VAR_group_org_admins=test-gcp-org-admins@test.infra.cft.tips'
+#   - 'TF_VAR_group_billing_admins=test-gcp-billing-admins@test.infra.cft.tips'
+- id: create-org
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do create org-default']
+- id: converge-org
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge org-default']
+  env:
+  - 'TF_VAR_domain_to_allow=test.infra.cft.tips'
+- id: verify-org
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify org-default']
+- id: destroy-org
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy org-default']
+  env:
+  - 'TF_VAR_domain_to_allow=test.infra.cft.tips'
 tags:
 - 'ci'
-- 'placeholder'
+- 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
   _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'

--- a/test/fixtures/bootstrap/main.tf
+++ b/test/fixtures/bootstrap/main.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "bootstrap" {
+  source               = "../../../0-bootstrap"
+  parent_folder        = var.parent_folder
+  org_id               = var.org_id
+  group_org_admins     = var.group_email
+  group_billing_admins = var.group_email
+  billing_account      = var.billing_account
+  org_project_creators = var.org_project_creators
+}

--- a/test/fixtures/bootstrap/variables.tf
+++ b/test/fixtures/bootstrap/variables.tf
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "org_id" {
+  description = "The numeric organization id"
+}
+
+variable "parent_folder" {
+  description = "The folder to deploy in"
+}
+
+variable "billing_account" {
+  description = "The billing account id associated with the project, e.g. XXXXXX-YYYYYY-ZZZZZZ"
+}
+
+variable "group_email" {
+  description = "The group that will be assigned permissions for testing."
+}
+
+variable "org_project_creators" {
+  description = "Additional list of members to have project creator role accross the organization. Prefix of group: user: or serviceAccount: is required."
+  type        = list(string)
+  default     = []
+}

--- a/test/fixtures/envs/main.tf
+++ b/test/fixtures/envs/main.tf
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "dev" {
+  source                     = "../../../2-environments/envs/dev"
+  org_id                     = var.org_id
+  billing_account            = var.billing_account
+  monitoring_workspace_users = var.group_email
+  parent_folder              = var.parent_folder
+  terraform_service_account  = var.terraform_sa_email
+}
+
+module "nonprod" {
+  source                     = "../../../2-environments/envs/nonprod"
+  org_id                     = var.org_id
+  billing_account            = var.billing_account
+  monitoring_workspace_users = var.group_email
+  parent_folder              = var.parent_folder
+  terraform_service_account  = var.terraform_sa_email
+}
+
+module "prod" {
+  source                     = "../../../2-environments/envs/prod"
+  org_id                     = var.org_id
+  billing_account            = var.billing_account
+  monitoring_workspace_users = var.group_email
+  parent_folder              = var.parent_folder
+  terraform_service_account  = var.terraform_sa_email
+}

--- a/test/fixtures/envs/variables.tf
+++ b/test/fixtures/envs/variables.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "org_id" {
+  description = "The numeric organization id"
+}
+
+variable "parent_folder" {
+  description = "The folder to deploy in"
+}
+
+variable "billing_account" {
+  description = "The billing account id associated with the project, e.g. XXXXXX-YYYYYY-ZZZZZZ"
+}
+
+variable "group_email" {
+  description = "The group that will be assigned permissions for testing."
+}
+
+variable "terraform_sa_email" {
+  description = "The SA that will be used for creating projects."
+}

--- a/test/fixtures/org/main.tf
+++ b/test/fixtures/org/main.tf
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "test" {
+  source                    = "../../../1-org"
+  parent_folder             = var.parent_folder
+  org_id                    = var.org_id
+  billing_account           = var.billing_account
+  terraform_service_account = var.terraform_sa_email
+  default_region            = "us-east4"
+  billing_data_users        = var.group_email
+  audit_data_users          = var.group_email
+  domains_to_allow          = [var.domain_to_allow]
+}

--- a/test/fixtures/org/variables.tf
+++ b/test/fixtures/org/variables.tf
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "org_id" {
+  description = "The numeric organization id"
+}
+
+variable "parent_folder" {
+  description = "The folder to deploy in"
+}
+
+variable "billing_account" {
+  description = "The billing account id associated with the project, e.g. XXXXXX-YYYYYY-ZZZZZZ"
+}
+
+variable "group_email" {
+  description = "The group that will be assigned permissions for testing."
+}
+
+variable "terraform_sa_email" {
+  description = "The SA that will be used for creating projects."
+}
+
+variable "domain_to_allow" {
+  description = "The test domain_to_allow allow users from in IAM."
+}

--- a/test/integration/bootstrap/controls/bootstrap.rb
+++ b/test/integration/bootstrap/controls/bootstrap.rb
@@ -1,0 +1,13 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/test/integration/envs/controls/envs.rb
+++ b/test/integration/envs/controls/envs.rb
@@ -1,0 +1,13 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/test/integration/envs/inspec.yml
+++ b/test/integration/envs/inspec.yml
@@ -1,0 +1,4 @@
+name: org
+attributes:
+  - name: foo
+    required: true

--- a/test/integration/org/controls/org.rb
+++ b/test/integration/org/controls/org.rb
@@ -1,0 +1,13 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/test/integration/org/inspec.yml
+++ b/test/integration/org/inspec.yml
@@ -1,0 +1,4 @@
+name: org
+attributes:
+  - name: foo
+    required: true

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  int_required_roles = [
+    "roles/owner"
+  ]
+  int_org_required_roles = [
+    "roles/billing.user",
+    "roles/resourcemanager.organizationAdmin",
+    "roles/resourcemanager.projectCreator",
+    "roles/resourcemanager.folderAdmin",
+    "roles/iam.serviceAccountTokenCreator",
+    "roles/orgpolicy.policyAdmin",
+    "roles/logging.admin",
+  ]
+}
+
+resource "google_organization_iam_member" "org_admins_group" {
+  for_each = toset(local.int_org_required_roles)
+  org_id   = var.org_id
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.int_test.email}"
+}
+
+resource "google_billing_account_iam_member" "tf_billing_user" {
+  billing_account_id = var.billing_account
+  role               = "roles/billing.admin"
+  member             = "serviceAccount:${google_service_account.int_test.email}"
+}
+
+resource "google_service_account" "int_test" {
+  project      = module.project.project_id
+  account_id   = "ci-account"
+  display_name = "ci-account"
+}
+
+resource "google_project_iam_member" "int_test" {
+  for_each = toset(local.int_required_roles)
+
+  project = module.project.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.int_test.email}"
+}
+
+resource "google_service_account_key" "int_test" {
+  service_account_id = google_service_account.int_test.id
+}

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "random_id" "random_project_id_suffix" {
+  byte_length = 2
+}
+
+resource "google_folder" "test_folder" {
+  display_name = "test_foundation_folder_${random_id.random_project_id_suffix.hex}"
+  parent       = "folders/${var.folder_id}"
+}
+
+module "project" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 8.0"
+
+  name                 = "ci-bootstrap"
+  random_project_id    = true
+  org_id               = var.org_id
+  folder_id            = var.folder_id
+  billing_account      = var.billing_account
+  skip_gcloud_download = true
+
+  activate_apis = [
+    "cloudresourcemanager.googleapis.com",
+    "cloudbilling.googleapis.com",
+    "iam.googleapis.com",
+    "storage-api.googleapis.com",
+    "serviceusage.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "sourcerepo.googleapis.com",
+    "cloudkms.googleapis.com",
+    "bigquery.googleapis.com",
+  ]
+}

--- a/test/setup/outputs.tf
+++ b/test/setup/outputs.tf
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "project_id" {
+  value = module.project.project_id
+}
+
+
+output "parent_folder" {
+  description = "Parent folder id"
+  value       = split("/", google_folder.test_folder.id)[1]
+}
+
+output "sa_key" {
+  value     = google_service_account_key.int_test.private_key
+  sensitive = true
+}
+
+output "terraform_sa_email" {
+  value = google_service_account.int_test.email
+}
+
+output "org_project_creators" {
+  value = ["serviceAccount:${google_service_account.int_test.email}"]
+}
+
+output "org_id" {
+  value = var.org_id
+}
+
+output "billing_account" {
+  value = var.billing_account
+}
+
+output "group_email" {
+  value = var.group_email
+}

--- a/test/setup/variables.tf
+++ b/test/setup/variables.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "org_id" {
+  description = "The numeric organization id"
+}
+
+variable "folder_id" {
+  description = "The folder to deploy in"
+}
+
+variable "billing_account" {
+  description = "The billing account id associated with the project, e.g. XXXXXX-YYYYYY-ZZZZZZ"
+}
+
+variable "group_email" {
+  description = "The group that will be assigned permissions for testing."
+}


### PR DESCRIPTION
New jenkins Module - Creates:
 - The prj-cicd project to hold Jenkins Agent
 - GCE Instance for the Jenkins Agent, assigning the SSH public keys needed to allow connectivity from the Jenkins Master
 - FW rules to allow communication over port 22 - TODO: use a fixed IP or no public IP at all
 -  Custom Service account to run the Jenkins Agent's GCE Instance