### PR TITLE
Create dedicated interconnect module.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 .idea/
+.vscode/
 .DS_Store
 
 # Include override files you do wish to add to version control using negated pattern

--- a/3-networks/envs/dev/main.tf
+++ b/3-networks/envs/dev/main.tf
@@ -107,7 +107,7 @@ module "restricted_shared_vpc" {
 #   region1_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
 #   region1_interconnect2_location = "las-zone1-770"
 
-#   region2                        = var.default_region1
+#   region2                        = var.default_region2
 #   region2_router1_name           = module.restricted_shared_vpc.region2_router1.router.name
 #   region2_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
 #   region2_interconnect1_location = "lax-zone2-19"
@@ -187,7 +187,7 @@ module "private_shared_vpc" {
 #   region1_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
 #   region1_interconnect2_location = "las-zone1-770"
 
-#   region2                        = var.default_region1
+#   region2                        = var.default_region2
 #   region2_router1_name           = module.private_shared_vpc.region2_router1.router.name
 #   region2_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
 #   region2_interconnect1_location = "lax-zone2-19"

--- a/3-networks/envs/dev/main.tf
+++ b/3-networks/envs/dev/main.tf
@@ -89,6 +89,38 @@ module "restricted_shared_vpc" {
 }
 
 /******************************************
+ Interconnect for restricted shared VPC
+*****************************************/
+# uncommnet if you have done the requirement steps listed in ../../modules/dedicated_interconnect/README.md
+# update the interconnect, interconnect locations, and peer field with actual values.
+
+# module "shared_restricted_interconnect" {
+#   source = "../../modules/dedicated_interconnect"
+
+#   vpc_name = "${local.environment_code}-shared-restricted"
+
+#   region1                        = var.default_region1
+#   region1_router1_name           = module.restricted_shared_vpc.region1_router1.router.name
+#   region1_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
+#   region1_interconnect1_location = "las-zone1-770"
+#   region1_router2_name           = module.restricted_shared_vpc.region1_router2.router.name
+#   region1_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
+#   region1_interconnect2_location = "las-zone1-770"
+
+#   region2                        = var.default_region1
+#   region2_router1_name           = module.restricted_shared_vpc.region2_router1.router.name
+#   region2_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
+#   region2_interconnect1_location = "lax-zone2-19"
+#   region2_router2_name           = module.restricted_shared_vpc.region2_router2.router.name
+#   region2_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
+#   region2_interconnect2_location = "lax-zone1-403"
+
+#   peer_asn        = "64515"
+#   peer_ip_address = "8.8.8.8" # on-prem router ip address
+#   peer_name       = "interconnect-peer"
+# }
+
+/******************************************
  Base shared VPC
 *****************************************/
 
@@ -134,3 +166,36 @@ module "private_shared_vpc" {
     ]
   }
 }
+
+/******************************************
+ Interconnect for base shared VPC
+*****************************************/
+
+# uncommnet if you have done the requirement steps listed in ../../modules/dedicated_interconnect/README.md
+# update the interconnect, interconnect locations, and peer field with actual values.
+
+# module "shared_base_interconnect" {
+#   source = "../../modules/dedicated_interconnect"
+
+#   vpc_name = "${local.environment_code}-shared-private"
+
+#   region1                        = var.default_region1
+#   region1_router1_name           = module.private_shared_vpc.region1_router1.router.name
+#   region1_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
+#   region1_interconnect1_location = "las-zone1-770"
+#   region1_router2_name           = module.private_shared_vpc.region1_router2.router.name
+#   region1_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
+#   region1_interconnect2_location = "las-zone1-770"
+
+#   region2                        = var.default_region1
+#   region2_router1_name           = module.private_shared_vpc.region2_router1.router.name
+#   region2_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
+#   region2_interconnect1_location = "lax-zone2-19"
+#   region2_router2_name           = module.private_shared_vpc.region2_router2.router.name
+#   region2_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
+#   region2_interconnect2_location = "lax-zone1-403"
+
+#   peer_asn        = "64515"
+#   peer_ip_address = "8.8.8.8" # on-prem router ip address
+#   peer_name       = "interconnect-peer"
+# }

