### PR TITLE
Add flags to enable network logs.

### DIFF
--- a/3-networks/envs/dev/README.md
+++ b/3-networks/envs/dev/README.md
@@ -43,8 +43,11 @@ The purpose of this step is to setup private and restricted shared VPCs with def
 | access\_context\_manager\_policy\_id | The id of the default Access Context Manager policy created in step `1-org`. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`. | number | n/a | yes |
 | default\_region1 | First subnet region. The shared vpc modules only configures two regions. | string | n/a | yes |
 | default\_region2 | Second subnet region. The shared vpc modules only configures two regions. | string | n/a | yes |
+| dns\_enable\_logging | Toggle DNS logging for VPC DNS. | bool | `"true"` | no |
 | domain | The DNS name of peering managed zone, for instance 'example.com.' | string | n/a | yes |
+| firewall\_enable\_logging | Toggle firewall logginglogging for VPC Firewalls. | bool | `"true"` | no |
 | org\_id | Organization ID | string | n/a | yes |
+| subnetworks\_enable\_logging | Toggle subnetworks flow logging for VPC Subnetwoks. | bool | `"true"` | no |
 | terraform\_service\_account | Service account email of the account to impersonate to run Terraform. | string | n/a | yes |
 
 ## Outputs

--- a/3-networks/envs/dev/main.tf
+++ b/3-networks/envs/dev/main.tf
@@ -63,7 +63,7 @@ module "restricted_shared_vpc" {
       subnet_ip             = "10.0.160.0/21"
       subnet_region         = var.default_region1
       subnet_private_access = "true"
-      subnet_flow_logs      = "false"
+      subnet_flow_logs      = var.subnetworks_enable_logging
       description           = "First ${local.env} subnet example."
     },
     {
@@ -71,7 +71,7 @@ module "restricted_shared_vpc" {
       subnet_ip             = "10.0.168.0/21"
       subnet_region         = var.default_region2
       subnet_private_access = "true"
-      subnet_flow_logs      = "false"
+      subnet_flow_logs      = var.subnetworks_enable_logging
       description           = "Second ${local.env} subnet example."
     }
   ]
@@ -144,7 +144,7 @@ module "private_shared_vpc" {
       subnet_ip             = "10.0.128.0/21"
       subnet_region         = var.default_region1
       subnet_private_access = "true"
-      subnet_flow_logs      = "false"
+      subnet_flow_logs      = var.subnetworks_enable_logging
       description           = "First ${local.env} subnet example."
     },
     {
@@ -152,7 +152,7 @@ module "private_shared_vpc" {
       subnet_ip             = "10.0.136.0/21"
       subnet_region         = var.default_region2
       subnet_private_access = "true"
-      subnet_flow_logs      = "false"
+      subnet_flow_logs      = var.subnetworks_enable_logging
       description           = "Second ${local.env} subnet example."
     }
   ]

--- a/3-networks/envs/dev/variables.tf
+++ b/3-networks/envs/dev/variables.tf
@@ -43,3 +43,21 @@ variable "domain" {
   type        = string
   description = "The DNS name of peering managed zone, for instance 'example.com.'"
 }
+
+variable "dns_enable_logging" {
+  type        = bool
+  description = "Toggle DNS logging for VPC DNS."
+  default     = true
+}
+
+variable "subnetworks_enable_logging" {
+  type        = bool
+  description = "Toggle subnetworks flow logging for VPC Subnetwoks."
+  default     = true
+}
+
+variable "firewall_enable_logging" {
+  type        = bool
+  description = "Toggle firewall logginglogging for VPC Firewalls."
+  default     = true
+}

--- a/3-networks/envs/nonprod/README.md
+++ b/3-networks/envs/nonprod/README.md
@@ -43,8 +43,11 @@ The purpose of this step is to setup private and restricted shared VPCs with def
 | access\_context\_manager\_policy\_id | The id of the default Access Context Manager policy created in step `1-org`. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`. | number | n/a | yes |
 | default\_region1 | First subnet region. The shared vpc modules only configures two regions. | string | n/a | yes |
 | default\_region2 | Second subnet region. The shared vpc modules only configures two regions. | string | n/a | yes |
