### PR TITLE
fix: Hardcode some project details, add bu2 to integration tests

### DIFF
--- a/4-projects/business_unit_1/dev/example_base_shared_vpc_project.tf
+++ b/4-projects/business_unit_1/dev/example_base_shared_vpc_project.tf
@@ -26,12 +26,12 @@ module "base_shared_vpc_project" {
   vpc_type                    = "private"
 
   # Metadata
-  project_prefix    = "${local.business_code}-d-sample"
-  application_name  = "${local.business_code}-sample-private-vpc"
+  project_prefix    = "bu1-d-sample"
+  application_name  = "bu1-sample-application1"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu1"
 }
 
 #   # Network Setting (Optional)

--- a/4-projects/business_unit_1/dev/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_1/dev/example_restricted_shared_vpc_project.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-locals {
-  prefix = "d_shared_restricted"
-}
-
 module "restricted_shared_vpc_project" {
   source                      = "../../modules/single_project"
   impersonate_service_account = var.terraform_service_account
@@ -34,10 +30,10 @@ module "restricted_shared_vpc_project" {
   vpc_service_control_perimeter_name = "accessPolicies/${var.policy_id}/servicePerimeters/${var.perimeter_name}"
 
   # Metadata
-  project_prefix    = "${local.business_code}-d-sample"
-  application_name  = "${local.business_code}-restricted-sample-single"
+  project_prefix    = "bu1-d-sample"
+  application_name  = "bu1-sample-application1"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu1"
 }

--- a/4-projects/business_unit_1/dev/example_single_project.tf
+++ b/4-projects/business_unit_1/dev/example_single_project.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-locals {
-  business_code = "bu1"
-}
-
 module "example_single_project" {
   source = "../../modules/single_project"
 
@@ -31,10 +27,10 @@ module "example_single_project" {
   skip_gcloud_download = var.skip_gcloud_download
 
   # Metadata
-  project_prefix    = "${local.business_code}-d-sample-single"
-  application_name  = "${local.business_code}-sample-single"
+  project_prefix    = "bu1-d-sample-single"
+  application_name  = "bu1-sample-application1"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu1"
 }

--- a/4-projects/business_unit_1/dev/example_single_project_optional.tf
+++ b/4-projects/business_unit_1/dev/example_single_project_optional.tf
@@ -26,12 +26,12 @@
 #   skip_gcloud_download        = var.skip_gcloud_download
 
 #   # Metadata
-#   project_prefix    = "${local.business_code}-d-sample-single"
-#   application_name  = "${local.business_code}-sample-single"
+#   project_prefix    = "bu1-d-sample-single"
+#   application_name  = "bu1-sample-application1"
 #   billing_code      = "1234"
 #   primary_contact   = "example@example.com"
 #   secondary_contact = "example2@example.com"
-#   business_code     = local.business_code
+#   business_code     = "bu1"
 
 #   # Network Setting (Optional)
 #   enable_networking    = true

--- a/4-projects/business_unit_1/nonprod/example_base_shared_vpc_project.tf
+++ b/4-projects/business_unit_1/nonprod/example_base_shared_vpc_project.tf
@@ -26,10 +26,10 @@ module "base_shared_vpc_project" {
   vpc_type                    = "private"
 
   # Metadata
-  project_prefix    = "${local.business_code}-n-sample"
-  application_name  = "${local.business_code}-restricted-sample-single"
+  project_prefix    = "bu1-n-sample"
+  application_name  = "bu1-sample-application1"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu1"
 }

--- a/4-projects/business_unit_1/nonprod/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_1/nonprod/example_restricted_shared_vpc_project.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-locals {
-  prefix = "n_shared_restricted"
-}
-
 module "restricted_shared_vpc_project" {
   source                      = "../../modules/single_project"
   impersonate_service_account = var.terraform_service_account
@@ -34,12 +30,12 @@ module "restricted_shared_vpc_project" {
   vpc_service_control_perimeter_name = "accessPolicies/${var.policy_id}/servicePerimeters/${var.perimeter_name}"
 
   # Metadata
-  project_prefix    = "${local.business_code}-n-sample"
-  application_name  = "${local.business_code}-sample-private-vpc"
+  project_prefix    = "bu1-n-sample"
+  application_name  = "bu1-sample-application1"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu1"
 }
 
 #   # Network Setting (Optional)

--- a/4-projects/business_unit_1/nonprod/example_single_project.tf
+++ b/4-projects/business_unit_1/nonprod/example_single_project.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-locals {
-  business_code = "bu1"
-}
-
 module "example_single_project" {
   source = "../../modules/single_project"
 
@@ -31,10 +27,10 @@ module "example_single_project" {
   folder_id = var.parent_folder
 
   # Metadata
-  project_prefix    = "${local.business_code}-n-sample-single"
-  application_name  = "${local.business_code}-sample-single"
+  project_prefix    = "bu1-n-sample-single"
+  application_name  = "bu1-sample-application1"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu1"
 }

--- a/4-projects/business_unit_1/nonprod/example_single_project_optional.tf
+++ b/4-projects/business_unit_1/nonprod/example_single_project_optional.tf
@@ -25,12 +25,12 @@
 #   skip_gcloud_download        = var.skip_gcloud_download
 
 #   # Metadata
-#   project_prefix    = "${local.business_code}-n-sample-single"
-#   application_name  = "${local.business_code}-sample-single"
+#   project_prefix    = "bu1-n-sample-single"
+#   application_name  = "bu1-sample-application1"
 #   billing_code      = "1234"
 #   primary_contact   = "example@example.com"
 #   secondary_contact = "example2@example.com"
-#   business_code     = local.business_code
+#   business_code     = "bu1"
 
 #   # Network Setting (Optional)
 #   enable_networking    = true

--- a/4-projects/business_unit_1/prod/example_base_shared_vpc_project.tf
+++ b/4-projects/business_unit_1/prod/example_base_shared_vpc_project.tf
@@ -26,10 +26,10 @@ module "base_shared_vpc_project" {
   vpc_type                    = "private"
 
   # Metadata
-  project_prefix    = "${local.business_code}-p-sample"
-  application_name  = "${local.business_code}-restricted-sample-single"
+  project_prefix    = "bu1-p-sample"
+  application_name  = "bu1-sample-application1"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu1"
 }

--- a/4-projects/business_unit_1/prod/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_1/prod/example_restricted_shared_vpc_project.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-locals {
-  prefix = "p_shared_restricted"
-}
-
 module "restricted_shared_vpc_project" {
   source                      = "../../modules/single_project"
   impersonate_service_account = var.terraform_service_account
@@ -34,12 +30,12 @@ module "restricted_shared_vpc_project" {
   vpc_service_control_perimeter_name = "accessPolicies/${var.policy_id}/servicePerimeters/${var.perimeter_name}"
 
   # Metadata
-  project_prefix    = "${local.business_code}-p-sample"
-  application_name  = "${local.business_code}-sample-private-vpc"
+  project_prefix    = "bu1-p-sample"
+  application_name  = "bu1-sample-application1"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu1"
 }
 
 #   # Network Setting (Optional)

--- a/4-projects/business_unit_1/prod/example_single_project.tf
+++ b/4-projects/business_unit_1/prod/example_single_project.tf
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-locals {
-  env           = "prod"
-  business_code = "bu1"
-}
-
 module "example_single_project" {
   source = "../../modules/single_project"
 
@@ -32,10 +27,10 @@ module "example_single_project" {
   folder_id = var.parent_folder
 
   # Metadata
-  project_prefix    = "${local.business_code}-p-sample-single"
-  application_name  = "${local.business_code}-sample-single"
+  project_prefix    = "bu1-p-sample-single"
+  application_name  = "bu1-sample-application1"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu1"
 }

--- a/4-projects/business_unit_1/prod/example_single_project_optional.tf
+++ b/4-projects/business_unit_1/prod/example_single_project_optional.tf
@@ -26,12 +26,12 @@
 #   skip_gcloud_download        = var.skip_gcloud_download
 
 #   # Metadata
-#   project_prefix    = "${local.business_code}-p-sample-single"
-#   application_name  = "${local.business_code}-sample-single"
+#   project_prefix    = "bu1-p-sample-single"
+#   application_name  = "bu1-sample-application1"
 #   billing_code      = "1234"
 #   primary_contact   = "example@example.com"
 #   secondary_contact = "example2@example.com"
-#   business_code     = local.business_code
+#   business_code     = "bu1"
 
 #   # Network Setting (Optional)
 #   enable_networking    = true

--- a/4-projects/business_unit_2/dev/example_base_shared_vpc_project.tf
+++ b/4-projects/business_unit_2/dev/example_base_shared_vpc_project.tf
@@ -26,10 +26,10 @@ module "base_shared_vpc_project" {
   vpc_type                    = "private"
 
   # Metadata
-  project_prefix    = "${local.business_code}-d-sample"
-  application_name  = "${local.business_code}-sample-private-vpc"
+  project_prefix    = "bu2-d-sample"
+  application_name  = "bu2-sample-application2"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu2"
 }

--- a/4-projects/business_unit_2/dev/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_2/dev/example_restricted_shared_vpc_project.tf
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-locals {
-  prefix         = "d_shared_restricted"
-  perimeter_name = "sp_${local.prefix}_default_perimeter_1234"
-}
-
 module "restricted_shared_vpc_project" {
   source                      = "../../modules/single_project"
   impersonate_service_account = var.terraform_service_account
@@ -32,15 +27,15 @@ module "restricted_shared_vpc_project" {
 
   activate_apis                      = ["accesscontextmanager.googleapis.com"]
   vpc_service_control_attach_enabled = "true"
-  vpc_service_control_perimeter_name = "accessPolicies/${var.policy_id}/servicePerimeters/${local.perimeter_name}"
+  vpc_service_control_perimeter_name = "accessPolicies/${var.policy_id}/servicePerimeters/${var.perimeter_name}"
 
   # Metadata
-  project_prefix    = "${local.business_code}-d-sample"
-  application_name  = "${local.business_code}-restricted-sample-single"
+  project_prefix    = "bu2-d-sample"
+  application_name  = "bu2-sample-application2"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu2"
 }
 
 #   # Network Setting (Optional)

--- a/4-projects/business_unit_2/dev/example_single_project.tf
+++ b/4-projects/business_unit_2/dev/example_single_project.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-locals {
-  business_code = "bu2"
-}
-
 module "example_single_project" {
   source = "../../modules/single_project"
 
@@ -31,10 +27,10 @@ module "example_single_project" {
   folder_id = var.parent_folder
 
   # Metadata
-  project_prefix    = "${local.business_code}-d-sample-single"
-  application_name  = "${local.business_code}-sample-single"
+  project_prefix    = "bu2-d-sample-single"
+  application_name  = "bu2-sample-application2"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu2"
 }

--- a/4-projects/business_unit_2/dev/example_single_project_optional.tf
+++ b/4-projects/business_unit_2/dev/example_single_project_optional.tf
@@ -26,12 +26,12 @@
 #   skip_gcloud_download        = var.skip_gcloud_download
 
 #   # Metadata
-#   project_prefix    = "${local.business_code}-d-sample-single"
-#   application_name  = "${local.business_code}-sample-single"
+#   project_prefix    = "bu2-d-sample-single"
+#   application_name  = "bu2-sample-application2"
 #   billing_code      = "1234"
 #   primary_contact   = "example@example.com"
 #   secondary_contact = "example2@example.com"
-#   business_code     = local.business_code
+#   business_code     = "bu2"
 
 #   # Network Setting (Optional)
 #   enable_networking    = true

--- a/4-projects/business_unit_2/dev/variables.tf
+++ b/4-projects/business_unit_2/dev/variables.tf
@@ -59,3 +59,8 @@ variable "parent_folder" {
   type        = string
   default     = ""
 }
+
+variable "perimeter_name" {
+  description = "Access context manager service perimeter name to attach the restricted svpc project."
+  type        = string
+}

--- a/4-projects/business_unit_2/nonprod/example_base_shared_vpc_project.tf
+++ b/4-projects/business_unit_2/nonprod/example_base_shared_vpc_project.tf
@@ -26,10 +26,10 @@ module "base_shared_vpc_project" {
   vpc_type                    = "private"
 
   # Metadata
-  project_prefix    = "${local.business_code}-n-sample"
-  application_name  = "${local.business_code}-sample-private-vpc"
+  project_prefix    = "bu2-n-sample"
+  application_name  = "bu2-sample-application2"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu2"
 }

--- a/4-projects/business_unit_2/nonprod/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_2/nonprod/example_restricted_shared_vpc_project.tf
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-locals {
-  prefix         = "n_shared_restricted"
-  perimeter_name = "sp_${local.prefix}_default_perimeter_1234"
-}
-
 module "restricted_shared_vpc_project" {
   source                      = "../../modules/single_project"
   impersonate_service_account = var.terraform_service_account
@@ -32,15 +27,15 @@ module "restricted_shared_vpc_project" {
 
   activate_apis                      = ["accesscontextmanager.googleapis.com"]
   vpc_service_control_attach_enabled = "true"
-  vpc_service_control_perimeter_name = "accessPolicies/${var.policy_id}/servicePerimeters/${local.perimeter_name}"
+  vpc_service_control_perimeter_name = "accessPolicies/${var.policy_id}/servicePerimeters/${var.perimeter_name}"
 
   # Metadata
-  project_prefix    = "${local.business_code}-n-sample"
-  application_name  = "${local.business_code}-restricted-sample-single"
+  project_prefix    = "bu2-n-sample"
+  application_name  = "bu2-sample-application2"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu2"
 }
 
 #   # Network Setting (Optional)

--- a/4-projects/business_unit_2/nonprod/example_single_project.tf
+++ b/4-projects/business_unit_2/nonprod/example_single_project.tf
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-locals {
-  business_code = "bu2"
-}
+
 
 module "example_single_project" {
   source = "../../modules/single_project"
@@ -31,10 +29,10 @@ module "example_single_project" {
   folder_id = var.parent_folder
 
   # Metadata
-  project_prefix    = "${local.business_code}-n-sample-single"
-  application_name  = "${local.business_code}-sample-single"
+  project_prefix    = "bu2-n-sample-single"
+  application_name  = "bu2-sample-application2"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu2"
 }

--- a/4-projects/business_unit_2/nonprod/example_single_project_optional.tf
+++ b/4-projects/business_unit_2/nonprod/example_single_project_optional.tf
@@ -26,12 +26,12 @@
 #   skip_gcloud_download        = var.skip_gcloud_download
 
 #   # Metadata
-#   project_prefix    = "${local.business_code}-n-sample-single"
-#   application_name  = "${local.business_code}-sample-single"
+#   project_prefix    = "bu2-n-sample-single"
+#   application_name  = "bu2-sample-application2"
 #   billing_code      = "1234"
 #   primary_contact   = "example@example.com"
 #   secondary_contact = "example2@example.com"
-#   business_code     = local.business_code
+#   business_code     = "bu2"
 
 #   # Network Setting (Optional)
 #   enable_networking    = true

--- a/4-projects/business_unit_2/nonprod/variables.tf
+++ b/4-projects/business_unit_2/nonprod/variables.tf
@@ -59,3 +59,8 @@ variable "parent_folder" {
   type        = string
   default     = ""
 }
+
+variable "perimeter_name" {
+  description = "Access context manager service perimeter name to attach the restricted svpc project."
+  type        = string
+}

--- a/4-projects/business_unit_2/prod/example_base_shared_vpc_project.tf
+++ b/4-projects/business_unit_2/prod/example_base_shared_vpc_project.tf
@@ -26,10 +26,10 @@ module "base_shared_vpc_project" {
   vpc_type                    = "private"
 
   # Metadata
-  project_prefix    = "${local.business_code}-p-sample"
-  application_name  = "${local.business_code}-restricted-sample-single"
+  project_prefix    = "bu2-p-sample"
+  application_name  = "bu2-sample-application2"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu2"
 }

--- a/4-projects/business_unit_2/prod/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_2/prod/example_restricted_shared_vpc_project.tf
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-locals {
-  prefix         = "p_shared_restricted"
-  perimeter_name = "sp_${local.prefix}_default_perimeter_1234"
-}
-
 module "restricted_shared_vpc_project" {
   source                      = "../../modules/single_project"
   impersonate_service_account = var.terraform_service_account
@@ -32,15 +27,15 @@ module "restricted_shared_vpc_project" {
 
   activate_apis                      = ["accesscontextmanager.googleapis.com"]
   vpc_service_control_attach_enabled = "true"
-  vpc_service_control_perimeter_name = "accessPolicies/${var.policy_id}/servicePerimeters/${local.perimeter_name}"
+  vpc_service_control_perimeter_name = "accessPolicies/${var.policy_id}/servicePerimeters/${var.perimeter_name}"
 
   # Metadata
-  project_prefix    = "${local.business_code}-p-sample"
-  application_name  = "${local.business_code}-sample-private-vpc"
+  project_prefix    = "bu2-p-sample"
+  application_name  = "bu2-sample-application2"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu2"
 }
 
 #   # Network Setting (Optional)

--- a/4-projects/business_unit_2/prod/example_single_project.tf
+++ b/4-projects/business_unit_2/prod/example_single_project.tf
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-locals {
-  business_code = "bu2"
-}
+
 
 module "example_single_project" {
   source = "../../modules/single_project"
@@ -31,10 +29,10 @@ module "example_single_project" {
   folder_id = var.parent_folder
 
   # Metadata
-  project_prefix    = "${local.business_code}-p-sample-single"
-  application_name  = "${local.business_code}-sample-single"
+  project_prefix    = "bu2-p-sample-single"
+  application_name  = "bu2-sample-application2"
   billing_code      = "1234"
   primary_contact   = "example@example.com"
   secondary_contact = "example2@example.com"
-  business_code     = local.business_code
+  business_code     = "bu2"
 }

--- a/4-projects/business_unit_2/prod/example_single_project_optional.tf
+++ b/4-projects/business_unit_2/prod/example_single_project_optional.tf
@@ -26,12 +26,12 @@
 #   skip_gcloud_download        = var.skip_gcloud_download
 
 #   # Metadata
-#   project_prefix    = "${local.business_code}-p-sample-single"
-#   application_name  = "${local.business_code}-sample-single"
+#   project_prefix    = "bu2-p-sample-single"
+#   application_name  = "bu2-sample-application2"
 #   billing_code      = "1234"
 #   primary_contact   = "example@example.com"
 #   secondary_contact = "example2@example.com"
-#   business_code     = local.business_code
+#   business_code     = "bu2"
 
 #   # Network Setting (Optional)
 #   enable_networking    = true

--- a/4-projects/business_unit_2/prod/variables.tf
+++ b/4-projects/business_unit_2/prod/variables.tf
@@ -59,3 +59,8 @@ variable "parent_folder" {
   type        = string
   default     = ""
 }
+
+variable "perimeter_name" {
+  description = "Access context manager service perimeter name to attach the restricted svpc project."
+  type        = string
+}

--- a/test/export_sc.sh
+++ b/test/export_sc.sh
@@ -22,10 +22,4 @@ pushd /workspace/test/fixtures/networks
 terraform workspace select kitchen-terraform-networks-default
 # shellcheck disable=SC1090
 source <(python /usr/local/bin/export_tf_outputs.py --path=/workspace/test/fixtures/networks)
-# shellcheck disable=SC2154
-echo "${TF_VAR_dev_restricted_service_perimeter_name}"
-# shellcheck disable=SC2154
-echo "${TF_VAR_prod_restricted_service_perimeter_name}"
-# shellcheck disable=SC2154
-echo "${TF_VAR_nonprod_restricted_service_perimeter_name}"
 popd

--- a/test/fixtures/projects/main.tf
+++ b/test/fixtures/projects/main.tf
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-resource "random_id" "suffix" {
-  byte_length = 4
-}
-
-
-module "projects" {
+module "projects_bu1_dev" {
   source                    = "../../../4-projects/business_unit_1/dev"
   terraform_service_account = var.terraform_sa_email
   org_id                    = var.org_id
@@ -50,3 +45,33 @@ module "projects_bu1_prod" {
   perimeter_name            = var.prod_restricted_service_perimeter_name
 }
 
+module "projects_bu2_dev" {
+  source                    = "../../../4-projects/business_unit_2/dev"
+  terraform_service_account = var.terraform_sa_email
+  org_id                    = var.org_id
+  billing_account           = var.billing_account
+  policy_id                 = var.policy_id
+  parent_folder             = var.parent_folder
+  perimeter_name            = var.dev_restricted_service_perimeter_name
+}
+
+module "projects_bu2_nonprod" {
+  source                    = "../../../4-projects/business_unit_2/nonprod"
+  terraform_service_account = var.terraform_sa_email
+  org_id                    = var.org_id
+  billing_account           = var.billing_account
+  policy_id                 = var.policy_id
+  parent_folder             = var.parent_folder
+  perimeter_name            = var.nonprod_restricted_service_perimeter_name
+}
+
+
+module "projects_bu2_prod" {
+  source                    = "../../../4-projects/business_unit_2/prod"
+  terraform_service_account = var.terraform_sa_email
+  org_id                    = var.org_id
+  billing_account           = var.billing_account
+  policy_id                 = var.policy_id
+  parent_folder             = var.parent_folder
+  perimeter_name            = var.prod_restricted_service_perimeter_name
+}


### PR DESCRIPTION
fixes #119 

- Hardcodes application names across all envs
    - bu1  -> `bu1-sample-application1`
    - bu2  -> `bu2-sample-application2`
- Hardcode `local.business_code`
- Remove unused locals
- Add bu2 to IT
- Remove debug echo statements from helper