### PR TITLE
Fix readmes for cloud build with wrapper script and add missing symbolic link

### DIFF
--- a/1-org/envs/shared/README.md
+++ b/1-org/envs/shared/README.md
@@ -23,7 +23,7 @@ You can choose not to enable the Data Access logs by setting variable `data_acce
 1. Ensure wrapper script can be executed `chmod 755 ./tf-wrapper.sh`.
 1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap (you can re-run `terraform output` in the 0-bootstrap directory to find these values). Make sure that `default_region` is set to a valid [BigQuery dataset region](https://cloud.google.com/bigquery/docs/locations).
 1. Commit changes with `git add .` and `git commit -m 'Your message'`
-1. Push your plan branch to trigger a plan `git push --set-upstream origin plan`
+1. Push your plan branch to trigger a plan `git push --set-upstream origin plan` (the branch `plan` is not a special one. Any branch which name is different from `dev`, `nonprod` or `prod` will trigger a terraform plan).
     1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
 1. Merge changes to prod branch with `git checkout -b prod` and `git push origin prod`
     1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID

--- a/1-org/envs/shared/README.md
+++ b/1-org/envs/shared/README.md
@@ -19,18 +19,19 @@ You can choose not to enable the Data Access logs by setting variable `data_acce
 1. Navigate into the repo `cd gcp-org` and change to a non prod branch `git checkout -b plan`
 1. Copy contents of foundation to new repo `cp -R ../terraform-example-foundation/1-org/* .` (modify accordingly based on your current directory).
 1. Copy cloud build configuration files for terraform `cp ../terraform-example-foundation/build/cloudbuild-tf-* . ` (modify accordingly based on your current directory).
