### PR TITLE
fix: Fix concurrent builds for int tests

### DIFF
--- a/1-org/README.md
+++ b/1-org/README.md
@@ -41,6 +41,7 @@ The purpose of this step is to setup top level shared folders, monitoring & netw
 | audit\_data\_users | Gsuite or Cloud Identity group that have access to audit logs. | string | n/a | yes |
 | billing\_account | The ID of the billing account to associate this project with | string | n/a | yes |
 | billing\_data\_users | Gsuite or Cloud Identity group that have access to billing data set. | string | n/a | yes |
+| create\_access\_context\_manager\_access\_policy | Whether to create access context manager access policy | bool | `"true"` | no |
 | data\_access\_table\_expiration\_ms | Period before tables expire for data access logs in milliseconds. Default is 30 days. | number | `"2592000000"` | no |
 | default\_region | Default region for BigQuery resources. | string | n/a | yes |
 | domains\_to\_allow | The list of domains to allow users from in IAM. | list(string) | n/a | yes |

--- a/1-org/org_policy.tf
+++ b/1-org/org_policy.tf
@@ -149,9 +149,8 @@ module "org_enforce_bucket_level_access" {
   Access Context Manager Policy
 *******************************************/
 
-module "access_context_manager_policy" {
-  source      = "terraform-google-modules/vpc-service-controls/google"
-  version     = "~> 2.0.0"
-  parent_id   = var.org_id
-  policy_name = "default policy"
+resource "google_access_context_manager_access_policy" "access_policy" {
+  count  = var.create_access_context_manager_access_policy ? 1 : 0
+  parent = "organizations/${var.org_id}"
+  title  = "default policy"
 }

--- a/1-org/variables.tf
+++ b/1-org/variables.tf
@@ -89,3 +89,9 @@ variable "parent_folder" {
   type        = string
   default     = ""
 }
+
+variable "create_access_context_manager_access_policy" {
+  description = "Whether to create access context manager access policy"
+  type        = bool
+  default     = true
+}

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -22,14 +22,14 @@ steps:
   - 'TF_VAR_folder_id=$_FOLDER_ID'
   - 'TF_VAR_billing_account=$_BILLING_ACCOUNT'
   - 'TF_VAR_group_email=test-gcp-org-admins@test.infra.cft.tips'
-- id: clean
-  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', './test/clean_org.sh']
-  env:
-  - 'TF_VAR_org_id=$_ORG_ID'
-  - 'TF_VAR_folder_id=$_FOLDER_ID'
-  - 'TF_VAR_billing_account=$_BILLING_ACCOUNT'
-  - 'TF_VAR_group_email=test-gcp-org-admins@test.infra.cft.tips'
+# - id: clean
+#   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+#   args: ['/bin/bash', '-c', './test/clean_org.sh']
+#   env:
+#   - 'TF_VAR_org_id=$_ORG_ID'
+#   - 'TF_VAR_folder_id=$_FOLDER_ID'
+#   - 'TF_VAR_billing_account=$_BILLING_ACCOUNT'
+#   - 'TF_VAR_group_email=test-gcp-org-admins@test.infra.cft.tips'
 - id: create
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do create']

--- a/test/fixtures/org/main.tf
+++ b/test/fixtures/org/main.tf
@@ -14,15 +14,21 @@
  * limitations under the License.
  */
 
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+
 module "test" {
-  source                    = "../../../1-org"
-  parent_folder             = var.parent_folder
-  org_id                    = var.org_id
-  billing_account           = var.billing_account
-  terraform_service_account = var.terraform_sa_email
-  default_region            = "us-east4"
-  billing_data_users        = var.group_email
-  audit_data_users          = var.group_email
-  scc_notification_name     = "test-scc-notification"
-  domains_to_allow          = [var.domain_to_allow]
+  source                                      = "../../../1-org"
+  parent_folder                               = var.parent_folder
+  org_id                                      = var.org_id
+  billing_account                             = var.billing_account
+  terraform_service_account                   = var.terraform_sa_email
+  default_region                              = "us-east4"
+  billing_data_users                          = var.group_email
+  audit_data_users                            = var.group_email
+  scc_notification_name                       = "test-scc-notif-${random_id.suffix.hex}"
+  domains_to_allow                            = [var.domain_to_allow]
+  create_access_context_manager_access_policy = false
 }


### PR DESCRIPTION
Enables concurrent builds for int tests by

- randomize scc notif name
- pin `access_context_manager_access_policy` to use existing policy