### PR TITLE
the creation of the base and restricted share vpc host projects under…

### DIFF
--- a/2-environments/envs/dev/main.tf
+++ b/2-environments/envs/dev/main.tf
@@ -17,7 +17,8 @@
 module "env" {
   source = "../../modules/env_baseline"
 
-  env = "dev"
+  env              = "dev"
+  environment_code = "d"
 
   parent_id                  = var.parent_folder != "" ? "folders/${var.parent_folder}" : "organizations/${var.org_id}"
   org_id                     = var.org_id

--- a/2-environments/envs/nonprod/main.tf
+++ b/2-environments/envs/nonprod/main.tf
@@ -17,7 +17,8 @@
 module "env" {
   source = "../../modules/env_baseline"
 
-  env = "nonprod"
+  env              = "nonprod"
+  environment_code = "n"
 
   parent_id                  = var.parent_folder != "" ? "folders/${var.parent_folder}" : "organizations/${var.org_id}"
   org_id                     = var.org_id

--- a/2-environments/envs/prod/main.tf
+++ b/2-environments/envs/prod/main.tf
@@ -17,7 +17,8 @@
 module "env" {
   source = "../../modules/env_baseline"
 
-  env = "prod"
+  env              = "prod"
+  environment_code = "p"
 
   parent_id                  = var.parent_folder != "" ? "folders/${var.parent_folder}" : "organizations/${var.org_id}"
   org_id                     = var.org_id

--- a/2-environments/modules/env_baseline/networking.tf
+++ b/2-environments/modules/env_baseline/networking.tf
@@ -40,3 +40,52 @@ module "vpc_host_project" {
     application_name = "org-shared-vpc-${var.env}"
   }
 }
+
+
+module "base_shared_vpc_host_project" {
+  source                      = "terraform-google-modules/project-factory/google"
+  version                     = "~> 7.0"
+  random_project_id           = "true"
+  impersonate_service_account = var.terraform_service_account
+  name                        = "prj-${var.environment_code}-shared-base"
+  org_id                      = var.org_id
+  billing_account             = var.billing_account
+  folder_id                   = google_folder.env.id
+  activate_apis = [
+    "compute.googleapis.com",
+    "dns.googleapis.com",
+    "servicenetworking.googleapis.com",
+    "container.googleapis.com",
+    "logging.googleapis.com"
+  ]
+
+  labels = {
+    environment      = var.env
+    application_name = "base-shared-vpc-host-${var.env}"
+  }
+}
+
+module "restricted_shared_vpc_host_project" {
+  source                      = "terraform-google-modules/project-factory/google"
+  version                     = "~> 7.0"
+  random_project_id           = "true"
+  impersonate_service_account = var.terraform_service_account
+  name                        = "prj-${var.environment_code}-shared-restricted"
+  org_id                      = var.org_id
+  billing_account             = var.billing_account
+  folder_id                   = google_folder.env.id
+  activate_apis = [
+    "compute.googleapis.com",
+    "dns.googleapis.com",
+    "servicenetworking.googleapis.com",
+    "container.googleapis.com",
+    "logging.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "accesscontextmanager.googleapis.com"
+  ]
+
+  labels = {
+    environment      = var.env
+    application_name = "restricted-shared-vpc-host-${var.env}"
+  }
+}

--- a/2-environments/modules/env_baseline/variables.tf
+++ b/2-environments/modules/env_baseline/variables.tf
@@ -19,6 +19,11 @@ variable "env" {
   type        = string
 }
 
+variable "environment_code" {
+  type        = string
+  description = "A short form of the folder level resources (environment) within the Google Cloud organization (ex. d)."
+}
+
 variable "parent_id" {
   description = "The parent folder or org for environments"
   type        = string


### PR DESCRIPTION
This PR adds the creation of the new **base and restricted** share vpc host projects under the `dev`, `nonprod` and `prod` folders.

Old `org-shared-vpc-ENV` projects will be removed after the merge of the the new `3-network` infrastructure.