### PR TITLE
Dns hub fixes

### DIFF
--- a/3-networks/envs/shared/README.md
+++ b/3-networks/envs/shared/README.md
@@ -23,8 +23,8 @@ The purpose of this step is to setup the global [DNS Hub](https://cloud.google.c
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | bgp\_asn\_dns | BGP Autonomous System Number (ASN). | number | `"64667"` | no |
-| dns\_default\_region1 | First subnet region for DNS Hub network. | string | n/a | yes |
-| dns\_default\_region2 | Second subnet region for DNS Hub network. | string | n/a | yes |
+| default\_region1 | First subnet region for DNS Hub network. | string | n/a | yes |
+| default\_region2 | Second subnet region for DNS Hub network. | string | n/a | yes |
 | dns\_enable\_logging | Toggle DNS logging for VPC DNS. | bool | `"true"` | no |
 | domain | The DNS name of forwarding managed zone, for instance 'example.com' | string | n/a | yes |
 | org\_id | Organization ID | string | n/a | yes |

--- a/3-networks/envs/shared/main.tf
+++ b/3-networks/envs/shared/main.tf
@@ -47,16 +47,16 @@ module "dns_hub_vpc" {
   delete_default_internet_gateway_routes = "true"
 
   subnets = [{
-    subnet_name           = "sb-dns-hub-${var.dns_default_region1}"
+    subnet_name           = "sb-dns-hub-${var.default_region1}"
     subnet_ip             = "172.16.0.0/25"
-    subnet_region         = var.dns_default_region1
+    subnet_region         = var.default_region1
     subnet_private_access = "true"
     subnet_flow_logs      = var.subnetworks_enable_logging
     description           = "DNS hub subnet for region 1."
     }, {
-    subnet_name           = "sb-dns-hub-${var.dns_default_region2}"
+    subnet_name           = "sb-dns-hub-${var.default_region2}"
     subnet_ip             = "172.16.0.128/25"
-    subnet_region         = var.dns_default_region2
+    subnet_region         = var.default_region2
     subnet_private_access = "true"
     subnet_flow_logs      = var.subnetworks_enable_logging
     description           = "DNS hub subnet for region 2."
@@ -111,10 +111,10 @@ module "dns-forwarding-zone" {
 module "dns_hub_region1_router1" {
   source  = "terraform-google-modules/cloud-router/google"
   version = "~> 0.2.0"
-  name    = "cr-dns-hub-${var.dns_default_region1}-cr1"
+  name    = "cr-dns-hub-${var.default_region1}-cr1"
   project = local.dns_hub_project_id
   network = module.dns_hub_vpc.network_name
-  region  = var.dns_default_region1
+  region  = var.default_region1
   bgp = {
     asn                  = var.bgp_asn_dns
     advertised_ip_ranges = [{ range = "35.199.192.0/19" }]
@@ -124,10 +124,10 @@ module "dns_hub_region1_router1" {
 module "dns_hub_region1_router2" {
   source  = "terraform-google-modules/cloud-router/google"
   version = "~> 0.2.0"
-  name    = "cr-dns-hub-${var.dns_default_region1}-cr2"
+  name    = "cr-dns-hub-${var.default_region1}-cr2"
   project = local.dns_hub_project_id
   network = module.dns_hub_vpc.network_name
-  region  = var.dns_default_region1
+  region  = var.default_region1
   bgp = {
     asn                  = var.bgp_asn_dns
     advertised_ip_ranges = [{ range = "35.199.192.0/19" }]
@@ -137,10 +137,10 @@ module "dns_hub_region1_router2" {
 module "dns_hub_region2_router1" {
   source  = "terraform-google-modules/cloud-router/google"
   version = "~> 0.2.0"
-  name    = "cr-dns-hub-${var.dns_default_region2}-cr3"
+  name    = "cr-dns-hub-${var.default_region2}-cr3"
   project = local.dns_hub_project_id
   network = module.dns_hub_vpc.network_name
-  region  = var.dns_default_region2
+  region  = var.default_region2
   bgp = {
     asn                  = var.bgp_asn_dns
     advertised_ip_ranges = [{ range = "35.199.192.0/19" }]
@@ -150,10 +150,10 @@ module "dns_hub_region2_router1" {
 module "dns_hub_region2_router2" {
   source  = "terraform-google-modules/cloud-router/google"
   version = "~> 0.2.0"
-  name    = "cr-dns-hub-${var.dns_default_region2}-cr4"
+  name    = "cr-dns-hub-${var.default_region2}-cr4"
   project = local.dns_hub_project_id
   network = module.dns_hub_vpc.network_name
-  region  = var.dns_default_region2
+  region  = var.default_region2
   bgp = {
     asn                  = var.bgp_asn_dns
     advertised_ip_ranges = [{ range = "35.199.192.0/19" }]
@@ -172,7 +172,7 @@ module "dns_hub_region2_router2" {
 
 #   vpc_name = "dns-hub"
 
-#   region1                        = var.dns_default_region1
+#   region1                        = var.default_region1
 #   region1_router1_name           = module.dns_hub_region1_router1.router.name
 #   region1_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
 #   region1_interconnect1_location = "las-zone1-770"
@@ -180,11 +180,11 @@ module "dns_hub_region2_router2" {
 #   region1_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
 #   region1_interconnect2_location = "las-zone1-770"
 
-#   region2                        = var.dns_default_region2
+#   region2                        = var.default_region2
 #   region2_router1_name           = module.dns_hub_region2_router1.router.name
 #   region2_interconnect1          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
 #   region2_interconnect1_location = "lax-zone2-19"
-#   region2_router2_name           = module.dns_hub_region2_router2.router.name
+#   region2_router2_name           = module.hub_region2_router2.router.name
 #   region2_interconnect2          = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
 #   region2_interconnect2_location = "lax-zone1-403"
 

--- a/3-networks/envs/shared/terraform.example.tfvars
+++ b/3-networks/envs/shared/terraform.example.tfvars
@@ -16,9 +16,9 @@
 
 terraform_service_account = "org-terraform@example-project-2334.iam.gserviceaccount.com"
 
-dns_default_region1 = "us-central1"
+default_region1 = "us-central1"
 
-dns_default_region2 = "us-west1"
+default_region2 = "us-west1"
 
 domain = "example.com."
 

--- a/3-networks/envs/shared/terraform.example.tfvars
+++ b/3-networks/envs/shared/terraform.example.tfvars
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+org_id = "000000000000"
+
 terraform_service_account = "org-terraform@example-project-2334.iam.gserviceaccount.com"
 
 default_region1 = "us-central1"

--- a/3-networks/envs/shared/variables.tf
+++ b/3-networks/envs/shared/variables.tf
@@ -24,12 +24,12 @@ variable "terraform_service_account" {
   description = "Service account email of the account to impersonate to run Terraform."
 }
 
-variable "dns_default_region1" {
+variable "default_region1" {
   type        = string
   description = "First subnet region for DNS Hub network."
 }
 
-variable "dns_default_region2" {
+variable "default_region2" {
   type        = string
   description = "Second subnet region for DNS Hub network."
 }

--- a/test/fixtures/dns_hub/main.tf
+++ b/test/fixtures/dns_hub/main.tf
@@ -16,8 +16,8 @@
 
 module "dns_hub" {
   source                       = "../../../3-networks/envs/shared"
-  dns_default_region1          = "us-central1"
-  dns_default_region2          = "us-west1"
+  default_region1              = "us-central1"
+  default_region2              = "us-west1"
   domain                       = var.domain
   target_name_server_addresses = ["8.8.8.8", "8.8.8.4"]
   terraform_service_account    = var.terraform_sa_email


### PR DESCRIPTION
DNS hub(env/shared) now uses the same variable names for the default_regions used by other envs (dev, nonprod, prod). 
Closes #136

Added the org_id to the terraform.example.tfvars.
Closes #125