--- a/3-networks/envs/nonprod/main.tf
+++ b/3-networks/envs/nonprod/main.tf
@@ -90,6 +90,38 @@ module "restricted_shared_vpc" {
 }
 
 /******************************************
+ Interconnect for restricted shared VPC
+*****************************************/
+# uncommnet if you have done the requirement steps listed in ../../modules/dedicated_interconnect/README.md
+# update the interconnect, interconnect locations, and peer field with actual values.
+
+# module "shared_restricted_interconnect" {
+#   source = "../../modules/dedicated_interconnect"
+
+#   vpc_name = "${local.environment_code}-shared-restricted"
+
+#   region1                        = var.default_region1
+#   region1_router1_name           = module.restricted_shared_vpc.region1_router1.router.name
+#   region1_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
+#   region1_interconnect1_location = "las-zone1-770"
+#   region1_router2_name           = module.restricted_shared_vpc.region1_router2.router.name
+#   region1_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
+#   region1_interconnect2_location = "las-zone1-770"
+
+#   region2                        = var.default_region1
+#   region2_router1_name           = module.restricted_shared_vpc.region2_router1.router.name
+#   region2_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
+#   region2_interconnect1_location = "lax-zone2-19"
+#   region2_router2_name           = module.restricted_shared_vpc.region2_router2.router.name
+#   region2_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
+#   region2_interconnect2_location = "lax-zone1-403"
+
+#   peer_asn        = "64515"
+#   peer_ip_address = "8.8.8.8" # on-prem router ip address
+#   peer_name       = "interconnect-peer"
+# }
+
+/******************************************
  Private shared VPC
 *****************************************/
 
@@ -137,3 +169,36 @@ module "private_shared_vpc" {
     ]
   }
 }
+
+/******************************************
+ Interconnect for base shared VPC
+*****************************************/
+
+# uncommnet if you have done the requirement steps listed in ../../modules/dedicated_interconnect/README.md
+# update the interconnect, interconnect locations, and peer field with actual values.
+
+# module "shared_base_interconnect" {
+#   source = "../../modules/dedicated_interconnect"
+
+#   vpc_name = "${local.environment_code}-shared-private"
+
+#   region1                        = var.default_region1
+#   region1_router1_name           = module.private_shared_vpc.region1_router1.router.name
+#   region1_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
+#   region1_interconnect1_location = "las-zone1-770"
+#   region1_router2_name           = module.private_shared_vpc.region1_router2.router.name
+#   region1_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
+#   region1_interconnect2_location = "las-zone1-770"
+
+#   region2                        = var.default_region1
+#   region2_router1_name           = module.private_shared_vpc.region2_router1.router.name
+#   region2_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
+#   region2_interconnect1_location = "lax-zone2-19"
+#   region2_router2_name           = module.private_shared_vpc.region2_router2.router.name
+#   region2_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
+#   region2_interconnect2_location = "lax-zone1-403"
+
+#   peer_asn        = "64515"
+#   peer_ip_address = "8.8.8.8" # on-prem router ip address
+#   peer_name       = "interconnect-peer"
+# }

--- a/3-networks/envs/nonprod/main.tf
+++ b/3-networks/envs/nonprod/main.tf
@@ -108,7 +108,7 @@ module "restricted_shared_vpc" {
 #   region1_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
 #   region1_interconnect2_location = "las-zone1-770"
 
-#   region2                        = var.default_region1
+#   region2                        = var.default_region2
 #   region2_router1_name           = module.restricted_shared_vpc.region2_router1.router.name
 #   region2_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
 #   region2_interconnect1_location = "lax-zone2-19"
@@ -190,7 +190,7 @@ module "private_shared_vpc" {
 #   region1_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
 #   region1_interconnect2_location = "las-zone1-770"
 
-#   region2                        = var.default_region1
+#   region2                        = var.default_region2
 #   region2_router1_name           = module.private_shared_vpc.region2_router1.router.name
 #   region2_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
 #   region2_interconnect1_location = "lax-zone2-19"

--- a/3-networks/envs/prod/main.tf
+++ b/3-networks/envs/prod/main.tf
@@ -89,6 +89,38 @@ module "restricted_shared_vpc" {
 }
 
 /******************************************
+ Interconnect for restricted shared VPC
+*****************************************/
+# uncommnet if you have done the requirement steps listed in ../../modules/dedicated_interconnect/README.md
+# update the interconnect, interconnect locations, and peer field with actual values.
+
+# module "shared_restricted_interconnect" {
+#   source = "../../modules/dedicated_interconnect"
+
+#   vpc_name = "${local.environment_code}-shared-restricted"
+
+#   region1                        = var.default_region1
+#   region1_router1_name           = module.restricted_shared_vpc.region1_router1.router.name
+#   region1_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
+#   region1_interconnect1_location = "las-zone1-770"
+#   region1_router2_name           = module.restricted_shared_vpc.region1_router2.router.name
+#   region1_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
+#   region1_interconnect2_location = "las-zone1-770"
+
+#   region2                        = var.default_region1
+#   region2_router1_name           = module.restricted_shared_vpc.region2_router1.router.name
+#   region2_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
+#   region2_interconnect1_location = "lax-zone2-19"
+#   region2_router2_name           = module.restricted_shared_vpc.region2_router2.router.name
+#   region2_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
+#   region2_interconnect2_location = "lax-zone1-403"
+
+#   peer_asn        = "64515"
+#   peer_ip_address = "8.8.8.8" # on-prem router ip address
+#   peer_name       = "interconnect-peer"
+# }
+
+/******************************************
  Private shared VPC
 *****************************************/
 
@@ -134,3 +166,36 @@ module "private_shared_vpc" {
     ]
   }
 }
