### PR TITLE
Fix google provider version in 0-bootstrap step

### DIFF
--- a/0-bootstrap/main.tf
+++ b/0-bootstrap/main.tf
@@ -15,11 +15,11 @@
  */
 
 provider "google" {
-  version = "~> 3.30.0"
+  version = "~> 3.30"
 }
 
 provider "google-beta" {
-  version = "~> 3.30.0"
+  version = "~> 3.30"
 }
 
 provider "null" {


### PR DESCRIPTION
Fixes `Error: no suitable version is available`  in  0-bootstrap step

```
No provider "google" plugins meet the constraint " < 4.0, < 4.0, < 4.0, < 4.0, < 4.0, < 4.0,>= 2.1,>= 2.1,>= 2.1,>= 2.1,>= 3.8,>= 3.8,~> 3.30.0,~> 3.31,~> 3.5".

```

@rjerrems @morgante @bharathkkb  could you please check this fix?