### PR TITLE
Kellydodson: example-foundation readme updates

### DIFF
--- a/1-org/README.md
+++ b/1-org/README.md
@@ -5,15 +5,17 @@ The purpose of this step is to setup top level shared folders, monitoring & netw
 ## Prerequisites
 
 1. 0-bootstrap executed successfully.
+2. Cloud Identity / Gsuite group for security admins
+3. Membership in the security admins group for user running terraform
 
 ## Usage
 
 ### Setup to run via Cloud Build
-1. Clone repo `gcloud source repos clone gcp-org --project=YOUR_CLOUD_BUILD_PROJECT_ID (this is from `terraform output` from the previous section, 0-bootstrap)`
+1. Clone repo `gcloud source repos clone gcp-org --project=YOUR_CLOUD_BUILD_PROJECT_ID` (this is from terraform output from the previous section, 0-bootstrap)
 1. Navigate into the repo `cd gcp-org` and change to a non master branch `git checkout -b plan`
 1. Copy contents of foundation to new repo `cp -R ../terraform-example-foundation/1-org/* .` (modify accordingly based on your current directory)
 1. Copy cloud build configuration files for terraform `cp ../terraform-example-foundation/build/cloudbuild-tf-* . ` (modify accordingly based on your current directory)
-1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap (you can re-run `terraform output` in the 0-bootstrap directory to find these values).
+1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap (you can re-run `terraform output` in the 0-bootstrap directory to find these values). Make sure that `default_region` is set to a valid [BigQuery dataset region](https://cloud.google.com/bigquery/docs/locations).
 1. Rename backend.tf.example backend.tf and update with your bucket from bootstrap.
 1. Commit changes with `git add .` and `git commit -m 'Your message'`
 1. Push your non master branch to trigger a plan `git push --set-upstream origin plan`
@@ -42,7 +44,6 @@ The purpose of this step is to setup top level shared folders, monitoring & netw
 | data\_access\_table\_expiration\_ms | Period before tables expire for data access logs in milliseconds. Default is 30 days. | number | `"2592000000"` | no |
 | default\_region | Default region for BigQuery resources. | string | n/a | yes |
 | domains\_to\_allow | The list of domains to allow users from in IAM. | list(string) | n/a | yes |
-| monitoring\_workspace\_users | Gsuite or Cloud Identity group that have access to Monitoring Workspaces. | string | n/a | yes |
 | org\_id | The organization id for the associated services | string | n/a | yes |
 | parent\_folder | Optional - if using a folder for testing. | string | `""` | no |
 | system\_event\_table\_expiration\_ms | Period before tables expire for system event logs in milliseconds. Default is 400 days. | number | `"34560000000"` | no |

--- a/1-org/README.md
+++ b/1-org/README.md
@@ -42,6 +42,7 @@ The purpose of this step is to setup top level shared folders, monitoring & netw
 | data\_access\_table\_expiration\_ms | Period before tables expire for data access logs in milliseconds. Default is 30 days. | number | `"2592000000"` | no |
 | default\_region | Default region for BigQuery resources. | string | n/a | yes |
 | domains\_to\_allow | The list of domains to allow users from in IAM. | list(string) | n/a | yes |
+| monitoring\_workspace\_users | Gsuite or Cloud Identity group that have access to Monitoring Workspaces. | string | n/a | yes |
 | org\_id | The organization id for the associated services | string | n/a | yes |
 | parent\_folder | Optional - if using a folder for testing. | string | `""` | no |
 | system\_event\_table\_expiration\_ms | Period before tables expire for system event logs in milliseconds. Default is 400 days. | number | `"34560000000"` | no |

--- a/2-environments/README.md
+++ b/2-environments/README.md
@@ -30,7 +30,7 @@ The purpose of this step is to set up dev, nonprod, and prod environments within
 1. Change into 2-environments folder
 1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap. Copy terraform.tfvars into each of the folders within the envs/ folder.
 1. Within each envs/ folder, update backend.tf with your bucket name from the bootstrap step.
-1. In sequence, change into each folder within the envs/ folder and run the following commands: 
+1. In sequence, change into each folder within the envs/ folder and run the following commands:
     1. Run `terraform init`
     1. Run `terraform plan` and review output
     1. Run `terraform apply`

--- a/2-environments/README.md
+++ b/2-environments/README.md
@@ -1,0 +1,36 @@
+# 2-environments
+
+The purpose of this step is to set up dev, nonprod, and prod environments within the GCP organization.
+
+## Prerequisites
+
+1. 0-bootstrap executed successfully.
+1. 1-org executed successfully.
+1. Cloud Identity / Gsuite group for monitoring admins.
+1. Membership in the monitoring admins group for user running terraform
+1. Empty Cloud Source Repository "gcp-envs" in Cloud Build project. Connect Cloud Build triggers replicated from the gcp-org CSR repository.
+
+## Usage
+### Setup to run via Cloud Build
+1. Clone repo `gcloud source repos clone gcp-envs --project=YOUR_CLOUD_BUILD_PROJECT_ID`
+1. Change freshly cloned repo and change to non master branch `git checkout -b plan`
+1. Copy contents of foundation to new repo `cp -R ../terraform-example-foundation/2-environments/* .` (modify accordingly based on your current directory)
+1. Copy cloud build configuration files for terraform `cp ../terraform-example-foundation/build/cloudbuild-tf-* . ` (modify accordingly based on your current directory)
+1. Change cloud build configuration files in order to `terraform init`, `terraform plan`, and `terraform apply` each environment in the envs folder.
+1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap. Copy terraform.tfvars into each of the folders within the envs/ folder.
+1. Within each envs/ folder, update backend.tf with your bucket name from the bootstrap step.
+1. Commit changes with `git add .` and `git commit -m 'Your message'`
+1. Push your non master branch to trigger a plan `git push --set-upstream origin plan`
+    1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
+1. Merge changes to master with `git checkout -b master` and `git push origin master`
+    1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
+
+
+### Run terraform locally
+1. Change into 2-environments folder
+1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap. Copy terraform.tfvars into each of the folders within the envs/ folder.
+1. Within each envs/ folder, update backend.tf with your bucket name from the bootstrap step.
+1. In sequence, change into each folder within the envs/ folder and run the following commands: 
+    1. Run `terraform init`
+    1. Run `terraform plan` and review output
+    1. Run `terraform apply`

--- a/3-networks/README.md
+++ b/3-networks/README.md
@@ -1,4 +1,4 @@
-# 2-networks
+# 3-networks
 
 The purpose of this step is to setup shared VPCs with default DNS, NAT, Private Service networking and baseline firewall rules.
 
@@ -6,13 +6,14 @@ The purpose of this step is to setup shared VPCs with default DNS, NAT, Private 
 
 1. 0-bootstrap executed successfully.
 1. 1-org executed successfully.
+1. 2-environments executed successfully.
 
 ## Usage
 
 ### Setup to run via Cloud Build
 1. Clone repo `gcloud source repos clone gcp-networks --project=YOUR_CLOUD_BUILD_PROJECT_ID`
 1. Change freshly cloned repo and change to non master branch `git checkout -b plan`
-1. Copy contents of foundation to new repo `cp -R ../terraform-example-foundation/2-networks/* .` (modify accordingly based on your current directory)
+1. Copy contents of foundation to new repo `cp -R ../terraform-example-foundation/3-networks/* .` (modify accordingly based on your current directory)
 1. Copy cloud build configuration files for terraform `cp ../terraform-example-foundation/build/cloudbuild-tf-* . ` (modify accordingly based on your current directory)
 1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap.
 1. Rename backend.tf.example backend.tf and update with your bucket from bootstrap.
@@ -24,7 +25,7 @@ The purpose of this step is to setup shared VPCs with default DNS, NAT, Private 
 
 
 ### Run terraform locally
-1. Change into 2-networks folder
+1. Change into 3-networks folder
 1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap.
 1. Rename backend.tf.example backend.tf and update with your bucket from bootstrap.
 1. Run `terraform init`

--- a/4-projects/README.md
+++ b/4-projects/README.md
@@ -1,4 +1,4 @@
-# 3-projects
+# 4-projects
 
 The purpose of this step is to setup folder structure and projects for applications, which are connected as service projects to the shared VPC created in the previous stage. Optionally, you can also create dedicated DNS zones and subnets for these applications.
 
@@ -6,13 +6,14 @@ The purpose of this step is to setup folder structure and projects for applicati
 
 1. 0-bootstrap executed successfully.
 1. 1-org executed successfully.
-1. 2-networks executed successfully.
+1. 2-environments executed successfully.
+1. 3-networks executed successfully.
 
 ## Usage
 ### Setup to run via Cloud Build
 1. Clone repo `gcloud source repos clone gcp-projects --project=YOUR_CLOUD_BUILD_PROJECT_ID`
 1. Change freshly cloned repo and change to non master branch `git checkout -b plan`
-1. Copy contents of foundation to new repo `cp -R ../terraform-example-foundation/3-projects/* .` (modify accordingly based on your current directory)
+1. Copy contents of foundation to new repo `cp -R ../terraform-example-foundation/4-projects/* .` (modify accordingly based on your current directory)
 1. Copy cloud build configuration files for terraform `cp ../terraform-example-foundation/build/cloudbuild-tf-* . ` (modify accordingly based on your current directory)
 1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap.
 1. Rename backend.tf.example backend.tf and update with your bucket from bootstrap.
@@ -24,7 +25,7 @@ The purpose of this step is to setup folder structure and projects for applicati
 
 
 ### Run terraform locally
-1. Change into 3-projects folder
+1. Change into 4-projects folder
 1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap.
 1. Rename backend.tf.example backend.tf and update with your bucket from bootstrap.
 1. Run `terraform init`


### PR DESCRIPTION
Made changes to example-foundation READMEs based on run-through of example-foundation. 
Summary of Changes to READMEs:
1-org:
- added info about security admins GSuite group (prerequisite)
- added info about valid BQ dataset regions
2-environments:
- added README.md
- added instructions customized for envs/ folders (instructions for backend.tf, tfvars files)
- added info about creating monitoring admins groups (prerequisites)
- added info about creating new gcp-envs CSR repo & triggers replicated from gcp-org repo (prerequisites)
- added info about altering Cloud Build files to apply each environment folder
3-networks:
- small changes; replaced "2-networks" with "3-networks" in README
4-projects:
- small changes; replaced "3-projects" with "4-projects" in README