+| dns\_enable\_logging | Toggle DNS logging for VPC DNS. | bool | `"true"` | no |
 | domain | The DNS name of peering managed zone, for instance 'example.com.' | string | n/a | yes |
+| firewall\_enable\_logging | Toggle firewall logginglogging for VPC Firewalls. | bool | `"true"` | no |
 | org\_id | Organization ID | string | n/a | yes |
+| subnetworks\_enable\_logging | Toggle subnetworks flow logging for VPC Subnetwoks. | bool | `"true"` | no |
 | terraform\_service\_account | Service account email of the account to impersonate to run Terraform. | string | n/a | yes |
 
 ## Outputs

--- a/3-networks/envs/nonprod/main.tf
+++ b/3-networks/envs/nonprod/main.tf
@@ -64,7 +64,7 @@ module "restricted_shared_vpc" {
       subnet_ip             = "10.0.96.0/21"
       subnet_region         = var.default_region1
       subnet_private_access = "true"
-      subnet_flow_logs      = "false"
+      subnet_flow_logs      = var.subnetworks_enable_logging
       description           = "First ${local.env} subnet example."
     },
     {
@@ -72,7 +72,7 @@ module "restricted_shared_vpc" {
       subnet_ip             = "10.0.104.0/21"
       subnet_region         = var.default_region2
       subnet_private_access = "true"
-      subnet_flow_logs      = "false"
+      subnet_flow_logs      = var.subnetworks_enable_logging
       description           = "Second ${local.env} subnet example."
     }
   ]
@@ -146,7 +146,7 @@ module "private_shared_vpc" {
       subnet_ip             = "10.0.64.0/21"
       subnet_region         = var.default_region1
       subnet_private_access = "true"
-      subnet_flow_logs      = "false"
+      subnet_flow_logs      = var.subnetworks_enable_logging
       description           = "First ${local.env} subnet example."
     },
     {
@@ -154,7 +154,7 @@ module "private_shared_vpc" {
       subnet_ip             = "10.0.72.0/21"
       subnet_region         = var.default_region2
       subnet_private_access = "true"
-      subnet_flow_logs      = "false"
+      subnet_flow_logs      = var.subnetworks_enable_logging
       description           = "Second ${local.env} subnet example."
     }
   ]

--- a/3-networks/envs/nonprod/variables.tf
+++ b/3-networks/envs/nonprod/variables.tf
@@ -43,3 +43,21 @@ variable "domain" {
   type        = string
   description = "The DNS name of peering managed zone, for instance 'example.com.'"
 }
+
+variable "dns_enable_logging" {
+  type        = bool
+  description = "Toggle DNS logging for VPC DNS."
+  default     = true
+}
+
+variable "subnetworks_enable_logging" {
+  type        = bool
+  description = "Toggle subnetworks flow logging for VPC Subnetwoks."
+  default     = true
+}
+
+variable "firewall_enable_logging" {
+  type        = bool
+  description = "Toggle firewall logginglogging for VPC Firewalls."
+  default     = true
+}

