### PR TITLE
Add missing provider configuration to allow impersonation.

### DIFF
--- a/2-environments/envs/dev/providers.tf
+++ b/2-environments/envs/dev/providers.tf
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  tf_sa = var.terraform_service_account
+}
+
+provider "google" {
+  alias = "impersonate"
+
+  scopes = [
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/userinfo.email",
+  ]
+}
+
+data "google_service_account_access_token" "default" {
+  provider               = google.impersonate
+  target_service_account = local.tf_sa
+  scopes                 = ["userinfo-email", "cloud-platform"]
+  lifetime               = "600s"
+}
+
+/******************************************
+  Provider credential configuration
+ *****************************************/
+provider "google" {
+  access_token = data.google_service_account_access_token.default.access_token
+  version      = "~> 3.12"
+}
+
+provider "google-beta" {
+  access_token = data.google_service_account_access_token.default.access_token
+  version      = "~> 3.12"
+}
+

--- a/2-environments/envs/nonprod/providers.tf
+++ b/2-environments/envs/nonprod/providers.tf
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  tf_sa = var.terraform_service_account
+}
+
+provider "google" {
+  alias = "impersonate"
+
+  scopes = [
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/userinfo.email",
+  ]
+}
+
+data "google_service_account_access_token" "default" {
+  provider               = google.impersonate
+  target_service_account = local.tf_sa
+  scopes                 = ["userinfo-email", "cloud-platform"]
+  lifetime               = "600s"
+}
+
+/******************************************
+  Provider credential configuration
+ *****************************************/
+provider "google" {
+  access_token = data.google_service_account_access_token.default.access_token
+  version      = "~> 3.12"
+}
+
+provider "google-beta" {
+  access_token = data.google_service_account_access_token.default.access_token
+  version      = "~> 3.12"
+}
+

--- a/2-environments/envs/prod/providers.tf
+++ b/2-environments/envs/prod/providers.tf
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  tf_sa = var.terraform_service_account
+}
+
+provider "google" {
+  alias = "impersonate"
+
+  scopes = [
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/userinfo.email",
+  ]
+}
+
+data "google_service_account_access_token" "default" {
+  provider               = google.impersonate
+  target_service_account = local.tf_sa
+  scopes                 = ["userinfo-email", "cloud-platform"]
+  lifetime               = "600s"
+}
+
+/******************************************
+  Provider credential configuration
+ *****************************************/
+provider "google" {
+  access_token = data.google_service_account_access_token.default.access_token
+  version      = "~> 3.12"
+}
+
+provider "google-beta" {
+  access_token = data.google_service_account_access_token.default.access_token
+  version      = "~> 3.12"
+}
+


### PR DESCRIPTION
Projects created in step `2-environment`  do not have the Terraform service account created  in step `0-bootstrap` as the owner of the project. 

The owner of the project created is the user running Terraform. 

Step `2-environment` is missing the  `providers.tf` that enable the impersonation using the terraform service account created  in step `0-bootstrap`.

@rjerrems @morgante  @bharathkkb  could you please take a look at this fix?