+
+/******************************************
+ Interconnect for base shared VPC
+*****************************************/
+
+# uncommnet if you have done the requirement steps listed in ../../modules/dedicated_interconnect/README.md
+# update the interconnect, interconnect locations, and peer field with actual values.
+
+# module "shared_base_interconnect" {
+#   source = "../../modules/dedicated_interconnect"
+
+#   vpc_name = "${local.environment_code}-shared-private"
+
+#   region1                        = var.default_region1
+#   region1_router1_name           = module.private_shared_vpc.region1_router1.router.name
+#   region1_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
+#   region1_interconnect1_location = "las-zone1-770"
+#   region1_router2_name           = module.private_shared_vpc.region1_router2.router.name
+#   region1_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
+#   region1_interconnect2_location = "las-zone1-770"
+
+#   region2                        = var.default_region1
+#   region2_router1_name           = module.private_shared_vpc.region2_router1.router.name
+#   region2_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
+#   region2_interconnect1_location = "lax-zone2-19"
+#   region2_router2_name           = module.private_shared_vpc.region2_router2.router.name
+#   region2_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
+#   region2_interconnect2_location = "lax-zone1-403"
+
+#   peer_asn        = "64515"
+#   peer_ip_address = "8.8.8.8" # on-prem router ip address
+#   peer_name       = "interconnect-peer"
+# }