+1. Copy terraform wrapper script `cp ../terraform-example-foundation/build/tf-wrapper.sh . ` (modify accordingly based on your current directory).
+1. Ensure wrapper script can be executed `chmod 755 ./tf-wrapper.sh`.
 1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap (you can re-run `terraform output` in the 0-bootstrap directory to find these values). Make sure that `default_region` is set to a valid [BigQuery dataset region](https://cloud.google.com/bigquery/docs/locations).
 1. Commit changes with `git add .` and `git commit -m 'Your message'`
-1. Push your non prod branch to trigger a plan `git push --set-upstream origin plan`
+1. Push your plan branch to trigger a plan `git push --set-upstream origin plan`
     1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
 1. Merge changes to prod branch with `git checkout -b prod` and `git push origin prod`
     1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
 
-
 ### Run terraform locally
 1. Change into 1-org/envs/shared/ folder.
 1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap.
-1. Rename backend.tf.example backend.tf and update with your bucket from bootstrap.
+1. Update backend.tf with your bucket from bootstrap.
 1. Run `terraform init`
 1. Run `terraform plan` and review output.
 1. Run `terraform apply`

--- a/2-environments/README.md
+++ b/2-environments/README.md
@@ -19,7 +19,7 @@ The purpose of this step is to set up dev, nonprod, and prod environments within
 1. Ensure wrapper script can be executed `chmod 755 ./tf-wrapper.sh`.
 1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap.
 1. Commit changes with `git add .` and `git commit -m 'Your message'`
-1. Push your plan branch to trigger a plan for all environments `git push --set-upstream origin plan`
+1. Push your plan branch to trigger a plan for all environments `git push --set-upstream origin plan` (the branch `plan` is not a special one. Any branch which name is different from `dev`, `nonprod` or `prod` will trigger a terraform plan).
     1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
 1. Merge changes to dev with `git checkout -b dev` and `git push origin dev`
     1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID

--- a/2-environments/README.md
+++ b/2-environments/README.md
@@ -14,13 +14,18 @@ The purpose of this step is to set up dev, nonprod, and prod environments within
 1. Clone repo `gcloud source repos clone gcp-environments --project=YOUR_CLOUD_BUILD_PROJECT_ID`
 1. Change freshly cloned repo and change to non master branch `git checkout -b plan`
 1. Copy contents of foundation to new repo `cp -R ../terraform-example-foundation/2-environments/* .` (modify accordingly based on your current directory)
-1. Copy cloud build configuration files for terraform `cp ../terraform-example-foundation/build/cloudbuild-tf-* . ` (modify accordingly based on your current directory)
-1. Change cloud build configuration files in order to `terraform init`, `terraform plan`, and `terraform apply` each environment in the envs folder.
-1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap. Copy terraform.tfvars into each of the folders within the envs/ folder.
+1. Copy cloud build configuration files for terraform `cp ../terraform-example-foundation/build/cloudbuild-tf-* . ` (modify accordingly based on your current directory).
+1. Copy terraform wrapper script `cp ../terraform-example-foundation/build/tf-wrapper.sh . ` (modify accordingly based on your current directory)
+1. Ensure wrapper script can be executed `chmod 755 ./tf-wrapper.sh`.
+1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap.
 1. Commit changes with `git add .` and `git commit -m 'Your message'`
-1. Push your non master branch to trigger a plan `git push --set-upstream origin plan`
+1. Push your plan branch to trigger a plan for all environments `git push --set-upstream origin plan`
     1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
-1. Merge changes to master with `git checkout -b master` and `git push origin master`
+1. Merge changes to dev with `git checkout -b dev` and `git push origin dev`
+    1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
+1. Merge changes to nonprod with `git checkout -b nonprod` and `git push origin nonprod`
+    1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
+1. Merge changes to prod with `git checkout -b prod` and `git push origin prod`
     1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
 
 

--- a/2-environments/envs/dev/terraform.tfvars
+++ b/2-environments/envs/dev/terraform.tfvars
@@ -1,1 +1,1 @@
-....terraform.tfvars
+./../terraform.tfvars

--- a/2-environments/envs/dev/terraform.tfvars
+++ b/2-environments/envs/dev/terraform.tfvars
@@ -1,1 +1,1 @@
-./../terraform.tfvars
+../../terraform.tfvars

--- a/2-environments/envs/dev/terraform.tfvars
+++ b/2-environments/envs/dev/terraform.tfvars
@@ -1,0 +1,1 @@
+....terraform.tfvars

--- a/3-networks/README.md
+++ b/3-networks/README.md
@@ -24,9 +24,14 @@ The purpose of this step is to :
 1. Ensure wrapper script can be executed `chmod 755 ./tf-wrapper.sh`.
 1. Within each envs/ folder rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap.
 1. Commit changes with `git add .` and `git commit -m 'Your message'`
+1. You will need only once to manually plan + apply the `shared` environment since dev, nonprod and prod depend on it.
+    1. cd to ./envs/shared/
+    1. Update backend.tf with your bucket name from the bootstrap step.
+    1. Run `terraform plan` and review output
+    1. Run `terraform apply`
+    1. If you would like the bucket to be replaced by cloud build at run time, change the bucket name back to `UPDATE_ME
 1. Push your plan branch to trigger a plan `git push --set-upstream origin plan` (the branch `plan` is not a special one. Any branch which name is different from `dev`, `nonprod` or `prod` will trigger a terraform plan).
     1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
-1. Plan will fail for dev/nonprod/prod until prod has been applied at least once since all envs depend on shared (DNS Hub) that is deployed in the prod branch.
 1. Merge changes to prod with `git checkout -b prod` and `git push origin prod`
     1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
 1. After prod has been applied apply dev and nonprod

--- a/3-networks/README.md
+++ b/3-networks/README.md
@@ -10,7 +10,7 @@ The purpose of this step is to :
 1. 0-bootstrap executed successfully.
 1. 1-org executed successfully.
 1. 2-environments executed successfully.
-1. Obtain the value for the access_context_manager_policy_id variable. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`. It is the value under `name`.
+1. Obtain the value for the access_context_manager_policy_id variable. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format="value(name)"`.
 
 ## Usage
 
@@ -44,4 +44,3 @@ The purpose of this step is to :
     1. Run `terraform init`
     1. Run `terraform plan` and review output
     1. Run `terraform apply`
-

--- a/3-networks/README.md
+++ b/3-networks/README.md
@@ -24,7 +24,7 @@ The purpose of this step is to :
 1. Ensure wrapper script can be executed `chmod 755 ./tf-wrapper.sh`.
 1. Within each envs/ folder rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap.
 1. Commit changes with `git add .` and `git commit -m 'Your message'`
-1. Push your plan branch to trigger a plan `git push --set-upstream origin plan`
+1. Push your plan branch to trigger a plan `git push --set-upstream origin plan` (the branch `plan` is not a special one. Any branch which name is different from `dev`, `nonprod` or `prod` will trigger a terraform plan).
     1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
 1. Plan will fail for dev/nonprod/prod until prod has been applied at least once since all envs depend on shared (DNS Hub) that is deployed in the prod branch.
 1. Merge changes to prod with `git checkout -b prod` and `git push origin prod`

--- a/3-networks/README.md
+++ b/3-networks/README.md
@@ -1,6 +1,6 @@
 # 3-networks
 
-The purpose of this step is to:
+The purpose of this step is to :
 
 - Setup the global [DNS Hub](https://cloud.google.com/blog/products/networking/cloud-forwarding-peering-and-zones).
 - Setup private and restricted shared VPCs with default DNS, NAT (optional), Private Service networking, VPC service controls, onprem dedicated interconnect and baseline firewall rules for each environment.
@@ -9,10 +9,39 @@ The purpose of this step is to:
 
 1. 0-bootstrap executed successfully.
 1. 1-org executed successfully.
-1. 2-environments/envs/[dev|nonprod|prod] executed successfully.
+1. 2-environments executed successfully.
+1. Obtain the value for the access_context_manager_policy_id variable. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`. It is the value under `name`.
 
 ## Usage
 
-Follow the instructions in the README.md files of each individual 3-networks/envs/ folder.
+### Setup to run via Cloud Build
 
-**3-networks/envs/shared** must be executed successfully before environments `dev`, `nonprod` and `prod` are executed.
+1. Clone repo `gcloud source repos clone gcp-networks --project=YOUR_CLOUD_BUILD_PROJECT_ID`
+1. Change freshly cloned repo and change to non master branch `git checkout -b plan`
+1. Copy contents of foundation to new repo `cp -R ../terraform-example-foundation/3-networks/* .` (modify accordingly based on your current directory)
+1. Copy cloud build configuration files for terraform `cp ../terraform-example-foundation/build/cloudbuild-tf-* . ` (modify accordingly based on your current directory)
+1. Copy terraform wrapper script `cp ../terraform-example-foundation/build/tf-wrapper.sh . ` (modify accordingly based on your current directory)
+1. Ensure wrapper script can be executed `chmod 755 ./tf-wrapper.sh`.
+1. Within each envs/ folder rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap.
+1. Commit changes with `git add .` and `git commit -m 'Your message'`
+1. Push your plan branch to trigger a plan `git push --set-upstream origin plan`
+    1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
+1. Plan will fail for dev/nonprod/prod until prod has been applied at least once since all envs depend on shared (DNS Hub) that is deployed in the prod branch.
+1. Merge changes to prod with `git checkout -b prod` and `git push origin prod`
+    1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
+1. After prod has been applied apply dev and nonprod
+1. Merge changes to dev with `git checkout -b dev` and `git push origin dev`
+    1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
+1. Merge changes to nonprod with `git checkout -b nonprod` and `git push origin nonprod`
+    1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
+
+### Run terraform locally
+
+1. Change into 3-networks folder
+1. Within each envs/ folder rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap.
+1. Within each envs/ folder, update backend.tf with your bucket name from the bootstrap step.
+1. In this sequence (shared, prod, dev, nonprod), change into each folder within the envs/ folder and run the following commands:
+    1. Run `terraform init`
+    1. Run `terraform plan` and review output
+    1. Run `terraform apply`
+

--- a/3-networks/envs/dev/README.md
+++ b/3-networks/envs/dev/README.md
@@ -8,7 +8,7 @@ The purpose of this step is to setup private and restricted shared VPCs with def
 1. 1-org executed successfully.
 1. 2-environments/envs/dev executed successfully.
 1. 3-networks/envs/shared executed successfully.
-1. Obtain the value for the access_context_manager_policy_id variable. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`. It is the value under `name`.
+1. Obtain the value for the access_context_manager_policy_id variable. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format="value(name)"`.
 
 ## Usage
 
@@ -37,7 +37,7 @@ __Note:__ You can get the environment secrets project executing `gcloud projects
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| access\_context\_manager\_policy\_id | The id of the default Access Context Manager policy created in step `1-org`. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`. | number | n/a | yes |
+| access\_context\_manager\_policy\_id | The id of the default Access Context Manager policy created in step `1-org`. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format="value(name)"`. | number | n/a | yes |
 | default\_region1 | First subnet region. The shared vpc modules only configures two regions. | string | n/a | yes |
 | default\_region2 | Second subnet region. The shared vpc modules only configures two regions. | string | n/a | yes |
 | dns\_enable\_logging | Toggle DNS logging for VPC DNS. | bool | `"true"` | no |

--- a/3-networks/envs/dev/README.md
+++ b/3-networks/envs/dev/README.md
@@ -8,27 +8,14 @@ The purpose of this step is to setup private and restricted shared VPCs with def
 1. 1-org executed successfully.
 1. 2-environments/envs/dev executed successfully.
 1. 3-networks/envs/shared executed successfully.
+1. Obtain the value for the access_context_manager_policy_id variable. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`. It is the value under `name`.
 
 ## Usage
-
-### Setup to run via Cloud Build
-1. Clone repo `gcloud source repos clone gcp-networks --project=YOUR_CLOUD_BUILD_PROJECT_ID`
-1. Change freshly cloned repo and change to non master branch `git checkout -b plan-dev`
-1. Copy contents of foundation to new repo `cp -R ../terraform-example-foundation/3-networks/* .` (modify accordingly based on your current directory)
-1. Copy cloud build configuration files for terraform `cp ../terraform-example-foundation/build/cloudbuild-tf-* . ` (modify accordingly based on your current directory).
-1. Change cloud build configuration files in order to `terraform init ./envs/dev`, `terraform plan ./envs/dev`, and `terraform apply ./envs/dev`.
-1. Rename ./envs/dev/terraform.example.tfvars to ./envs/dev/terraform.tfvars and update the file with values from your environment and bootstrap.
-1. Commit changes with `git add .` and `git commit -m 'Your message'`
-1. Push your non master branch to trigger a plan `git push --set-upstream origin plan-dev`
-    1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
-1. Merge changes to master with `git checkout -b master` and `git push origin master`
-    1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
-
 
 ### Run terraform locally
 1. Change into 3-networks/envs/dev folder
 1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap.
-1. Rename backend.tf.example to backend.tf and update with your bucket from bootstrap.
+1. Update backend.tf with your bucket from bootstrap.
 1. Run `terraform init`
 1. Run `terraform plan` and review output
 1. Run `terraform apply`

--- a/3-networks/envs/dev/variables.tf
+++ b/3-networks/envs/dev/variables.tf
@@ -21,7 +21,7 @@ variable "org_id" {
 
 variable "access_context_manager_policy_id" {
   type        = number
-  description = "The id of the default Access Context Manager policy created in step `1-org`. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`."
+  description = "The id of the default Access Context Manager policy created in step `1-org`. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format=\"value(name)\"`."
 }
 
 variable "terraform_service_account" {

--- a/3-networks/envs/nonprod/README.md
+++ b/3-networks/envs/nonprod/README.md
@@ -8,27 +8,14 @@ The purpose of this step is to setup private and restricted shared VPCs with def
 1. 1-org executed successfully.
 1. 2-environments/envs/nonprod executed successfully.
 1. 3-networks/envs/shared executed successfully.
+1. Obtain the value for the access_context_manager_policy_id variable. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`. It is the value under `name`.
 
 ## Usage
-
-### Setup to run via Cloud Build
-1. Clone repo `gcloud source repos clone gcp-networks --project=YOUR_CLOUD_BUILD_PROJECT_ID`
-1. Change freshly cloned repo and change to non master branch `git checkout -b plan-nonprod`
-1. Copy contents of foundation to new repo `cp -R ../terraform-example-foundation/3-networks/* .` (modify accordingly based on your current directory)
-1. Copy cloud build configuration files for terraform `cp ../terraform-example-foundation/build/cloudbuild-tf-* . ` (modify accordingly based on your current directory).
-1. Change cloud build configuration files in order to `terraform init ./envs/nonprod`, `terraform plan ./envs/nonprod`, and `terraform apply ./envs/nonprod`.
-1. Rename ./envs/nonprod/terraform.example.tfvars to ./envs/nonprod/terraform.tfvars and update the file with values from your environment and bootstrap.
-1. Commit changes with `git add .` and `git commit -m 'Your message'`
-1. Push your non master branch to trigger a plan `git push --set-upstream origin plan-nonprod`
-    1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
-1. Merge changes to master with `git checkout -b master` and `git push origin master`
-    1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
-
 
 ### Run terraform locally
 1. Change into 3-networks/envs/nonprod folder
 1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap.
-1. Rename backend.tf.example to backend.tf and update with your bucket from bootstrap.
+1. Update backend.tf with your bucket from bootstrap.
 1. Run `terraform init`
 1. Run `terraform plan` and review output
 1. Run `terraform apply`

--- a/3-networks/envs/nonprod/README.md
+++ b/3-networks/envs/nonprod/README.md
@@ -8,7 +8,7 @@ The purpose of this step is to setup private and restricted shared VPCs with def
 1. 1-org executed successfully.
 1. 2-environments/envs/nonprod executed successfully.
 1. 3-networks/envs/shared executed successfully.
-1. Obtain the value for the access_context_manager_policy_id variable. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`. It is the value under `name`.
+1. Obtain the value for the access_context_manager_policy_id variable. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format="value(name)"`.
 
 ## Usage
 
@@ -37,7 +37,7 @@ __Note:__ You can get the environment secrets project executing `gcloud projects
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| access\_context\_manager\_policy\_id | The id of the default Access Context Manager policy created in step `1-org`. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`. | number | n/a | yes |
+| access\_context\_manager\_policy\_id | The id of the default Access Context Manager policy created in step `1-org`. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format="value(name)"`. | number | n/a | yes |
 | default\_region1 | First subnet region. The shared vpc modules only configures two regions. | string | n/a | yes |
 | default\_region2 | Second subnet region. The shared vpc modules only configures two regions. | string | n/a | yes |
 | dns\_enable\_logging | Toggle DNS logging for VPC DNS. | bool | `"true"` | no |

--- a/3-networks/envs/nonprod/variables.tf
+++ b/3-networks/envs/nonprod/variables.tf
@@ -21,7 +21,7 @@ variable "org_id" {
 
 variable "access_context_manager_policy_id" {
   type        = number
-  description = "The id of the default Access Context Manager policy created in step `1-org`. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`."
+  description = "The id of the default Access Context Manager policy created in step `1-org`. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format=\"value(name)\"`."
 }
 
 variable "terraform_service_account" {

--- a/3-networks/envs/prod/README.md
+++ b/3-networks/envs/prod/README.md
@@ -8,7 +8,7 @@ The purpose of this step is to setup private and restricted shared VPCs with def
 1. 1-org executed successfully.
 1. 2-environments/envs/prod executed successfully.
 1. 3-networks/envs/shared executed successfully.
-1. Obtain the value for the access_context_manager_policy_id variable. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`. It is the value under `name`.
+1. Obtain the value for the access_context_manager_policy_id variable. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format="value(name)"`.
 
 ## Usage
 
@@ -37,7 +37,7 @@ __Note:__ You can get the environment secrets project executing `gcloud projects
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| access\_context\_manager\_policy\_id | The id of the default Access Context Manager policy created in step `1-org`. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`. | number | n/a | yes |
+| access\_context\_manager\_policy\_id | The id of the default Access Context Manager policy created in step `1-org`. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format="value(name)"`. | number | n/a | yes |
 | default\_region1 | First subnet region. The shared vpc modules only configures two regions. | string | n/a | yes |
 | default\_region2 | Second subnet region. The shared vpc modules only configures two regions. | string | n/a | yes |
 | dns\_enable\_logging | Toggle DNS logging for VPC DNS. | bool | `"true"` | no |

--- a/3-networks/envs/prod/README.md
+++ b/3-networks/envs/prod/README.md
@@ -8,27 +8,14 @@ The purpose of this step is to setup private and restricted shared VPCs with def
 1. 1-org executed successfully.
 1. 2-environments/envs/prod executed successfully.
 1. 3-networks/envs/shared executed successfully.
+1. Obtain the value for the access_context_manager_policy_id variable. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`. It is the value under `name`.
 
 ## Usage
-
-### Setup to run via Cloud Build
-1. Clone repo `gcloud source repos clone gcp-networks --project=YOUR_CLOUD_BUILD_PROJECT_ID`
-1. Change freshly cloned repo and change to non master branch `git checkout -b plan-prod`
-1. Copy contents of foundation to new repo `cp -R ../terraform-example-foundation/3-networks/* .` (modify accordingly based on your current directory)
-1. Copy cloud build configuration files for terraform `cp ../terraform-example-foundation/build/cloudbuild-tf-* . ` (modify accordingly based on your current directory).
-1. Change cloud build configuration files in order to `terraform init ./envs/prod`, `terraform plan ./envs/prod`, and `terraform apply ./envs/prod`.
-1. Rename ./envs/prod/terraform.example.tfvars to ./envs/prod/terraform.tfvars and update the file with values from your environment and bootstrap.
-1. Commit changes with `git add .` and `git commit -m 'Your message'`
-1. Push your non master branch to trigger a plan `git push --set-upstream origin plan-prod`
-    1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
-1. Merge changes to master with `git checkout -b master` and `git push origin master`
-    1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
-
 
 ### Run terraform locally
 1. Change into 3-networks/envs/prod folder
 1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap.
-1. Rename backend.tf.example to backend.tf and update with your bucket from bootstrap.
+1. Update backend.tf with your bucket from bootstrap.
 1. Run `terraform init`
 1. Run `terraform plan` and review output
 1. Run `terraform apply`

--- a/3-networks/envs/prod/variables.tf
+++ b/3-networks/envs/prod/variables.tf
@@ -21,7 +21,7 @@ variable "org_id" {
 
 variable "access_context_manager_policy_id" {
   type        = number
-  description = "The id of the default Access Context Manager policy created in step `1-org`. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`."
+  description = "The id of the default Access Context Manager policy created in step `1-org`. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format=\"value(name)\"`."
 }
 
 variable "terraform_service_account" {

--- a/3-networks/envs/shared/README.md
+++ b/3-networks/envs/shared/README.md
@@ -9,28 +9,13 @@ The purpose of this step is to setup the global [DNS Hub](https://cloud.google.c
 
 ## Usage
 
-### Setup to run via Cloud Build
-1. Clone repo `gcloud source repos clone gcp-networks --project=YOUR_CLOUD_BUILD_PROJECT_ID`
-1. Change freshly cloned repo and change to non master branch `git checkout -b plan-shared`
-1. Copy contents of foundation to new repo `cp -R ../terraform-example-foundation/3-networks/* .` (modify accordingly based on your current directory)
-1. Copy cloud build configuration files for terraform `cp ../terraform-example-foundation/build/cloudbuild-tf-* . ` (modify accordingly based on your current directory).
-1. Change cloud build configuration files in order to `terraform init ./envs/shared`, `terraform plan ./envs/shared`, and `terraform apply ./envs/shared`.
-1. Rename ./envs/shared/terraform.example.tfvars to ./envs/shared/terraform.tfvars and update the file with values from your environment and bootstrap.
-1. Commit changes with `git add .` and `git commit -m 'Your message'`
-1. Push your non master branch to trigger a plan `git push --set-upstream origin plan-shared`
-    1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
-1. Merge changes to master with `git checkout -b master` and `git push origin master`
-    1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
-
-
 ### Run terraform locally
 1. Change into 3-networks/envs/shared folder
 1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap.
-1. Rename backend.tf.example to backend.tf and update with your bucket from bootstrap.
+1. Update backend.tf with your bucket from bootstrap.
 1. Run `terraform init`
 1. Run `terraform plan` and review output
 1. Run `terraform apply`
-
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs

--- a/3-networks/modules/restricted_shared_vpc/README.md
+++ b/3-networks/modules/restricted_shared_vpc/README.md
@@ -3,7 +3,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| access\_context\_manager\_policy\_id | The id of the default Access Context Manager policy. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`. | number | n/a | yes |
+| access\_context\_manager\_policy\_id | The id of the default Access Context Manager policy. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format="value(name)"`. | number | n/a | yes |
 | bgp\_asn\_subnet | BGP ASN for Subnets cloud routers. | number | n/a | yes |
 | default\_region1 | First subnet region. The shared vpc modules only configures two regions. | string | n/a | yes |
 | default\_region2 | Second subnet region. The shared vpc modules only configures two regions. | string | n/a | yes |

--- a/3-networks/modules/restricted_shared_vpc/variables.tf
+++ b/3-networks/modules/restricted_shared_vpc/variables.tf
@@ -21,7 +21,7 @@ variable "org_id" {
 
 variable "access_context_manager_policy_id" {
   type        = number
-  description = "The id of the default Access Context Manager policy. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`."
+  description = "The id of the default Access Context Manager policy. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format=\"value(name)\"`."
 }
 
 variable "project_id" {

--- a/4-projects/README.md
+++ b/4-projects/README.md
@@ -20,7 +20,7 @@ The purpose of this step is to setup folder structure and projects for applicati
 1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap.
 1. Copy terraform.tfvars to each business_unit/envs/ folder.
 1. Commit changes with `git add .` and `git commit -m 'Your message'`
-1. Push your plan branch to trigger a plan `git push --set-upstream origin plan`
+1. Push your plan branch to trigger a plan `git push --set-upstream origin plan` (the branch `plan` is not a special one. Any branch which name is different from `dev`, `nonprod` or `prod` will trigger a terraform plan).
     1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
 1. Merge changes to dev with `git checkout -b dev` and `git push origin dev`
     1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID

--- a/4-projects/README.md
+++ b/4-projects/README.md
@@ -14,12 +14,19 @@ The purpose of this step is to setup folder structure and projects for applicati
 1. Clone repo `gcloud source repos clone gcp-projects --project=YOUR_CLOUD_BUILD_PROJECT_ID`
 1. Change freshly cloned repo and change to non master branch `git checkout -b plan`
 1. Copy contents of foundation to new repo `cp -R ../terraform-example-foundation/4-projects/* .` (modify accordingly based on your current directory)
-1. Copy cloud build configuration files for terraform `cp ../terraform-example-foundation/build/cloudbuild-tf-* . ` (modify accordingly based on your current directory)
+1. Copy cloud build configuration files for terraform `cp ../terraform-example-foundation/build/cloudbuild-tf-* . ` (modify accordingly based on your current directory).
+1. Copy terraform wrapper script `cp ../terraform-example-foundation/build/tf-wrapper.sh . ` (modify accordingly based on your current directory)
+1. Ensure wrapper script can be executed `chmod 755 ./tf-wrapper.sh`.
 1. Rename terraform.example.tfvars to terraform.tfvars and update the file with values from your environment and bootstrap.
+1. Copy terraform.tfvars to each business_unit/envs/ folder.
 1. Commit changes with `git add .` and `git commit -m 'Your message'`
-1. Push your non master branch to trigger a plan `git push --set-upstream origin plan`
+1. Push your plan branch to trigger a plan `git push --set-upstream origin plan`
     1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
-1. Merge changes to master with `git checkout -b master` and `git push origin master`
+1. Merge changes to dev with `git checkout -b dev` and `git push origin dev`
+    1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
+1. Merge changes to nonprod with `git checkout -b nonprod` and `git push origin nonprod`
+    1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
+1. Merge changes to prod with `git checkout -b prod` and `git push origin prod`
     1. Review the apply output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
 
 

--- a/test/fixtures/networks/variables.tf
+++ b/test/fixtures/networks/variables.tf
@@ -24,7 +24,7 @@ variable "terraform_sa_email" {
 
 variable "policy_id" {
   type        = number
-  description = "The id of the default Access Context Manager policy created in step `1-org`. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID`."
+  description = "The id of the default Access Context Manager policy created in step `1-org`. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format=\"value(name)\"`."
 }
 
 variable "domain" {


### PR DESCRIPTION
This PR fixes READMEs for all the steps for the execution of the Cloud Build deploy path with the new wrapper script.

It was also added the creation of a missing symbolic link in `2-environments/envs/dev` needed by the instructions. Fixes #110 

Depends on the script and cloud build files from PR https://github.com/terraform-google-modules/terraform-example-foundation/pull/100 and should be merged after PR #100 

@bharathkkb @rjerrems @mikelaramie @morgante Cloud you please take a look at these changes ?