### PR TITLE
make default value and name for  firewall rule enabled consistent

### DIFF
--- a/3-networks/envs/dev/main.tf
+++ b/3-networks/envs/dev/main.tf
@@ -132,17 +132,17 @@ module "restricted_shared_vpc" {
 *****************************************/
 
 module "private_shared_vpc" {
-  source                     = "../../modules/standard_shared_vpc"
-  project_id                 = local.private_project_id
-  environment_code           = local.environment_code
-  vpc_label                  = "private"
-  private_service_cidr       = "10.0.144.0/20"
-  nat_enabled                = false
-  nat_bgp_asn                = "64514"
-  default_region1            = var.default_region1
-  default_region2            = var.default_region2
-  domain                     = var.domain
-  bgp_asn_subnet             = "64514"
+  source               = "../../modules/standard_shared_vpc"
+  project_id           = local.private_project_id
+  environment_code     = local.environment_code
+  vpc_label            = "private"
+  private_service_cidr = "10.0.144.0/20"
+  nat_enabled          = false
+  nat_bgp_asn          = "64514"
+  default_region1      = var.default_region1
+  default_region2      = var.default_region2
+  domain               = var.domain
+  bgp_asn_subnet       = "64514"
 
   subnets = [
     {

--- a/3-networks/envs/dev/main.tf
+++ b/3-networks/envs/dev/main.tf
@@ -143,7 +143,7 @@ module "private_shared_vpc" {
   default_region2            = var.default_region2
   domain                     = var.domain
   bgp_asn_subnet             = "64514"
-  windows_activation_enabled = true
+
   subnets = [
     {
       subnet_name           = "sb-${local.environment_code}-shared-private-${var.default_region1}"

--- a/3-networks/envs/dev/main.tf
+++ b/3-networks/envs/dev/main.tf
@@ -137,7 +137,7 @@ module "private_shared_vpc" {
   environment_code           = local.environment_code
   vpc_label                  = "private"
   private_service_cidr       = "10.0.144.0/20"
-  nat_enabled                = true
+  nat_enabled                = false
   nat_bgp_asn                = "64514"
   default_region1            = var.default_region1
   default_region2            = var.default_region2

--- a/3-networks/envs/nonprod/main.tf
+++ b/3-networks/envs/nonprod/main.tf
@@ -133,17 +133,17 @@ module "restricted_shared_vpc" {
 *****************************************/
 
 module "private_shared_vpc" {
-  source                     = "../../modules/standard_shared_vpc"
-  project_id                 = local.private_project_id
-  environment_code           = local.environment_code
-  vpc_label                  = "private"
-  private_service_cidr       = "10.0.80.0/20"
-  nat_enabled                = false
-  nat_bgp_asn                = "64514"
-  default_region1            = var.default_region1
-  default_region2            = var.default_region2
-  domain                     = var.domain
-  bgp_asn_subnet             = "64514"
+  source               = "../../modules/standard_shared_vpc"
+  project_id           = local.private_project_id
+  environment_code     = local.environment_code
+  vpc_label            = "private"
+  private_service_cidr = "10.0.80.0/20"
+  nat_enabled          = false
+  nat_bgp_asn          = "64514"
+  default_region1      = var.default_region1
+  default_region2      = var.default_region2
+  domain               = var.domain
+  bgp_asn_subnet       = "64514"
 
   subnets = [
     {

--- a/3-networks/envs/nonprod/main.tf
+++ b/3-networks/envs/nonprod/main.tf
@@ -138,7 +138,7 @@ module "private_shared_vpc" {
   environment_code           = local.environment_code
   vpc_label                  = "private"
   private_service_cidr       = "10.0.80.0/20"
-  nat_enabled                = true
+  nat_enabled                = false
   nat_bgp_asn                = "64514"
   default_region1            = var.default_region1
   default_region2            = var.default_region2

--- a/3-networks/envs/nonprod/main.tf
+++ b/3-networks/envs/nonprod/main.tf
@@ -144,7 +144,6 @@ module "private_shared_vpc" {
   default_region2            = var.default_region2
   domain                     = var.domain
   bgp_asn_subnet             = "64514"
-  windows_activation_enabled = true
 
   subnets = [
     {

--- a/3-networks/envs/prod/main.tf
+++ b/3-networks/envs/prod/main.tf
@@ -132,17 +132,17 @@ module "restricted_shared_vpc" {
 *****************************************/
 
 module "private_shared_vpc" {
-  source                     = "../../modules/standard_shared_vpc"
-  project_id                 = local.private_project_id
-  environment_code           = local.environment_code
-  vpc_label                  = "private"
-  private_service_cidr       = "10.0.16.0/20"
-  nat_enabled                = false
-  nat_bgp_asn                = "64514"
-  default_region1            = var.default_region1
-  default_region2            = var.default_region2
-  domain                     = var.domain
-  bgp_asn_subnet             = "64514"
+  source               = "../../modules/standard_shared_vpc"
+  project_id           = local.private_project_id
+  environment_code     = local.environment_code
+  vpc_label            = "private"
+  private_service_cidr = "10.0.16.0/20"
+  nat_enabled          = false
+  nat_bgp_asn          = "64514"
+  default_region1      = var.default_region1
+  default_region2      = var.default_region2
+  domain               = var.domain
+  bgp_asn_subnet       = "64514"
 
   subnets = [
     {

--- a/3-networks/envs/prod/main.tf
+++ b/3-networks/envs/prod/main.tf
@@ -137,7 +137,7 @@ module "private_shared_vpc" {
   environment_code           = local.environment_code
   vpc_label                  = "private"
   private_service_cidr       = "10.0.16.0/20"
-  nat_enabled                = true
+  nat_enabled                = false
   nat_bgp_asn                = "64514"
   default_region1            = var.default_region1
   default_region2            = var.default_region2

--- a/3-networks/envs/prod/main.tf
+++ b/3-networks/envs/prod/main.tf
@@ -143,7 +143,7 @@ module "private_shared_vpc" {
   default_region2            = var.default_region2
   domain                     = var.domain
   bgp_asn_subnet             = "64514"
-  windows_activation_enabled = true
+
   subnets = [
     {
       subnet_name           = "sb-${local.environment_code}-shared-private-${var.default_region1}"

--- a/3-networks/modules/restricted_shared_vpc/README.md
+++ b/3-networks/modules/restricted_shared_vpc/README.md
@@ -11,13 +11,13 @@
 | dns\_enable\_logging | Toggle DNS logging for VPC DNS. | bool | `"true"` | no |
 | domain | The DNS name of peering managed zone, for instance 'example.com.' | string | n/a | yes |
 | environment\_code | A short form of the folder level resources (environment) within the Google Cloud organization. | string | n/a | yes |
-| firewall\_enable\_logging | Toggle firewall logginglogging for VPC Firewalls. | bool | `"true"` | no |
+| firewall\_enable\_logging | Toggle firewall logging for VPC Firewalls. | bool | `"true"` | no |
 | members | An allowed list of members (users, service accounts). The signed-in identity originating the request must be a part of one of the provided members. If not specified, a request may come from any user (logged in/not logged in, etc.). Formats: user:{emailid}, serviceAccount:{emailid} | list(string) | n/a | yes |
 | nat\_bgp\_asn | BGP ASN for NAT cloud routes. If NAT is enabled this variable value must be a value in ranges [64512..65534] or [4200000000..4294967294]. | number | `"64512"` | no |
 | nat\_enabled | Toggle creation of NAT cloud router. | bool | `"false"` | no |
 | nat\_num\_addresses\_region1 | Number of external IPs to reserve for region 1 Cloud NAT. | number | `"2"` | no |
 | nat\_num\_addresses\_region2 | Number of external IPs to reserve for region 2 Cloud NAT. | number | `"2"` | no |
-| optional\_fw\_rules\_enabled | Toggle creation of optional firewall rules. | bool | `"false"` | no |
+| optional\_fw\_rules\_enabled | Toggle creation of optional firewall rules: IAP SSH, IAP RDP and Internal & Global load balancing health check and load balancing IP ranges. | bool | `"false"` | no |
 | org\_id | Organization ID | string | n/a | yes |
 | private\_service\_cidr | CIDR range for private service networking. Used for Cloud SQL and other managed services. | string | n/a | yes |
 | project\_id | Project ID for Restricted Shared VPC. | string | n/a | yes |

--- a/3-networks/modules/restricted_shared_vpc/variables.tf
+++ b/3-networks/modules/restricted_shared_vpc/variables.tf
@@ -104,7 +104,7 @@ variable "dns_enable_logging" {
 
 variable "firewall_enable_logging" {
   type        = bool
-  description = "Toggle firewall logginglogging for VPC Firewalls."
+  description = "Toggle firewall logging for VPC Firewalls."
   default     = true
 }
 
@@ -126,7 +126,7 @@ variable "windows_activation_enabled" {
 
 variable "optional_fw_rules_enabled" {
   type        = bool
-  description = "Toggle creation of optional firewall rules."
+  description = "Toggle creation of optional firewall rules: IAP SSH, IAP RDP and Internal & Global load balancing health check and load balancing IP ranges."
   default     = false
 }
 

--- a/3-networks/modules/standard_shared_vpc/README.md
+++ b/3-networks/modules/standard_shared_vpc/README.md
@@ -4,19 +4,19 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | bgp\_asn\_subnet | BGP ASN for Subnets cloud routers. | number | n/a | yes |
-| default\_fw\_rules\_enabled | Toggle creation of default firewall rules. | bool | `"true"` | no |
 | default\_region1 | Default region 1 for subnets and Cloud Routers | string | n/a | yes |
 | default\_region2 | Default region 2 for subnets and Cloud Routers | string | n/a | yes |
 | dns\_enable\_inbound\_forwarding | Toggle inbound query forwarding for VPC DNS. | bool | `"true"` | no |
 | dns\_enable\_logging | Toggle DNS logging for VPC DNS. | bool | `"true"` | no |
 | domain | The DNS name of peering managed zone, for instance 'example.com.' | string | n/a | yes |
 | environment\_code | A short form of the folder level resources (environment) within the Google Cloud organization. | string | n/a | yes |
-| firewall\_enable\_logging | Toggle firewall logginglogging for VPC Firewalls. | bool | `"true"` | no |
+| firewall\_enable\_logging | Toggle firewall logging for VPC Firewalls. | bool | `"true"` | no |
 | nat\_bgp\_asn | BGP ASN for first NAT cloud routes. | number | `"0"` | no |
 | nat\_enabled | Toggle creation of NAT cloud router. | bool | `"false"` | no |
 | nat\_num\_addresses | Number of external IPs to reserve for Cloud NAT. | number | `"2"` | no |
 | nat\_num\_addresses\_region1 | Number of external IPs to reserve for first Cloud NAT. | number | `"2"` | no |
 | nat\_num\_addresses\_region2 | Number of external IPs to reserve for second Cloud NAT. | number | `"2"` | no |
+| optional\_fw\_rules\_enabled | Toggle creation of optional firewall rules: IAP SSH, IAP RDP and Internal & Global load balancing health check and load balancing IP ranges. | bool | `"false"` | no |
 | private\_service\_cidr | CIDR range for private service networking. Used for Cloud SQL and other managed services. | string | n/a | yes |
 | project\_id | Project ID for Private Shared VPC. | string | n/a | yes |
 | secondary\_ranges | Secondary ranges that will be used in some of the subnets | object | `<map>` | no |

--- a/3-networks/modules/standard_shared_vpc/firewall.tf
+++ b/3-networks/modules/standard_shared_vpc/firewall.tf
@@ -55,12 +55,12 @@ resource "google_compute_firewall" "allow_private_api_egress" {
 
 
 /******************************************
-  Default firewall rules
+  Optional firewall rules
  *****************************************/
 
 // Allow SSH via IAP when using the allow-iap-ssh tag for Linux workloads.
 resource "google_compute_firewall" "allow_iap_ssh" {
-  count          = var.default_fw_rules_enabled ? 1 : 0
+  count          = var.optional_fw_rules_enabled ? 1 : 0
   name           = "fw-${var.environment_code}-shared-private-1000-i-a-all-allow-iap-ssh-tcp-22"
   network        = module.main.network_name
   project        = var.project_id
@@ -79,7 +79,7 @@ resource "google_compute_firewall" "allow_iap_ssh" {
 
 // Allow RDP via IAP when using the allow-iap-rdp tag for Windows workloads.
 resource "google_compute_firewall" "allow_iap_rdp" {
-  count          = var.default_fw_rules_enabled ? 1 : 0
+  count          = var.optional_fw_rules_enabled ? 1 : 0
   name           = "fw-${var.environment_code}-shared-private-1000-i-a-all-allow-iap-rdp-tcp-3389"
   network        = module.main.network_name
   project        = var.project_id
@@ -114,7 +114,7 @@ resource "google_compute_firewall" "allow_windows_activation" {
 
 // Allow traffic for Internal & Global load balancing health check and load balancing IP ranges.
 resource "google_compute_firewall" "allow_lb" {
-  count          = var.default_fw_rules_enabled ? 1 : 0
+  count          = var.optional_fw_rules_enabled ? 1 : 0
   name           = "fw-${var.environment_code}-shared-private-1000-i-a-all-allow-lb-tcp-80-8080-443"
   network        = module.main.network_name
   project        = var.project_id

--- a/3-networks/modules/standard_shared_vpc/variables.tf
+++ b/3-networks/modules/standard_shared_vpc/variables.tf
@@ -94,7 +94,7 @@ variable "dns_enable_logging" {
 
 variable "firewall_enable_logging" {
   type        = bool
-  description = "Toggle firewall logginglogging for VPC Firewalls."
+  description = "Toggle firewall logging for VPC Firewalls."
   default     = true
 }
 
@@ -120,8 +120,8 @@ variable "nat_num_addresses" {
   default     = 2
 }
 
-variable "default_fw_rules_enabled" {
+variable "optional_fw_rules_enabled" {
   type        = bool
-  description = "Toggle creation of default firewall rules."
-  default     = true
+  description = "Toggle creation of optional firewall rules: IAP SSH, IAP RDP and Internal & Global load balancing health check and load balancing IP ranges."
+  default     = false
 }


### PR DESCRIPTION
Makes default value and name for `default/optional` firewall rule enabled consistent.
Also fixes typo in logging toggle.

Closes #135 