--- a/3-networks/envs/prod/main.tf
+++ b/3-networks/envs/prod/main.tf
@@ -35,7 +35,7 @@ data "google_project" "restricted_host_project" {
 }
 
 data "google_projects" "private_host_project" {
-  filter = "labels.application_name=base-shared-vpc-host--${local.env}"
+  filter = "labels.application_name=base-shared-vpc-host-${local.env}"
 }
 
 /******************************************
@@ -107,7 +107,7 @@ module "restricted_shared_vpc" {
 #   region1_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
 #   region1_interconnect2_location = "las-zone1-770"
 
-#   region2                        = var.default_region1
+#   region2                        = var.default_region2
 #   region2_router1_name           = module.restricted_shared_vpc.region2_router1.router.name
 #   region2_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
 #   region2_interconnect1_location = "lax-zone2-19"

--- a/3-networks/modules/dedicated_interconnect/README.md
+++ b/3-networks/modules/dedicated_interconnect/README.md
@@ -6,7 +6,7 @@ This module implementes the recomendation proposed in [Establishing 99.99% Avail
 
 1. Execution of at least one of the environments in `3-networks/env/`.
 1. Creation on two Cloud Routers for each Region. Both the `Restricted shared VPC` and the `Standard shared VPC` modules create two Cloud Routers for each Region that should be used as input for this module. **This module only works with two regions.**
-1. Provisioning of four [dedicated interconnects](https://cloud.google.com/network-connectivity/docs/interconnect/concepts/dedicated-overview), Two for each region.
+1. Provisioning of four [dedicated interconnects](https://cloud.google.com/network-connectivity/docs/interconnect/concepts/dedicated-overview) in the `prj-interconnect` project created in step `1-org` under folder `fldr-common`.
 
 ## Usage
 
@@ -17,21 +17,21 @@ Sections with examples of calls to this module are commented in each one of the 
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| default\_region1 | First subnet region. The dedicated Interconnect module only configures two regions. | string | n/a | yes |
-| default\_region2 | Second subnet region. The dedicated Interconnect module only configures two regions. | string | n/a | yes |
-| interconnect1\_region1 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | string | n/a | yes |
-| interconnect1\_region2 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | string | n/a | yes |
-| interconnect2\_region1 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | string | n/a | yes |
-| interconnect2\_region2 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | string | n/a | yes |
-| interconnect\_location1\_region1 | Name of the interconnect location used in the creation of the Interconnect for the first location of region1 | string | n/a | yes |
-| interconnect\_location1\_region2 | Name of the interconnect location used in the creation of the Interconnect for the first location of region2 | string | n/a | yes |
-| interconnect\_location2\_region1 | Name of the interconnect location used in the creation of the Interconnect for the second location of region1 | string | n/a | yes |
-| interconnect\_location2\_region2 | Name of the interconnect location used in the creation of the Interconnect for the second location of region2 | string | n/a | yes |
 | peer\_asn | Peer BGP Autonomous System Number (ASN). | number | n/a | yes |
 | peer\_ip\_address | IP address of the BGP interface outside Google Cloud Platform. Only IPv4 is supported. | string | n/a | yes |
 | peer\_name | Name of this BGP peer. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])? | string | n/a | yes |
+| region1 | First subnet region. The dedicated Interconnect module only configures two regions. | string | n/a | yes |
+| region1\_interconnect1 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | string | n/a | yes |
+| region1\_interconnect1\_location | Name of the interconnect location used in the creation of the Interconnect for the first location of region1 | string | n/a | yes |
+| region1\_interconnect2 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | string | n/a | yes |
+| region1\_interconnect2\_location | Name of the interconnect location used in the creation of the Interconnect for the second location of region1 | string | n/a | yes |
 | region1\_router1\_name | Name of the Router 1 for Region 1 where the attachment resides. | string | n/a | yes |
 | region1\_router2\_name | Name of the Router 2 for Region 1 where the attachment resides. | string | n/a | yes |
+| region2 | Second subnet region. The dedicated Interconnect module only configures two regions. | string | n/a | yes |
+| region2\_interconnect1 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | string | n/a | yes |
+| region2\_interconnect1\_location | Name of the interconnect location used in the creation of the Interconnect for the first location of region2 | string | n/a | yes |
+| region2\_interconnect2 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | string | n/a | yes |
+| region2\_interconnect2\_location | Name of the interconnect location used in the creation of the Interconnect for the second location of region2 | string | n/a | yes |
 | region2\_router1\_name | Name of the Router 1 for Region 2 where the attachment resides. | string | n/a | yes |
 | region2\_router2\_name | Name of the Router 2 for Region 2 where the attachment resides | string | n/a | yes |
 | vpc\_name | Label to identify the VPC associated with shared VPC that will use the Interconnect. | string | n/a | yes |

--- a/3-networks/modules/dedicated_interconnect/README.md
+++ b/3-networks/modules/dedicated_interconnect/README.md
@@ -1,3 +1,17 @@
+# Dedicated interconnecte module
+
+This module implementes the recomendation proposed in [Establishing 99.99% Availability for Dedicated Interconnect](https://cloud.google.com/network-connectivity/docs/interconnect/tutorials/dedicated-creating-9999-availability).
+
+## Prerequisites
+
+1. Execution of at least one of the environments in `3-networks/env/`.
+1. Creation on two Cloud Routers for each Region. Both the `Restricted shared VPC` and the `Standard shared VPC` modules create two Cloud Routers for each Region that should be used as input for this module. **This module only works with two regions.**
+1. Provisioning of four [dedicated interconnects](https://cloud.google.com/network-connectivity/docs/interconnect/concepts/dedicated-overview), Two for each region.
+
+## Usage
+
+Sections with examples of calls to this module are commented in each one of the environments. Uncomment these section and update the input values with your interconnects and peer BGP information and rerun Terraform.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
@@ -20,6 +34,19 @@
 | region1\_router2\_name | Name of the Router 2 for Region 1 where the attachment resides. | string | n/a | yes |
 | region2\_router1\_name | Name of the Router 1 for Region 2 where the attachment resides. | string | n/a | yes |
 | region2\_router2\_name | Name of the Router 2 for Region 2 where the attachment resides | string | n/a | yes |
-| vpc\_name | lable to identify the VPC associated with shared VPC that will use the Interconnect. | string | n/a | yes |
+| vpc\_name | Label to identify the VPC associated with shared VPC that will use the Interconnect. | string | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| interconnect\_attachment1\_region1 | The created attachment |
+| interconnect\_attachment1\_region1\_customer\_router\_ip\_address | IPv4 address + prefix length to be configured on the customer router subinterface for this interconnect attachment. |
+| interconnect\_attachment1\_region2 | The created attachment |
+| interconnect\_attachment1\_region2\_customer\_router\_ip\_address | IPv4 address + prefix length to be configured on the customer router subinterface for this interconnect attachment. |
+| interconnect\_attachment2\_region1 | The created attachment |
+| interconnect\_attachment2\_region1\_customer\_router\_ip\_address | IPv4 address + prefix length to be configured on the customer router subinterface for this interconnect attachment. |
+| interconnect\_attachment2\_region2 | The created attachment |
+| interconnect\_attachment2\_region2\_customer\_router\_ip\_address | IPv4 address + prefix length to be configured on the customer router subinterface for this interconnect attachment. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/3-networks/modules/dedicated_interconnect/README.md
+++ b/3-networks/modules/dedicated_interconnect/README.md
@@ -40,13 +40,13 @@ Sections with examples of calls to this module are commented in each one of the 
 
 | Name | Description |
 |------|-------------|
-| interconnect\_attachment1\_region1 | The created attachment |
+| interconnect\_attachment1\_region1 | The interconnect attachment 1 for region 1 |
 | interconnect\_attachment1\_region1\_customer\_router\_ip\_address | IPv4 address + prefix length to be configured on the customer router subinterface for this interconnect attachment. |
-| interconnect\_attachment1\_region2 | The created attachment |
+| interconnect\_attachment1\_region2 | The interconnect attachment 1 for region 2 |
 | interconnect\_attachment1\_region2\_customer\_router\_ip\_address | IPv4 address + prefix length to be configured on the customer router subinterface for this interconnect attachment. |
-| interconnect\_attachment2\_region1 | The created attachment |
+| interconnect\_attachment2\_region1 | The interconnect attachment 2 for region 1 |
 | interconnect\_attachment2\_region1\_customer\_router\_ip\_address | IPv4 address + prefix length to be configured on the customer router subinterface for this interconnect attachment. |
-| interconnect\_attachment2\_region2 | The created attachment |
+| interconnect\_attachment2\_region2 | The interconnect attachment 2 for region 2 |
 | interconnect\_attachment2\_region2\_customer\_router\_ip\_address | IPv4 address + prefix length to be configured on the customer router subinterface for this interconnect attachment. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/3-networks/modules/dedicated_interconnect/README.md
+++ b/3-networks/modules/dedicated_interconnect/README.md
@@ -1,0 +1,25 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| default\_region1 | First subnet region. The dedicated Interconnect module only configures two regions. | string | n/a | yes |
+| default\_region2 | Second subnet region. The dedicated Interconnect module only configures two regions. | string | n/a | yes |
+| interconnect1\_region1 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | string | n/a | yes |
+| interconnect1\_region2 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | string | n/a | yes |
+| interconnect2\_region1 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | string | n/a | yes |
+| interconnect2\_region2 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | string | n/a | yes |
+| interconnect\_location1\_region1 | Name of the interconnect location used in the creation of the Interconnect for the first location of region1 | string | n/a | yes |
+| interconnect\_location1\_region2 | Name of the interconnect location used in the creation of the Interconnect for the first location of region2 | string | n/a | yes |
+| interconnect\_location2\_region1 | Name of the interconnect location used in the creation of the Interconnect for the second location of region1 | string | n/a | yes |
+| interconnect\_location2\_region2 | Name of the interconnect location used in the creation of the Interconnect for the second location of region2 | string | n/a | yes |
+| peer\_asn | Peer BGP Autonomous System Number (ASN). | number | n/a | yes |
+| peer\_ip\_address | IP address of the BGP interface outside Google Cloud Platform. Only IPv4 is supported. | string | n/a | yes |
+| peer\_name | Name of this BGP peer. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])? | string | n/a | yes |
+| region1\_router1\_name | Name of the Router 1 for Region 1 where the attachment resides. | string | n/a | yes |
+| region1\_router2\_name | Name of the Router 2 for Region 1 where the attachment resides. | string | n/a | yes |
+| region2\_router1\_name | Name of the Router 1 for Region 2 where the attachment resides. | string | n/a | yes |
+| region2\_router2\_name | Name of the Router 2 for Region 2 where the attachment resides | string | n/a | yes |
+| vpc\_name | lable to identify the VPC associated with shared VPC that will use the Interconnect. | string | n/a | yes |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/3-networks/modules/dedicated_interconnect/main.tf
+++ b/3-networks/modules/dedicated_interconnect/main.tf
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  interconnect_project_id = data.google_projects.interconnect_project.projects[0].project_id
+}
+
+data "google_projects" "interconnect_project" {
+  filter = "labels.application_name=prj-interconnect"
+}
+
+module "interconnect_attachment1_region1" {
+  source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
+  version = "~> 0.2.0"
+
+  name    = "vl-${var.interconnect_location1_region1}-${var.vpc_name}-${var.default_region1}-cr1"
+  project = local.interconnect_project_id
+  region  = var.default_region1
+  router  = var.region1_router1_name
+
+  interconnect = var.interconnect1_region1
+
+  interface = {
+    name = "if-${var.interconnect_location1_region1}-${var.vpc_name}-${var.default_region1}"
+  }
+
+  peer = {
+    name            = var.peer_name
+    peer_ip_address = var.peer_ip_address
+    peer_asn        = var.peer_asn
+  }
+}
+
+module "interconnect_attachment2_region1" {
+  source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
+  version = "~> 0.2.0"
+
+  name    = "vl-${var.interconnect_location2_region1}-${var.vpc_name}-${var.default_region1}-cr1"
+  project = local.interconnect_project_id
+  region  = var.default_region1
+  router  = var.region1_router2_name
+
+  interconnect = var.interconnect2_region1
+
+  interface = {
+    name = "if-${var.interconnect_location2_region1}-${var.vpc_name}-${var.default_region1}"
+  }
+
+  peer = {
+    name            = var.peer_name
+    peer_ip_address = var.peer_ip_address
+    peer_asn        = var.peer_asn
+  }
+}
+
+module "interconnect_attachment1_region2" {
+  source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
+  version = "~> 0.2.0"
+
+  name    = "vl-${var.interconnect_location1_region2}-${var.vpc_name}-${var.default_region2}-cr1"
+  project = local.interconnect_project_id
+  region  = var.default_region2
+  router  = var.region2_router1_name
+
+  interconnect = var.interconnect1_region2
+
+  interface = {
+    name = "if-${var.interconnect_location1_region2}-${var.vpc_name}-${var.default_region2}"
+  }
+
+  peer = {
+    name            = var.peer_name
+    peer_ip_address = var.peer_ip_address
+    peer_asn        = var.peer_asn
+  }
+}
+
+module "interconnect_attachment2_region2" {
+  source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
+  version = "~> 0.2.0"
+
+  name    = "vl-${var.interconnect_location2_region2}-${var.vpc_name}-${var.default_region2}-cr1"
+  project = local.interconnect_project_id
+  region  = var.default_region2
+  router  = var.region2_router2_name
+
+  interconnect = var.interconnect2_region2
+
+  interface = {
+    name = "if-${var.interconnect_location2_region2}-${var.vpc_name}-${var.default_region2}"
+  }
+
+  peer = {
+    name            = var.peer_name
+    peer_ip_address = var.peer_ip_address
+    peer_asn        = var.peer_asn
+  }
+}

--- a/3-networks/modules/dedicated_interconnect/main.tf
+++ b/3-networks/modules/dedicated_interconnect/main.tf
@@ -48,7 +48,7 @@ module "interconnect_attachment2_region1" {
   source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
   version = "~> 0.2.0"
 
-  name    = "vl-${var.interconnect_location2_region1}-${var.vpc_name}-${var.default_region1}-cr1"
+  name    = "vl-${var.interconnect_location2_region1}-${var.vpc_name}-${var.default_region1}-cr2"
   project = local.interconnect_project_id
   region  = var.default_region1
   router  = var.region1_router2_name
@@ -92,7 +92,7 @@ module "interconnect_attachment2_region2" {
   source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
   version = "~> 0.2.0"
 
-  name    = "vl-${var.interconnect_location2_region2}-${var.vpc_name}-${var.default_region2}-cr1"
+  name    = "vl-${var.interconnect_location2_region2}-${var.vpc_name}-${var.default_region2}-cr2"
   project = local.interconnect_project_id
   region  = var.default_region2
   router  = var.region2_router2_name

--- a/3-networks/modules/dedicated_interconnect/main.tf
+++ b/3-networks/modules/dedicated_interconnect/main.tf
@@ -26,15 +26,15 @@ module "interconnect_attachment1_region1" {
   source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
   version = "~> 0.2.0"
 
-  name    = "vl-${var.interconnect_location1_region1}-${var.vpc_name}-${var.default_region1}-cr1"
+  name    = "vl-${var.region1_interconnect1_location}-${var.vpc_name}-${var.region1}-cr1"
   project = local.interconnect_project_id
-  region  = var.default_region1
+  region  = var.region1
   router  = var.region1_router1_name
 
-  interconnect = var.interconnect1_region1
+  interconnect = var.region1_interconnect1
 
   interface = {
-    name = "if-${var.interconnect_location1_region1}-${var.vpc_name}-${var.default_region1}"
+    name = "if-${var.region1_interconnect1_location}-${var.vpc_name}-${var.region1}"
   }
 
   peer = {
@@ -48,15 +48,15 @@ module "interconnect_attachment2_region1" {
   source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
   version = "~> 0.2.0"
 
-  name    = "vl-${var.interconnect_location2_region1}-${var.vpc_name}-${var.default_region1}-cr2"
+  name    = "vl-${var.region1_interconnect2_location}-${var.vpc_name}-${var.region1}-cr2"
   project = local.interconnect_project_id
-  region  = var.default_region1
+  region  = var.region1
   router  = var.region1_router2_name
 
-  interconnect = var.interconnect2_region1
+  interconnect = var.region1_interconnect2
 
   interface = {
-    name = "if-${var.interconnect_location2_region1}-${var.vpc_name}-${var.default_region1}"
+    name = "if-${var.region1_interconnect2_location}-${var.vpc_name}-${var.region1}"
   }
 
   peer = {
@@ -70,15 +70,15 @@ module "interconnect_attachment1_region2" {
   source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
   version = "~> 0.2.0"
 
-  name    = "vl-${var.interconnect_location1_region2}-${var.vpc_name}-${var.default_region2}-cr1"
+  name    = "vl-${var.region2_interconnect1_location}-${var.vpc_name}-${var.region2}-cr1"
   project = local.interconnect_project_id
-  region  = var.default_region2
+  region  = var.region2
   router  = var.region2_router1_name
 
-  interconnect = var.interconnect1_region2
+  interconnect = var.region2_interconnect1
 
   interface = {
-    name = "if-${var.interconnect_location1_region2}-${var.vpc_name}-${var.default_region2}"
+    name = "if-${var.region2_interconnect1_location}-${var.vpc_name}-${var.region2}"
   }
 
   peer = {
@@ -92,15 +92,15 @@ module "interconnect_attachment2_region2" {
   source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
   version = "~> 0.2.0"
 
-  name    = "vl-${var.interconnect_location2_region2}-${var.vpc_name}-${var.default_region2}-cr2"
+  name    = "vl-${var.region2_interconnect2_location}-${var.vpc_name}-${var.region2}-cr2"
   project = local.interconnect_project_id
-  region  = var.default_region2
+  region  = var.region2
   router  = var.region2_router2_name
 
-  interconnect = var.interconnect2_region2
+  interconnect = var.region2_interconnect2
 
   interface = {
-    name = "if-${var.interconnect_location2_region2}-${var.vpc_name}-${var.default_region2}"
+    name = "if-${var.region2_interconnect2_location}-${var.vpc_name}-${var.region2}"
   }
 
   peer = {

--- a/3-networks/modules/dedicated_interconnect/outputs.tf
+++ b/3-networks/modules/dedicated_interconnect/outputs.tf
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "interconnect_attachment1_region1" {
+  value       = module.interconnect_attachment1_region1.attachment
+  description = "The created attachment"
+}
+
+output "interconnect_attachment1_region1_customer_router_ip_address" {
+  value       = module.interconnect_attachment1_region1.attachment.customer_router_ip_address
+  description = "IPv4 address + prefix length to be configured on the customer router subinterface for this interconnect attachment."
+}
+
+output "interconnect_attachment2_region1" {
+  value       = module.interconnect_attachment2_region1.attachment
+  description = "The created attachment"
+}
+
+output "interconnect_attachment2_region1_customer_router_ip_address" {
+  value       = module.interconnect_attachment2_region1.attachment.customer_router_ip_address
+  description = "IPv4 address + prefix length to be configured on the customer router subinterface for this interconnect attachment."
+}
+
+output "interconnect_attachment1_region2" {
+  value       = module.interconnect_attachment1_region2.attachment
+  description = "The created attachment"
+}
+
+output "interconnect_attachment1_region2_customer_router_ip_address" {
+  value       = module.interconnect_attachment1_region2.attachment.customer_router_ip_address
+  description = "IPv4 address + prefix length to be configured on the customer router subinterface for this interconnect attachment."
+}
+
+output "interconnect_attachment2_region2" {
+  value       = module.interconnect_attachment2_region2.attachment
+  description = "The created attachment"
+}
+
+output "interconnect_attachment2_region2_customer_router_ip_address" {
+  value       = module.interconnect_attachment2_region2.attachment.customer_router_ip_address
+  description = "IPv4 address + prefix length to be configured on the customer router subinterface for this interconnect attachment."
+}

--- a/3-networks/modules/dedicated_interconnect/outputs.tf
+++ b/3-networks/modules/dedicated_interconnect/outputs.tf
@@ -16,7 +16,7 @@
 
 output "interconnect_attachment1_region1" {
   value       = module.interconnect_attachment1_region1.attachment
-  description = "The created attachment"
+  description = "The interconnect attachment 1 for region 1"
 }
 
 output "interconnect_attachment1_region1_customer_router_ip_address" {
@@ -26,7 +26,7 @@ output "interconnect_attachment1_region1_customer_router_ip_address" {
 
 output "interconnect_attachment2_region1" {
   value       = module.interconnect_attachment2_region1.attachment
-  description = "The created attachment"
+  description = "The interconnect attachment 2 for region 1"
 }
 
 output "interconnect_attachment2_region1_customer_router_ip_address" {
@@ -36,7 +36,7 @@ output "interconnect_attachment2_region1_customer_router_ip_address" {
 
 output "interconnect_attachment1_region2" {
   value       = module.interconnect_attachment1_region2.attachment
-  description = "The created attachment"
+  description = "The interconnect attachment 1 for region 2"
 }
 
 output "interconnect_attachment1_region2_customer_router_ip_address" {
@@ -46,7 +46,7 @@ output "interconnect_attachment1_region2_customer_router_ip_address" {
 
 output "interconnect_attachment2_region2" {
   value       = module.interconnect_attachment2_region2.attachment
-  description = "The created attachment"
+  description = "The interconnect attachment 2 for region 2"
 }
 
 output "interconnect_attachment2_region2_customer_router_ip_address" {

--- a/3-networks/modules/dedicated_interconnect/variables.tf
+++ b/3-networks/modules/dedicated_interconnect/variables.tf
@@ -19,12 +19,12 @@ variable "vpc_name" {
   description = "Label to identify the VPC associated with shared VPC that will use the Interconnect."
 }
 
-variable "default_region1" {
+variable "region1" {
   type        = string
   description = "First subnet region. The dedicated Interconnect module only configures two regions."
 }
 
-variable "default_region2" {
+variable "region2" {
   type        = string
   description = "Second subnet region. The dedicated Interconnect module only configures two regions."
 }
@@ -44,42 +44,42 @@ variable "peer_asn" {
   description = "Peer BGP Autonomous System Number (ASN)."
 }
 
-variable "interconnect_location1_region1" {
+variable "region1_interconnect1_location" {
   type        = string
   description = "Name of the interconnect location used in the creation of the Interconnect for the first location of region1"
 }
 
-variable "interconnect_location2_region1" {
+variable "region1_interconnect2_location" {
   type        = string
   description = "Name of the interconnect location used in the creation of the Interconnect for the second location of region1"
 }
 
-variable "interconnect_location1_region2" {
+variable "region2_interconnect1_location" {
   type        = string
   description = "Name of the interconnect location used in the creation of the Interconnect for the first location of region2"
 }
 
-variable "interconnect_location2_region2" {
+variable "region2_interconnect2_location" {
   type        = string
   description = "Name of the interconnect location used in the creation of the Interconnect for the second location of region2"
 }
 
-variable "interconnect1_region1" {
+variable "region1_interconnect1" {
   type        = string
   description = "URL of the underlying Interconnect object that this attachment's traffic will traverse through."
 }
 
-variable "interconnect2_region1" {
+variable "region1_interconnect2" {
   type        = string
   description = "URL of the underlying Interconnect object that this attachment's traffic will traverse through."
 }
 
-variable "interconnect1_region2" {
+variable "region2_interconnect1" {
   type        = string
   description = "URL of the underlying Interconnect object that this attachment's traffic will traverse through."
 }
 
-variable "interconnect2_region2" {
+variable "region2_interconnect2" {
   type        = string
   description = "URL of the underlying Interconnect object that this attachment's traffic will traverse through."
 }

--- a/3-networks/modules/dedicated_interconnect/variables.tf
+++ b/3-networks/modules/dedicated_interconnect/variables.tf
@@ -16,7 +16,7 @@
 
 variable "vpc_name" {
   type        = string
-  description = "lable to identify the VPC associated with shared VPC that will use the Interconnect."
+  description = "Label to identify the VPC associated with shared VPC that will use the Interconnect."
 }
 
 variable "default_region1" {

--- a/3-networks/modules/dedicated_interconnect/variables.tf
+++ b/3-networks/modules/dedicated_interconnect/variables.tf
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "vpc_name" {
+  type        = string
+  description = "lable to identify the VPC associated with shared VPC that will use the Interconnect."
+}
+
+variable "default_region1" {
+  type        = string
+  description = "First subnet region. The dedicated Interconnect module only configures two regions."
+}
+
+variable "default_region2" {
+  type        = string
+  description = "Second subnet region. The dedicated Interconnect module only configures two regions."
+}
+
+variable "peer_name" {
+  type        = string
+  description = "Name of this BGP peer. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])?"
+}
+
+variable "peer_ip_address" {
+  type        = string
+  description = "IP address of the BGP interface outside Google Cloud Platform. Only IPv4 is supported."
+}
+
+variable "peer_asn" {
+  type        = number
+  description = "Peer BGP Autonomous System Number (ASN)."
+}
+
+variable "interconnect_location1_region1" {
+  type        = string
+  description = "Name of the interconnect location used in the creation of the Interconnect for the first location of region1"
+}
+
+variable "interconnect_location2_region1" {
+  type        = string
+  description = "Name of the interconnect location used in the creation of the Interconnect for the second location of region1"
+}
+
+variable "interconnect_location1_region2" {
+  type        = string
+  description = "Name of the interconnect location used in the creation of the Interconnect for the first location of region2"
+}
+
+variable "interconnect_location2_region2" {
+  type        = string
+  description = "Name of the interconnect location used in the creation of the Interconnect for the second location of region2"
+}
+
+variable "interconnect1_region1" {
+  type        = string
+  description = "URL of the underlying Interconnect object that this attachment's traffic will traverse through."
+}
+
+variable "interconnect2_region1" {
+  type        = string
+  description = "URL of the underlying Interconnect object that this attachment's traffic will traverse through."
+}
+
+variable "interconnect1_region2" {
+  type        = string
+  description = "URL of the underlying Interconnect object that this attachment's traffic will traverse through."
+}
+
+variable "interconnect2_region2" {
+  type        = string
+  description = "URL of the underlying Interconnect object that this attachment's traffic will traverse through."
+}
+
+variable "region1_router1_name" {
+  type        = string
+  description = "Name of the Router 1 for Region 1 where the attachment resides."
+}
+
+variable "region1_router2_name" {
+  type        = string
+  description = "Name of the Router 2 for Region 1 where the attachment resides."
+}
+
+variable "region2_router1_name" {
+  type        = string
+  description = "Name of the Router 1 for Region 2 where the attachment resides."
+}
+
+variable "region2_router2_name" {
+  type        = string
+  description = "Name of the Router 2 for Region 2 where the attachment resides"
+}


### PR DESCRIPTION
Creation of  dedicated interconnect module in `3-networks`.

TODOs:

- [x] add  commented call in all the environments for both private and restricted shared VPC after https://github.com/terraform-google-modules/terraform-example-foundation/pull/72 is merged.
- [x] update README.md file in the new module and in each environment to presente the new module as the recommended option for onprem connection.

Depends on:

- https://github.com/terraform-google-modules/terraform-example-foundation/pull/72
- https://github.com/terraform-google-modules/terraform-example-foundation/pull/71