### PR TITLE
Adds a commented call to the jenkins-agent submodule

### DIFF
--- a/0-bootstrap/README.md
+++ b/0-bootstrap/README.md
@@ -6,7 +6,7 @@ The purpose of this step is to bootstrap a GCP organization, creating all the re
 
 1. A GCP [Organization](https://cloud.google.com/resource-manager/docs/creating-managing-organization)
 1. A GCP [Billing Account](https://cloud.google.com/billing/docs/how-to/manage-billing-account)
-1. Cloud Identity / Gsuite groups for organization and billing admins
+1. Cloud Identity / G Suite groups for organization and billing admins
 1. Membership in the `group_org_admins` group for user running terraform
 1. Grant the roles mentioned in bootstrap [README.md](https://github.com/terraform-google-modules/terraform-google-bootstrap#permissions), as well as `roles/resourcemanager.folderCreator` for the user running the step.
 

--- a/0-bootstrap/README.md
+++ b/0-bootstrap/README.md
@@ -32,7 +32,7 @@ Further details of permissions required and resources created, can be found in t
 | group\_billing\_admins | Google Group for GCP Billing Administrators | string | n/a | yes |
 | group\_org\_admins | Google Group for GCP Organization Administrators | string | n/a | yes |
 | org\_id | GCP Organization ID | string | n/a | yes |
-| org\_project\_creators | Additional list of members to have project creator role accross the organization. Prefix of group: user: or serviceAccount: is required. | list(string) | `<list>` | no |
+| org\_project\_creators | Additional list of members to have project creator role across the organization. Prefix of group: user: or serviceAccount: is required. | list(string) | `<list>` | no |
 | parent\_folder | Optional - if using a folder for testing. | string | `""` | no |
 | skip\_gcloud\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
 
@@ -53,6 +53,12 @@ Further details of permissions required and resources created, can be found in t
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Requirements
+
+If you are using `jenkins_bootstrap`, please see the [README](./modules/jenkins-agent/README.md) for the requirements.
+
+## Instructions
+
+If you are using `jenkins_bootstrap`, please follow the instructions on how to run the bootstrap step with the `jenkins_bootstrap` sub-module described in the [README](./modules/jenkins-agent/README.md), which include implementing VPN, configuring your Jenkins Master among other steps.
 
 ### Software
 

--- a/0-bootstrap/main.tf
+++ b/0-bootstrap/main.tf
@@ -89,6 +89,7 @@ module "seed_bootstrap" {
   ]
 }
 
+// Comment-out the cloudbuild_bootstrap module and its outputs if you want to use Jenkins instead of Cloud Build
 module "cloudbuild_bootstrap" {
   source                    = "terraform-google-modules/bootstrap/google//modules/cloudbuild"
   version                   = "~> 1.2"
@@ -119,3 +120,23 @@ module "cloudbuild_bootstrap" {
     "prod"
   ]
 }
+
+//// Un-comment the jenkins_bootstrap module and its outputs if you want to use Jenkins instead of Cloud Build
+//module "jenkins_bootstrap" {
+//  source                                  = "./modules/jenkins-agent"
+//  org_id                                  = var.org_id
+//  folder_id                               = google_folder.seed.id
+//  billing_account                         = var.billing_account
+//  group_org_admins                        = var.group_org_admins
+//  default_region                          = var.default_region
+//  terraform_sa_email                      = module.seed_bootstrap.terraform_sa_email
+//  terraform_sa_name                       = module.seed_bootstrap.terraform_sa_name
+//  terraform_state_bucket                  = module.seed_bootstrap.gcs_bucket_tfstate
+//  sa_enable_impersonation                 = true
+//  jenkins_master_ip_addresses             = var.jenkins_master_ip_addresses
+//  jenkins_agent_gce_subnetwork_cidr_range = var.jenkins_agent_gce_subnetwork_cidr_range
+//  jenkins_agent_gce_private_ip_address    = var.jenkins_agent_gce_private_ip_address
+//  nat_bgp_asn                             = var.nat_bgp_asn
+//  jenkins_agent_sa_email                  = var.jenkins_agent_sa_email
+//  jenkins_agent_gce_ssh_pub_key           = var.jenkins_agent_gce_ssh_pub_key
+//}

--- a/0-bootstrap/modules/jenkins-agent/README.md
+++ b/0-bootstrap/modules/jenkins-agent/README.md
@@ -78,7 +78,7 @@ Error: failed pre-requisites: missing permission on "billingAccounts/aaaaaa-bbbb
 | jenkins\_agent\_gce\_machine\_type | Jenkins Agent GCE Instance type. | string | `"n1-standard-1"` | no |
 | jenkins\_agent\_gce\_name | Jenkins Agent GCE Instance name. | string | `"jenkins-agent-01"` | no |
 | jenkins\_agent\_gce\_private\_ip\_address | The private IP Address of the Jenkins Agent. This IP Address must be in the CIDR range of `jenkins_agent_gce_subnetwork_cidr_range` and be reachable through the VPN that exists between on-prem (Jenkins Master) and GCP (CICD Project, where the Jenkins Agent is located). | string | n/a | yes |
-| jenkins\_agent\_gce\_ssh\_pub\_key | SSH public key needed by the Jenkins Agent GCE Instance. The Jenkins Master holds the SSH private key. The correct format is `'ssh-rsa [KEY_VALUE] [USERNAME]'` | string | `""` | no |
+| jenkins\_agent\_gce\_ssh\_pub\_key | SSH public key needed by the Jenkins Agent GCE Instance. The Jenkins Master holds the SSH private key. The correct format is `'ssh-rsa [KEY_VALUE] [USERNAME]'` | string | n/a | yes |
 | jenkins\_agent\_gce\_ssh\_user | Jenkins Agent GCE Instance SSH username. | string | `"jenkins"` | no |
 | jenkins\_agent\_gce\_subnetwork\_cidr\_range | The subnetwork to which the Jenkins Agent will be connected to (in CIDR range 0.0.0.0/0) | string | n/a | yes |
 | jenkins\_agent\_sa\_email | Email for Jenkins Agent service account. | string | `"jenkins-agent-gce"` | no |
@@ -150,6 +150,235 @@ resources of this module:
 - Google Cloud KMS API: `cloudkms.googleapis.com`
 
 This API can be enabled in the default project created during establishing an organization.
+
+## Instructions
+
+You got to these instructions because you are using the `jenkins_bootstrap` to run the bootstrap step instead of `cloudbuild_bootstrap`. Please follow the indications below:
+
+### **1. Bootstrap Manual steps before running any terraform script**
+  - Required information:
+     - Access to the Jenkins Master host to run  `ssh-keygen` command.
+     - Access to the Jenkins Master Web UI.
+     - [SSH Agent Jenkins plugin](https://plugins.jenkins.io/ssh-agent) installed in your Jenkins Master
+     - Private IP address for the Jenkins Agent which will be created in the `cicd` GCP Project in step 1.2-d
+     - A Git repository where to store the infrastructure code (typically a private repository that might be on-prem).
+
+**1.1 In the Jenkins Master host, use the `ssh-keygen` command to generate a SSH key pair.**
+
+You will need this key pair to enable authentication between the Master and Agent.  Although the key-pair can be generated in any linux machine. It is recommended not to copy the secret private key from one host to another, so you may want to do this from the Jenkins Master host. Note the `ssh-keygen` command uses the `-N` option to protect the private key with a password. In this example, we are using `-N ""` which means we are not setting a password to protect this private key.
+
+    ```
+    SSH_LOCAL_CONFIG_DIR="$HOME/.ssh"
+    JENKINS_USER="jenkins"
+    JENKINS_AGENT_NAME="AgentGCE1"
+    SSH_KEY_FILE_PATH="$SSH_LOCAL_CONFIG_DIR/$JENKINS_USER-${JENKINS_AGENT_NAME}_rsa"
+    mkdir "$SSH_LOCAL_CONFIG_DIR"
+    ssh-keygen -t rsa -m PEM -N "" -C $JENKINS_USER -f $SSH_KEY_FILE_PATH
+    cat $SSH_KEY_FILE_PATH
+    ```
+
+ You will see an output similar to this:
+
+    ```
+    -----BEGIN RSA PRIVATE KEY-----
+          copy your private key
+            from BEGIN to END
+      And configure a new
+      Jenkins Agent in the Web UI
+    -----END RSA PRIVATE KEY-----
+    ```
+
+**1.2 Configure a new SSH Jenkins Agent.**
+
+In the Jenkins Master’s Web UI, use the following information to configure a new [SSH Jenkins Agent](https://plugins.jenkins.io/ssh-agent/):
+- SSH private key you just generated
+- The passphrase that protects the private key if you used the `-N ""` option
+- The Jenkins Agent’s private IP address assigned by your Network Administrator
+
+**1.3 Configure the Git repository in your Jenkins Master.**
+
+In your Jenkins Master, you might need to configure credentials to connect to the Git repository where you plan to store your infrastructure code.
+- You may also want to configure an automatic build trigger. Note that this is considered out of the scope of this document, since there are multiple options on how to do this and multiple Jenkins Plugins able to help with the task. You can also simply run the build job manually from the Jenkins Web UI.
+
+### **2 Bootstrap scripted steps using terraform**
+
+- Required information:
+  - Four Git repositories: one repo for each directory in this [monorepo](https://github.com/terraform-google-modules/terraform-example-foundation) (`0-bootstrap, 1-org, 2-environments, 3-networks, 4-projects`)
+  - Public SSH key generated in the Jenkins Master (this is not a secret and can be in your repository code). Copy the public key using: `cat "${SSH_KEY_FILE_PATH}.pub"`
+  - VPN details from your Network administrator:
+     - VPN public IP
+     - VPN PSK secret
+     - Private IP address for the Jenkins Agent (which will be created in the `cicd` GCP Project in Step "2.4. Run terraform commands"). This private IP will be reachable through the VPN connection that you will create in Step "3.2. Configure VPN Network tunnel".
+
+**2.1. Clone the Repository provided here**
+
+    ```
+    git clone https://github.com/terraform-google-modules/terraform-example-foundation
+    ```
+
+**2.2. Create a terraform.tfvars**
+
+Create a `terraform.tfvars` by copying the provided  `terraform.example.tfvars` file in the `0-bootstrap` directory and provide values for the required variables.**
+
+    ```
+    # copy the provided terraform.example.tfvars file
+    cd 0-bootstrap
+    cp terraform.example.tfvars terraform.tfvars
+
+    # Edit the file to provide the necessary values
+    vi terraform.tfvars
+    ```
+
+**2.3. Get the appropriate credentials.**
+
+ Run the following command to make sure you [have the appropriate permissions](https://github.com/terraform-google-modules/terraform-google-bootstrap#permissions), which will offer to open a link in your browser:
+
+    ```
+    gcloud auth application-default login
+    ```
+
+**2.4. Run terraform commands.**
+
+After the credentials are configured, you can run the terraform script below, which creates the `cicd` and `Seed` projects, the Jenkins Agent and other elements described in the introduction.
+
+    ```
+    terraform plan
+    terraform apply
+    ```
+
+Once the terraform script completes, note that communication between on-prem and the `cicd` project won’t happen yet - you will configure the VPN network connectivity in Step 3, which is done using `gcloud` commands instead of a terraform module.
+
+### **3. Manual steps after running bootstrap terraform script**
+- Required information:
+  - From previous Step 2.4:
+    - cicd project ID:
+    - Default region
+    - Jenkins Agent VPC name
+    - Terraform State bucket name: This is the bucket created in the `seed` project, using  which name starts with `cft-tfstate-*`.
+  - Usually, from your network administrator:
+    - On-prem VPN public IP Address
+    - Jenkins Master’s network CIDR
+    - Jenkins Agent network CIDR
+    - VPN PSK (pre-shared secret key)
+
+**3.1. Move Terraform state to the GCS bucket created in the seed project:**
+
+- 3.1.1 Copy the backend by running
+
+    ```
+    cp backend.tf.example backend.tf
+    ```
+
+- 3.1.2 and update the `bucket` value in the `backend.tf` file, which you can see by running
+
+    ```
+    terraform show | grep gcs_bucket_tfstate
+    ```
+
+- 3.1.3 Re-run `terraform init` and agree to copy state to gcs when prompted
+    ```
+    terraform init
+    ```
+
+- 3.1.4 agree to copy state to gcs when prompted.
+    - (Optional) Run `terraform apply` to verify state is configured correctly. You can confirm the terraform state is now in that bucket by visiting the bucket url in your seed project.
+
+**3.2. Configure VPN Network tunnel.**
+
+Configure VPN Network tunnel to enable connectivity between the `cicd` project and your on-prem environment. Learn more about [how to deploy a VPN tunnel in GCP](https://cloud.google.com/network-connectivity/docs/vpn/how-to).
+
+- 3.2.1 Supply the required values for the bash variables below:
+
+    ```
+    # Project variables:
+    CICD_PROJECT_ID="prj-cicd-*"
+    DEFAULT_REGION="us-central1"# Jenkins Network environment variables:
+    ONPREM_VPN_PUBLIC_IP_ADDRESS="1.1.1.1"
+    JENKINS_MASTER_NETWORK_CIDR="10.1.0.0/24"
+    JENKINS_AGENT_NETWORK_CIDR="10.2.0.0/24"
+    JENKINS_AGENT_VPC_NAME="vpc-b-jenkinsagents"# New VPN variables
+    VPN_PSK_SECRET="my-secret"
+    CICD_VPN_PUBLIC_IP_NAME="cicd-vpn-external-static-ip"
+    CICD_VPN_NAME="vpn-from-onprem-to-cicd"
+    ```
+
+- 3.2.2 Reserve an `EXTERNAL` IP address for the VPN:
+
+    ```
+    # Reserve a new external IP for the VPN in the cicd project
+    gcloud compute addresses create $CICD_VPN_PUBLIC_IP_NAME \
+    --project="${CICD_PROJECT_ID}" --region="${DEFAULT_REGION}"
+
+    gcloud compute addresses list  --project="${CICD_PROJECT_ID}" \
+   | grep $CICD_VPN_PUBLIC_IP_NAME
+   ```
+
+- 3.2.3 The above command will show the `EXTERNAL` static IP addresses that have been reserved for your VPN in the `cicd` project. You need to do two things with this IP Address:
+    - 3.2.3.1 Inform your Network administrator of the IP address so they configure the on-prem side of the VPN tunnel.
+    - 3.2.3.2 Set the variable below with the IP address you just obtained so you can create the GCP side of the VPN tunnel in the `cicd` project:
+        ```
+        # New VPN variables
+        CICD_VPN_PUBLIC_IP_ADDRESS="x.x.x.x"
+        ```
+
+- 3.2.4 We now have all the necessary information to create the VPN in the `cicd` project.
+
+    ```
+    # Create the new VPN gateway
+    gcloud compute --project $CICD_PROJECT_ID \
+      target-vpn-gateways create $CICD_VPN_NAME \
+      --region $DEFAULT_REGION \
+      --network $JENKINS_AGENT_VPC_NAME
+
+    # Create the forwarding rules
+    gcloud compute --project $CICD_PROJECT_ID \
+      forwarding-rules create "${CICD_VPN_NAME}-rule-esp" \
+      --region $DEFAULT_REGION \
+      --address $CICD_VPN_PUBLIC_IP_ADDRESS \
+      --ip-protocol "ESP" \
+      --target-vpn-gateway $CICD_VPN_NAME
+
+    gcloud compute --project $CICD_PROJECT_ID \
+      forwarding-rules create "${CICD_VPN_NAME}-rule-udp500" \
+      --region $DEFAULT_REGION \
+      --address $CICD_VPN_PUBLIC_IP_ADDRESS \
+      --ip-protocol "UDP" --ports "500" \
+      --target-vpn-gateway $CICD_VPN_NAME
+
+    gcloud compute --project $CICD_PROJECT_ID \
+      forwarding-rules create "${CICD_VPN_NAME}-rule-udp4500" \
+      --region $DEFAULT_REGION \
+      --address $CICD_VPN_PUBLIC_IP_ADDRESS \
+      --ip-protocol "UDP" --ports "4500" \
+      --target-vpn-gateway $CICD_VPN_NAME
+
+    # Create a Route Based VPN tunnel
+    gcloud compute --project $CICD_PROJECT_ID \
+      vpn-tunnels create "${CICD_VPN_NAME}-tunnel-1" \
+      --region $DEFAULT_REGION \
+      --peer-address $ONPREM_VPN_PUBLIC_IP_ADDRESS \
+      --shared-secret $VPN_PSK_SECRET  \
+      --ike-version "2" \
+      --local-traffic-selector="0.0.0.0/0" \
+      --remote-traffic-selector="0.0.0.0/0" \
+      --target-vpn-gateway $CICD_VPN_NAME
+
+    # Create the necessary Route
+    gcloud compute --project $CICD_PROJECT_ID \
+      routes create "${CICD_VPN_NAME}-tunnel-1-route-1" \
+      --network $JENKINS_AGENT_VPC_NAME \
+      --next-hop-vpn-tunnel "${CICD_VPN_NAME}-tunnel-1" \
+      --next-hop-vpn-tunnel-region $DEFAULT_REGION \
+      --destination-range $JENKINS_MASTER_NETWORK_CIDR
+    ```
+
+The VPN might show the message `First Handshake` for around 5 minutes. When the VPN is ready, the Status will show `Tunnel is up and running`. At this point, your Jenkins Master (on-prem) and Jenkins Agent (in cicd project) must have network connectivity through the VPN.
+
+- 3.2.5 Using the Jenkins Web UI, connect to the Agent and troubleshoot network connectivity if needed.
+
+- 3.2.6 Using the Jenkins Web UI, test that your Master can deploy a pipeline to the Jenkins Agent in GCP (you can test by running with a simple `echo "Hello World"` project / job) from the Jenkins Web UI.
+
+- 3.2.7 Use the automated Pipeline provided in the `Jenkinsfile` to deploy new infrastructure in the Step `1-org`
 
 ## Contributing
 

--- a/0-bootstrap/modules/jenkins-agent/files/jenkins_gce_startup_script.sh
+++ b/0-bootstrap/modules/jenkins-agent/files/jenkins_gce_startup_script.sh
@@ -15,20 +15,20 @@
 
 #!/bin/sh
 
-echo "**** Startup Step 1/6: Update apt-get repositories. ****"
+echo "**** Startup Step 1/9: Update apt-get repositories. ****"
 apt-get update
 
-echo "**** Startup Step 2/6: Install Java. Needed to accept jobs from Jenkins Master. ****"
+echo "**** Startup Step 2/9: Install Java. Needed to accept jobs from Jenkins Master. ****"
 apt-get install -y default-jdk
 
-echo "**** Startup Step 3/6: Install tools needed to run pipeline commands. ****"
+echo "**** Startup Step 3/9: Install tools needed to run pipeline commands. ****"
 apt-get install -y git jq unzip google-cloud-sdk google-cloud-sdk
 
-echo "**** Startup Step 4/6: Create a directory to locate Terraform binaries. ****"
+echo "**** Startup Step 4/9: Create a directory to locate Terraform binaries. ****"
 # shellcheck disable=SC2154
 mkdir -p "${tpl_TERRAFORM_DIR}" && cd "${tpl_TERRAFORM_DIR}" || exit
 
-echo "**** Startup Step 5/6: Download, verify and unzip Terraform binaries. ****"
+echo "**** Startup Step 5/9: Download, verify and unzip Terraform binaries. ****"
 # shellcheck disable=SC2154
 wget "https://releases.hashicorp.com/terraform/${tpl_TERRAFORM_VERSION}/terraform_${tpl_TERRAFORM_VERSION}_linux_amd64.zip" && \
     echo "${tpl_TERRAFORM_VERSION_SHA256SUM} terraform_${tpl_TERRAFORM_VERSION}_linux_amd64.zip" > terraform_SHA256SUMS && \
@@ -41,7 +41,44 @@ wget "https://releases.hashicorp.com/terraform/${tpl_TERRAFORM_VERSION}/terrafor
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-echo "**** Startup Step 6/6: Download and install the Terraform validator ****"
+echo "**** Startup Step 6/9: Download and install the Terraform validator ****"
 gsutil cp gs://terraform-validator/releases/2019-04-04/terraform-validator-linux-amd64 .
 chmod 755 "${tpl_TERRAFORM_DIR}terraform-validator-linux-amd64"
 mv "${tpl_TERRAFORM_DIR}terraform-validator-linux-amd64" "${tpl_TERRAFORM_DIR}terraform-validator"
+
+echo "**** Startup Step 7/9: Set the Linux PATH to point to the Terraform directory. ****"
+export PATH=$PATH:${tpl_TERRAFORM_DIR}
+
+echo "**** Startup Step 8/9: Create jenkins user. ****"
+# Home directory for the jenkins user
+JENKINS_HOME_DIR="/home/jenkins"
+
+# The "Remote Jenkins directory" is used to store Jenkins Agent logs
+JENKINS_AGENT_REMOTE_DIR="$JENKINS_HOME_DIR/jenkins_agent_dir"
+
+# Create  and set the jenkins user as owner
+mkdir -p "$JENKINS_AGENT_REMOTE_DIR" && \
+  chmod 766 "$JENKINS_AGENT_REMOTE_DIR" && \
+
+useradd -d /home/jenkins jenkins
+chown -R jenkins:jenkins /home/jenkins/
+
+echo "**** Startup Step 9/9: Add public SSH key to the list of authorized keys. ****"
+SSHD_CONFIG_DIR="/etc/ssh"
+
+# Setting up the sshd_config file
+sed -i $SSHD_CONFIG_DIR/sshd_config \
+        -e 's/#PubkeyAuthentication.*/PubkeyAuthentication yes/' \
+        -e 's/#AuthorizedKeysFile.*/AuthorizedKeysFile    \/etc\/ssh\/authorized_keys/'
+
+# The Jenkins Agent needs the Master public key. This can be in your github repo
+# shellcheck disable=SC2154
+cat > $SSHD_CONFIG_DIR/authorized_keys <<-EOT
+${tpl_SSH_PUB_KEY}
+EOT
+
+# Configure secure permissions on SSHD_CONFIG_DIR
+chmod 755 $SSHD_CONFIG_DIR && \
+ chmod 655 $SSHD_CONFIG_DIR/authorized_keys
+
+systemctl restart sshd

--- a/0-bootstrap/modules/jenkins-agent/main.tf
+++ b/0-bootstrap/modules/jenkins-agent/main.tf
@@ -59,6 +59,7 @@ data "template_file" "jenkins_agent_gce_startup_script" {
     tpl_TERRAFORM_DIR               = "/usr/local/bin/"
     tpl_TERRAFORM_VERSION           = var.terraform_version
     tpl_TERRAFORM_VERSION_SHA256SUM = var.terraform_version_sha256sum
+    tpl_SSH_PUB_KEY                 = var.jenkins_agent_gce_ssh_pub_key
   }
 }
 
@@ -110,14 +111,14 @@ resource "google_compute_instance" "jenkins_agent_gce_instance" {
 *******************************************/
 
 resource "google_compute_firewall" "fw_allow_ssh_into_jenkins_agent" {
-  project       = module.cicd_project.project_id
-  name          = "fw-${google_compute_network.jenkins_agents.name}-1000-i-a-all-all-tcp-22"
-  description   = "Allow the Jenkins Master (Client) to connect to the Jenkins Agents (Servers) using SSH."
-  network       = google_compute_network.jenkins_agents.name
-  source_ranges = var.jenkins_master_ip_addresses
-  target_tags   = local.jenkins_gce_fw_tags
-  priority      = 1000
-
+  project        = module.cicd_project.project_id
+  name           = "fw-${google_compute_network.jenkins_agents.name}-1000-i-a-all-all-tcp-22"
+  description    = "Allow the Jenkins Master (Client) to connect to the Jenkins Agents (Servers) using SSH."
+  network        = google_compute_network.jenkins_agents.name
+  source_ranges  = var.jenkins_master_ip_addresses
+  target_tags    = local.jenkins_gce_fw_tags
+  priority       = 1000
+  enable_logging = true
   allow {
     protocol = "tcp"
     ports    = ["22"]
@@ -165,7 +166,7 @@ resource "google_compute_router" "nat_router_region1" {
 }
 
 resource "google_compute_address" "nat_external_addresses1" {
-  name    = "ca-${google_compute_network.jenkins_agents.name}-${var.default_region}"
+  name    = "cn-${google_compute_network.jenkins_agents.name}-${var.default_region}"
   project = module.cicd_project.project_id
   region  = var.default_region
 }

--- a/0-bootstrap/modules/jenkins-agent/variables.tf
+++ b/0-bootstrap/modules/jenkins-agent/variables.tf
@@ -83,7 +83,7 @@ variable "jenkins_agent_sa_email" {
 }
 
 variable "jenkins_master_ip_addresses" {
-  description = "A list of IP Addresses and masks of the Jenkins Master in the form ['0.0.0.0/0']. Needed to create a FW rule that allows communication with the Jenkins Agent GCE Instance."
+  description = "A list of CIDR IP ranges of the Jenkins Master in the form ['0.0.0.0/0']. Usually only one IP in the form '0.0.0.0/32'. Needed to create a FW rule that allows communication with the Jenkins Agent GCE Instance."
   type        = list(string)
 }
 

--- a/0-bootstrap/modules/jenkins-agent/variables.tf
+++ b/0-bootstrap/modules/jenkins-agent/variables.tf
@@ -73,7 +73,6 @@ variable "jenkins_agent_gce_ssh_user" {
 variable "jenkins_agent_gce_ssh_pub_key" {
   description = "SSH public key needed by the Jenkins Agent GCE Instance. The Jenkins Master holds the SSH private key. The correct format is `'ssh-rsa [KEY_VALUE] [USERNAME]'`"
   type        = string
-  default     = ""
 }
 
 variable "jenkins_agent_sa_email" {

--- a/0-bootstrap/outputs.tf
+++ b/0-bootstrap/outputs.tf
@@ -64,7 +64,7 @@ output "kms_crypto_key" {
 }
 
 /* ----------------------------------------
-    Specific to jenkins_module
+    Specific to jenkins_bootstrap module
    ---------------------------------------- */
 //// Un-comment the jenkins_bootstrap module and its outputs if you want to use Jenkins instead of Cloud Build
 //output "cicd_project_id" {

--- a/0-bootstrap/outputs.tf
+++ b/0-bootstrap/outputs.tf
@@ -34,6 +34,10 @@ output "gcs_bucket_tfstate" {
   value       = module.seed_bootstrap.gcs_bucket_tfstate
 }
 
+/* ----------------------------------------
+    Specific to cloudbuild_module
+   ---------------------------------------- */
+// Comment-out the cloudbuild_bootstrap module and its outputs if you want to use Jenkins instead of Cloud Build
 output "cloudbuild_project_id" {
   description = "Project where CloudBuild configuration and terraform container image will reside."
   value       = module.cloudbuild_bootstrap.cloudbuild_project_id
@@ -59,3 +63,31 @@ output "kms_crypto_key" {
   value       = module.cloudbuild_bootstrap.kms_crypto_key
 }
 
+/* ----------------------------------------
+    Specific to jenkins_module
+   ---------------------------------------- */
+//// Un-comment the jenkins_bootstrap module and its outputs if you want to use Jenkins instead of Cloud Build
+//output "cicd_project_id" {
+//  description = "Project where the cicd pipeline (Jenkins Agents and terraform builder container image) reside."
+//  value       = module.jenkins_bootstrap.cicd_project_id
+//}
+//
+//output "jenkins_agent_gce_instance_id" {
+//  description = "Jenkins Agent GCE Instance id."
+//  value       = module.jenkins_bootstrap.jenkins_agent_gce_instance_id
+//}
+//
+//output "jenkins_agent_sa_email" {
+//  description = "Email for privileged custom service account for Jenkins Agent GCE instance."
+//  value       = module.jenkins_bootstrap.jenkins_agent_sa_email
+//}
+//
+//output "jenkins_agent_sa_name" {
+//  description = "Fully qualified name for privileged custom service account for Jenkins Agent GCE instance."
+//  value       = module.jenkins_bootstrap.jenkins_agent_sa_name
+//}
+//
+//output "gcs_bucket_jenkins_artifacts" {
+//  description = "Bucket used to store Jenkins artifacts in Jenkins project."
+//  value       = module.jenkins_bootstrap.gcs_bucket_jenkins_artifacts
+//}

--- a/0-bootstrap/variables.tf
+++ b/0-bootstrap/variables.tf
@@ -57,3 +57,39 @@ variable "skip_gcloud_download" {
   type        = bool
   default     = true
 }
+
+/////* ----------------------------------------
+////    Specific to jenkins_module
+////   ---------------------------------------- */
+//// Un-comment the jenkins_bootstrap module and its outputs if you want to use Jenkins instead of Cloud Build
+//variable "jenkins_agent_gce_subnetwork_cidr_range" {
+//  description = "The subnetwork to which the Jenkins Agent will be connected to (in CIDR range 0.0.0.0/0)"
+//  type        = string
+//}
+//
+//variable "jenkins_agent_gce_private_ip_address" {
+//  description = "The private IP Address of the Jenkins Agent. This IP Address must be in the CIDR range of `jenkins_agent_gce_subnetwork_cidr_range` and be reachable through the VPN that exists between on-prem (Jenkins Master) and GCP (CICD Project, where the Jenkins Agent is located)."
+//  type        = string
+//}
+//
+//variable "jenkins_agent_gce_ssh_pub_key" {
+//  description = "SSH public key needed by the Jenkins Agent GCE Instance. The Jenkins Master holds the SSH private key. The correct format is `'ssh-rsa [KEY_VALUE] [USERNAME]'`"
+//  type        = string
+//  default     = ""
+//}
+//
+//variable "jenkins_agent_sa_email" {
+//  description = "Email for Jenkins Agent service account."
+//  type        = string
+//  default     = "jenkins-agent-gce"
+//}
+//
+//variable "jenkins_master_ip_addresses" {
+//  description = "A list of CIDR IP ranges of the Jenkins Master in the form ['0.0.0.0/0']. Usually only one IP in the form '0.0.0.0/32'. Needed to create a FW rule that allows communication with the Jenkins Agent GCE Instance."
+//  type        = list(string)
+//}
+//
+//variable "nat_bgp_asn" {
+//  type        = number
+//  description = "BGP ASN for NAT cloud route. This is needed to allow the Jenkins Agent to download packages and updates from the internet without having an external IP address."
+//}

--- a/0-bootstrap/variables.tf
+++ b/0-bootstrap/variables.tf
@@ -47,7 +47,7 @@ variable "parent_folder" {
 }
 
 variable "org_project_creators" {
-  description = "Additional list of members to have project creator role accross the organization. Prefix of group: user: or serviceAccount: is required."
+  description = "Additional list of members to have project creator role across the organization. Prefix of group: user: or serviceAccount: is required."
   type        = list(string)
   default     = []
 }
@@ -59,7 +59,7 @@ variable "skip_gcloud_download" {
 }
 
 /////* ----------------------------------------
-////    Specific to jenkins_module
+////    Specific to jenkins_bootstrap module
 ////   ---------------------------------------- */
 //// Un-comment the jenkins_bootstrap module and its outputs if you want to use Jenkins instead of Cloud Build
 //variable "jenkins_agent_gce_subnetwork_cidr_range" {
@@ -75,7 +75,6 @@ variable "skip_gcloud_download" {
 //variable "jenkins_agent_gce_ssh_pub_key" {
 //  description = "SSH public key needed by the Jenkins Agent GCE Instance. The Jenkins Master holds the SSH private key. The correct format is `'ssh-rsa [KEY_VALUE] [USERNAME]'`"
 //  type        = string
-//  default     = ""
 //}
 //
 //variable "jenkins_agent_sa_email" {

--- a/README.md
+++ b/README.md
@@ -9,8 +9,23 @@ Each of these Terraform projects are to be layered on top of each other, running
 
 ### [0. bootstrap](./0-bootstrap/)
 
-This stage executes the [CFT Bootstrap module](https://github.com/terraform-google-modules/terraform-google-bootstrap) which bootstraps an existing GCP organization, creating all the required GCP resources & permissions to start using the Cloud Foundation Toolkit (CFT).
-This includes; projects, service accounts and a Terraform state bucket. After executing this step, you will have the following structure:
+This stage executes the [CFT Bootstrap module](https://github.com/terraform-google-modules/terraform-google-bootstrap) which bootstraps an existing GCP organization, creating all the required GCP resources & permissions to start using the Cloud Foundation Toolkit (CFT). This includes:
+- The `cft-seed` project, which contains:
+  - Terraform state bucket
+  - Custom Service Account used by Terraform to create new resources in GCP
+- The `cft-cloudbuild` project (`prj-cicd` if using Jenkins), which contains:
+  - A CICD pipeline implemented with either Cloud Build or Jenkins
+  - If using Cloud Build:
+    - Cloud Source Repository
+  - If using Jenkins:
+    - Custom Service Account to run Jenkins Agents GCE instances
+    - VPN connection with on-prem (or where ever your Jenkins Master is located)
+
+It is a best practice to have two separate projects here (`cft-seed` and `prj-cicd`) for separation of concerns. On one hand, `cft-seed` stores terraform state and has the Service Account able to create / modify infrastructure. On the other hand, the deployment of that infrastructure is coordinated by a tool of your choice (either Cloud Build or Jenkins), which is implemented in `prj-cicd`.
+
+If using Cloud Build, its default service account `@cloudbuild.gserviceaccount.com` is granted access to generate tokens over the Terraform custom service account. If using Jenkins, the custom service account used by the GCE instance is granted the access.
+
+After executing this step, you will have the following structure:
 
 ```
 example-organization/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ Each of these Terraform projects are to be layered on top of each other, running
 
 ### [0. bootstrap](./0-bootstrap/)
 
-This stage executes the [CFT Bootstrap module](https://github.com/terraform-google-modules/terraform-google-bootstrap) which bootstraps an existing GCP organization, creating all the required GCP resources & permissions to start using the Cloud Foundation Toolkit (CFT). This includes:
+This stage executes the [CFT Bootstrap module](https://github.com/terraform-google-modules/terraform-google-bootstrap) which bootstraps an existing GCP organization, creating all the required GCP resources & permissions to start using the Cloud Foundation Toolkit (CFT). You can use either of these two tools for your CICD pipelines: Cloud Build (by default) or Jenkins. If you want to use Jenkins instead of Cloud Build, please:
+   - Comment-out the `cloudbuild_bootstrap` module in `main.tf`, its variables in `variables.tf` and its outputs in `outputs.tf`
+   - Un-comment the `jenkins_bootstrap` module in `main.tf`, its variables in `variables.tf` and its outputs in `outputs.tf`
+   - Follow the instructions on how to run the bootstrap step with the `jenkins_bootstrap` sub-module described in the [README](./0-bootstrap/modules/jenkins-agent/README.md), which include implementing VPN, configuring your Jenkins Master among other steps.
+
+The bootstrap step includes:
 - The `cft-seed` project, which contains:
   - Terraform state bucket
   - Custom Service Account used by Terraform to create new resources in GCP


### PR DESCRIPTION
@rjerrems and @bharathkkb 
This should be the last PR for the Jenkins Agent module.
 - Successfully tested multiple times deploying the 0-bootstrap module using the jenkins module
 - After configuring VPN manually between on-prem and CICD project, jobs run from on-prem into the CICD Jenkins Agent