--- a/3-networks/envs/prod/README.md
+++ b/3-networks/envs/prod/README.md
@@ -43,8 +43,11 @@ The purpose of this step is to setup private and restricted shared VPCs with def
 | access\_context\_manager\_policy\_id | The id of the default Access Context Manager policy created in step `1-org`. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`. | number | n/a | yes |
 | default\_region1 | First subnet region. The shared vpc modules only configures two regions. | string | n/a | yes |
 | default\_region2 | Second subnet region. The shared vpc modules only configures two regions. | string | n/a | yes |
+| dns\_enable\_logging | Toggle DNS logging for VPC DNS. | bool | `"true"` | no |
 | domain | The DNS name of peering managed zone, for instance 'example.com.' | string | n/a | yes |
+| firewall\_enable\_logging | Toggle firewall logginglogging for VPC Firewalls. | bool | `"true"` | no |
 | org\_id | Organization ID | string | n/a | yes |
+| subnetworks\_enable\_logging | Toggle subnetworks flow logging for VPC Subnetwoks. | bool | `"true"` | no |
 | terraform\_service\_account | Service account email of the account to impersonate to run Terraform. | string | n/a | yes |
 
 ## Outputs

--- a/3-networks/envs/prod/main.tf
+++ b/3-networks/envs/prod/main.tf
@@ -63,7 +63,7 @@ module "restricted_shared_vpc" {
       subnet_ip             = "10.0.32.0/21"
       subnet_region         = var.default_region1
       subnet_private_access = "true"
-      subnet_flow_logs      = "false"
+      subnet_flow_logs      = var.subnetworks_enable_logging
       description           = "First ${local.env} subnet example."
     },
     {
@@ -71,7 +71,7 @@ module "restricted_shared_vpc" {
       subnet_ip             = "10.0.40.0/21"
       subnet_region         = var.default_region2
       subnet_private_access = "true"
-      subnet_flow_logs      = "false"
+      subnet_flow_logs      = var.subnetworks_enable_logging
       description           = "Second ${local.env} subnet example."
     }
   ]
@@ -144,7 +144,7 @@ module "private_shared_vpc" {
       subnet_ip             = "10.0.0.0/21"
       subnet_region         = var.default_region1
       subnet_private_access = "true"
-      subnet_flow_logs      = "false"
+      subnet_flow_logs      = var.subnetworks_enable_logging
       description           = "First ${local.env} subnet example."
     },
     {
@@ -152,7 +152,7 @@ module "private_shared_vpc" {
       subnet_ip             = "10.0.8.0/21"
       subnet_region         = var.default_region2
       subnet_private_access = "true"
-      subnet_flow_logs      = "false"
+      subnet_flow_logs      = var.subnetworks_enable_logging
       description           = "Second ${local.env} subnet example."
     }
   ]

--- a/3-networks/envs/prod/variables.tf
+++ b/3-networks/envs/prod/variables.tf
@@ -43,3 +43,21 @@ variable "domain" {
   type        = string
   description = "The DNS name of peering managed zone, for instance 'example.com.'"
 }
+
+variable "dns_enable_logging" {
+  type        = bool
+  description = "Toggle DNS logging for VPC DNS."
+  default     = true
+}
+
+variable "subnetworks_enable_logging" {
+  type        = bool
+  description = "Toggle subnetworks flow logging for VPC Subnetwoks."
+  default     = true
+}
+
+variable "firewall_enable_logging" {
+  type        = bool
+  description = "Toggle firewall logginglogging for VPC Firewalls."
+  default     = true
+}

--- a/3-networks/envs/shared/README.md
+++ b/3-networks/envs/shared/README.md
@@ -43,6 +43,7 @@ The purpose of this step is to setup the global [DNS Hub](https://cloud.google.c
 | dns\_default\_region2 | Second subnet region for DNS Hub network. | string | n/a | yes |
 | dns\_enable\_logging | Toggle DNS logging for VPC DNS. | bool | `"true"` | no |
 | domain | The DNS name of forwarding managed zone, for instance 'example.com' | string | n/a | yes |
+| subnetworks\_enable\_logging | Toggle subnetworks flow logging for VPC Subnetwoks. | bool | `"true"` | no |
 | target\_name\_server\_addresses | List of target name servers for forwarding zone. | list(string) | n/a | yes |
 | terraform\_service\_account | Service account email of the account to impersonate to run Terraform. | string | n/a | yes |
 

--- a/3-networks/envs/shared/main.tf
+++ b/3-networks/envs/shared/main.tf
@@ -44,14 +44,14 @@ module "dns_hub_vpc" {
     subnet_ip             = "172.16.0.0/25"
     subnet_region         = var.dns_default_region1
     subnet_private_access = "true"
-    subnet_flow_logs      = "false"
+    subnet_flow_logs      = var.subnetworks_enable_logging
     description           = "DNS hub subnet for region 1."
     }, {
     subnet_name           = "sb-dns-hub-${var.dns_default_region2}"
     subnet_ip             = "172.16.0.128/25"
     subnet_region         = var.dns_default_region2
     subnet_private_access = "true"
-    subnet_flow_logs      = "false"
+    subnet_flow_logs      = var.subnetworks_enable_logging
     description           = "DNS hub subnet for region 2."
   }]
 

--- a/3-networks/envs/shared/variables.tf
+++ b/3-networks/envs/shared/variables.tf
@@ -35,6 +35,12 @@ variable "dns_enable_logging" {
   default     = true
 }
 
+variable "subnetworks_enable_logging" {
+  type        = bool
+  description = "Toggle subnetworks flow logging for VPC Subnetwoks."
+  default     = true
+}
+
 variable "domain" {
   type        = string
   description = "The DNS name of forwarding managed zone, for instance 'example.com'"

--- a/3-networks/modules/restricted_shared_vpc/README.md
+++ b/3-networks/modules/restricted_shared_vpc/README.md
@@ -11,6 +11,7 @@
 | dns\_enable\_logging | Toggle DNS logging for VPC DNS. | bool | `"true"` | no |
 | domain | The DNS name of peering managed zone, for instance 'example.com.' | string | n/a | yes |
 | environment\_code | A short form of the folder level resources (environment) within the Google Cloud organization. | string | n/a | yes |
+| firewall\_enable\_logging | Toggle firewall logginglogging for VPC Firewalls. | bool | `"true"` | no |
 | members | An allowed list of members (users, service accounts). The signed-in identity originating the request must be a part of one of the provided members. If not specified, a request may come from any user (logged in/not logged in, etc.). Formats: user:{emailid}, serviceAccount:{emailid} | list(string) | n/a | yes |
 | nat\_bgp\_asn | BGP ASN for NAT cloud routes. If NAT is enabled this variable value must be a value in ranges [64512..65534] or [4200000000..4294967294]. | number | `"64512"` | no |
 | nat\_enabled | Toggle creation of NAT cloud router. | bool | `"false"` | no |

--- a/3-networks/modules/restricted_shared_vpc/firewall.tf
+++ b/3-networks/modules/restricted_shared_vpc/firewall.tf
@@ -19,11 +19,12 @@
   Mandatory firewall rules
  *****************************************/
 resource "google_compute_firewall" "deny_all_egress" {
-  name      = "fw-${var.environment_code}-shared-restricted-65535-e-d-all-all-tcp-udp"
-  network   = module.main.network_name
-  project   = var.project_id
-  direction = "EGRESS"
-  priority  = 65535
+  name           = "fw-${var.environment_code}-shared-restricted-65535-e-d-all-all-tcp-udp"
+  network        = module.main.network_name
+  project        = var.project_id
+  direction      = "EGRESS"
+  priority       = 65535
+  enable_logging = var.firewall_enable_logging
 
   deny {
     protocol = "tcp"
@@ -37,11 +38,12 @@ resource "google_compute_firewall" "deny_all_egress" {
 }
 
 resource "google_compute_firewall" "allow_restricted_api_egress" {
-  name      = "fw-${var.environment_code}-shared-restricted-65534-e-a-all-all-tcp-443"
-  network   = module.main.network_name
-  project   = var.project_id
-  direction = "EGRESS"
-  priority  = 65534
+  name           = "fw-${var.environment_code}-shared-restricted-65534-e-a-all-all-tcp-443"
+  network        = module.main.network_name
+  project        = var.project_id
+  direction      = "EGRESS"
+  priority       = 65534
+  enable_logging = var.firewall_enable_logging
 
   allow {
     protocol = "tcp"
@@ -57,10 +59,11 @@ resource "google_compute_firewall" "allow_restricted_api_egress" {
 
 // Allow SSH via IAP when using the allow-iap-ssh tag for Linux workloads.
 resource "google_compute_firewall" "allow_iap_ssh" {
-  count   = var.optional_fw_rules_enabled ? 1 : 0
-  name    = "fw-${var.environment_code}-shared-restricted-1000-i-a-all-allow-iap-ssh-tcp-22"
-  network = module.main.network_name
-  project = var.project_id
+  count          = var.optional_fw_rules_enabled ? 1 : 0
+  name           = "fw-${var.environment_code}-shared-restricted-1000-i-a-all-allow-iap-ssh-tcp-22"
+  network        = module.main.network_name
+  project        = var.project_id
+  enable_logging = var.firewall_enable_logging
 
   // Cloud IAP's TCP forwarding netblock
   source_ranges = data.google_netblock_ip_ranges.iap_forwarders.cidr_blocks_ipv4
@@ -75,10 +78,11 @@ resource "google_compute_firewall" "allow_iap_ssh" {
 
 // Allow RDP via IAP when using the allow-iap-rdp tag for Windows workloads.
 resource "google_compute_firewall" "allow_iap_rdp" {
-  count   = var.optional_fw_rules_enabled ? 1 : 0
-  name    = "fw-${var.environment_code}-shared-restricted-1000-i-a-all-allow-iap-rdp-tcp-3389"
-  network = module.main.network_name
-  project = var.project_id
+  count          = var.optional_fw_rules_enabled ? 1 : 0
+  name           = "fw-${var.environment_code}-shared-restricted-1000-i-a-all-allow-iap-rdp-tcp-3389"
+  network        = module.main.network_name
+  project        = var.project_id
+  enable_logging = var.firewall_enable_logging
 
   // Cloud IAP's TCP forwarding netblock
   source_ranges = data.google_netblock_ip_ranges.iap_forwarders.cidr_blocks_ipv4
@@ -93,10 +97,11 @@ resource "google_compute_firewall" "allow_iap_rdp" {
 
 // Allow traffic for Internal & Global load balancing health check and load balancing IP ranges.
 resource "google_compute_firewall" "allow_lb" {
-  count   = var.optional_fw_rules_enabled ? 1 : 0
-  name    = "fw-${var.environment_code}-shared-restricted-1000-i-a-all-allow-lb-tcp-80-8080-443"
-  network = module.main.network_name
-  project = var.project_id
+  count          = var.optional_fw_rules_enabled ? 1 : 0
+  name           = "fw-${var.environment_code}-shared-restricted-1000-i-a-all-allow-lb-tcp-80-8080-443"
+  network        = module.main.network_name
+  project        = var.project_id
+  enable_logging = var.firewall_enable_logging
 
   source_ranges = concat(data.google_netblock_ip_ranges.health_checkers.cidr_blocks_ipv4, data.google_netblock_ip_ranges.legacy_health_checkers.cidr_blocks_ipv4)
 
@@ -111,12 +116,13 @@ resource "google_compute_firewall" "allow_lb" {
 
 // Allow access to kms.windows.googlecloud.com for Windows license activation
 resource "google_compute_firewall" "allow_windows_activation" {
-  count     = var.windows_activation_enabled ? 1 : 0
-  name      = "fw-${var.environment_code}-shared-restricted-0-e-a-all-tcp-1688"
-  network   = module.main.network_name
-  project   = var.project_id
-  direction = "EGRESS"
-  priority  = 0
+  count          = var.windows_activation_enabled ? 1 : 0
+  name           = "fw-${var.environment_code}-shared-restricted-0-e-a-all-tcp-1688"
+  network        = module.main.network_name
+  project        = var.project_id
+  direction      = "EGRESS"
+  priority       = 0
+  enable_logging = var.firewall_enable_logging
 
   allow {
     protocol = "tcp"

--- a/3-networks/modules/restricted_shared_vpc/variables.tf
+++ b/3-networks/modules/restricted_shared_vpc/variables.tf
@@ -102,6 +102,12 @@ variable "dns_enable_logging" {
   default     = true
 }
 
+variable "firewall_enable_logging" {
+  type        = bool
+  description = "Toggle firewall logginglogging for VPC Firewalls."
+  default     = true
+}
+
 variable "domain" {
   type        = string
   description = "The DNS name of peering managed zone, for instance 'example.com.'"

--- a/3-networks/modules/standard_shared_vpc/README.md
+++ b/3-networks/modules/standard_shared_vpc/README.md
@@ -11,6 +11,7 @@
 | dns\_enable\_logging | Toggle DNS logging for VPC DNS. | bool | `"true"` | no |
 | domain | The DNS name of peering managed zone, for instance 'example.com.' | string | n/a | yes |
 | environment\_code | A short form of the folder level resources (environment) within the Google Cloud organization. | string | n/a | yes |
+| firewall\_enable\_logging | Toggle firewall logginglogging for VPC Firewalls. | bool | `"true"` | no |
 | nat\_bgp\_asn | BGP ASN for first NAT cloud routes. | number | `"0"` | no |
 | nat\_enabled | Toggle creation of NAT cloud router. | bool | `"false"` | no |
 | nat\_num\_addresses | Number of external IPs to reserve for Cloud NAT. | number | `"2"` | no |

--- a/3-networks/modules/standard_shared_vpc/firewall.tf
+++ b/3-networks/modules/standard_shared_vpc/firewall.tf
@@ -18,11 +18,12 @@
   Mandatory firewall rules
  *****************************************/
 resource "google_compute_firewall" "deny_all_egress" {
-  name      = "fw-${var.environment_code}-shared-private-65535-e-d-all-all-tcp-udp"
-  network   = module.main.network_name
-  project   = var.project_id
-  direction = "EGRESS"
-  priority  = 65535
+  name           = "fw-${var.environment_code}-shared-private-65535-e-d-all-all-tcp-udp"
+  network        = module.main.network_name
+  project        = var.project_id
+  direction      = "EGRESS"
+  priority       = 65535
+  enable_logging = var.firewall_enable_logging
 
   deny {
     protocol = "tcp"
@@ -37,11 +38,12 @@ resource "google_compute_firewall" "deny_all_egress" {
 
 
 resource "google_compute_firewall" "allow_private_api_egress" {
-  name      = "fw-${var.environment_code}-shared-private-65534-e-a-all-all-tcp-443"
-  network   = module.main.network_name
-  project   = var.project_id
-  direction = "EGRESS"
-  priority  = 65534
+  name           = "fw-${var.environment_code}-shared-private-65534-e-a-all-all-tcp-443"
+  network        = module.main.network_name
+  project        = var.project_id
+  direction      = "EGRESS"
+  priority       = 65534
+  enable_logging = var.firewall_enable_logging
 
   allow {
     protocol = "tcp"
@@ -58,10 +60,11 @@ resource "google_compute_firewall" "allow_private_api_egress" {
 
 // Allow SSH via IAP when using the allow-iap-ssh tag for Linux workloads.
 resource "google_compute_firewall" "allow_iap_ssh" {
-  count   = var.default_fw_rules_enabled ? 1 : 0
-  name    = "fw-${var.environment_code}-shared-private-1000-i-a-all-allow-iap-ssh-tcp-22"
-  network = module.main.network_name
-  project = var.project_id
+  count          = var.default_fw_rules_enabled ? 1 : 0
+  name           = "fw-${var.environment_code}-shared-private-1000-i-a-all-allow-iap-ssh-tcp-22"
+  network        = module.main.network_name
+  project        = var.project_id
+  enable_logging = var.firewall_enable_logging
 
   // Cloud IAP's TCP forwarding netblock
   source_ranges = concat(data.google_netblock_ip_ranges.iap_forwarders.cidr_blocks_ipv4)
@@ -76,10 +79,11 @@ resource "google_compute_firewall" "allow_iap_ssh" {
 
 // Allow RDP via IAP when using the allow-iap-rdp tag for Windows workloads.
 resource "google_compute_firewall" "allow_iap_rdp" {
-  count   = var.default_fw_rules_enabled ? 1 : 0
-  name    = "fw-${var.environment_code}-shared-private-1000-i-a-all-allow-iap-rdp-tcp-3389"
-  network = module.main.network_name
-  project = var.project_id
+  count          = var.default_fw_rules_enabled ? 1 : 0
+  name           = "fw-${var.environment_code}-shared-private-1000-i-a-all-allow-iap-rdp-tcp-3389"
+  network        = module.main.network_name
+  project        = var.project_id
+  enable_logging = var.firewall_enable_logging
 
   // Cloud IAP's TCP forwarding netblock
   source_ranges = concat(data.google_netblock_ip_ranges.iap_forwarders.cidr_blocks_ipv4)
@@ -94,12 +98,13 @@ resource "google_compute_firewall" "allow_iap_rdp" {
 
 // Allow access to kms.windows.googlecloud.com for Windows license activation
 resource "google_compute_firewall" "allow_windows_activation" {
-  count     = var.windows_activation_enabled ? 1 : 0
-  name      = "fw-${var.environment_code}-shared-private-0-e-a-all-tcp-1688"
-  network   = module.main.network_name
-  project   = var.project_id
-  direction = "EGRESS"
-  priority  = 0
+  count          = var.windows_activation_enabled ? 1 : 0
+  name           = "fw-${var.environment_code}-shared-private-0-e-a-all-tcp-1688"
+  network        = module.main.network_name
+  project        = var.project_id
+  direction      = "EGRESS"
+  priority       = 0
+  enable_logging = var.firewall_enable_logging
 
   allow {
     protocol = "tcp"
@@ -109,10 +114,11 @@ resource "google_compute_firewall" "allow_windows_activation" {
 
 // Allow traffic for Internal & Global load balancing health check and load balancing IP ranges.
 resource "google_compute_firewall" "allow_lb" {
-  count   = var.default_fw_rules_enabled ? 1 : 0
-  name    = "fw-${var.environment_code}-shared-private-1000-i-a-all-allow-lb-tcp-80-8080-443"
-  network = module.main.network_name
-  project = var.project_id
+  count          = var.default_fw_rules_enabled ? 1 : 0
+  name           = "fw-${var.environment_code}-shared-private-1000-i-a-all-allow-lb-tcp-80-8080-443"
+  network        = module.main.network_name
+  project        = var.project_id
+  enable_logging = var.firewall_enable_logging
 
   source_ranges = concat(data.google_netblock_ip_ranges.health_checkers.cidr_blocks_ipv4, data.google_netblock_ip_ranges.legacy_health_checkers.cidr_blocks_ipv4)
 

--- a/3-networks/modules/standard_shared_vpc/variables.tf
+++ b/3-networks/modules/standard_shared_vpc/variables.tf
@@ -92,6 +92,12 @@ variable "dns_enable_logging" {
   default     = true
 }
 
+variable "firewall_enable_logging" {
+  type        = bool
+  description = "Toggle firewall logginglogging for VPC Firewalls."
+  default     = true
+}
+
 variable "domain" {
   type        = string
   description = "The DNS name of peering managed zone, for instance 'example.com.'"


### PR DESCRIPTION
Changes in this pull request to support enabling network logs:

- DNS logs
  - add dns_enable_logging to variables of 3-network/envs/[dev, nonprod, prod, shared]. Default value is "true" 
- Subnetwork Flow Logs
  - add subnetworks_enable_logging to variables of 3-network/envs/[dev, nonprod, prod, shared]. Default value is "true" 
  - use variable subnetworks_enable_logging in subnetworks definitions
- Firewall logs
  - add firewall_enable_logging to variables of 3-network/envs/[dev,nonprod,prod]. Default value is "true"  
  - add firewall_enable_logging to variables of 3-network/modules/[restricted_shared_vpc, standard_shared_vpc]. Default value is "true"  
  - add variable firewall_enable_logging in firewall definitions

@morgante @rjerrems @bharathkkb  could you please take a look at this? 