### PR TITLE
make access context manager policy id usage consistent

### DIFF
--- a/4-projects/README.md
+++ b/4-projects/README.md
@@ -8,6 +8,7 @@ The purpose of this step is to setup folder structure and projects for applicati
 1. 1-org executed successfully.
 1. 2-environments executed successfully.
 1. 3-networks executed successfully.
+1. Obtain the value for the access_context_manager_policy_id variable. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format="value(name)"`.
 
 ## Usage
 ### Setup to run via Cloud Build
@@ -52,6 +53,7 @@ If you have uncommented the Subnetting and Private DNS Management module from pr
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| access\_context\_manager\_policy\_id | The ID of the access context manager policy the perimeter lies in. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format="value(name)"`. | string | n/a | yes |
 | billing\_account | The ID of the billing account to associated this project with | string | n/a | yes |
 | default\_region | Default region for subnet. | string | `"us-west1"` | no |
 | org\_id | The organization id for the associated services | string | n/a | yes |

--- a/4-projects/business_unit_1/dev/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_1/dev/example_restricted_shared_vpc_project.tf
@@ -27,7 +27,7 @@ module "restricted_shared_vpc_project" {
 
   activate_apis                      = ["accesscontextmanager.googleapis.com"]
   vpc_service_control_attach_enabled = "true"
-  vpc_service_control_perimeter_name = "accessPolicies/${var.policy_id}/servicePerimeters/${var.perimeter_name}"
+  vpc_service_control_perimeter_name = "accessPolicies/${var.access_context_manager_policy_id}/servicePerimeters/${var.perimeter_name}"
 
   # Metadata
   project_prefix    = "bu1-d-sample-restricted"

--- a/4-projects/business_unit_1/dev/variables.tf
+++ b/4-projects/business_unit_1/dev/variables.tf
@@ -41,9 +41,9 @@ variable "skip_gcloud_download" {
   default     = true
 }
 
-variable "policy_id" {
+variable "access_context_manager_policy_id" {
   type        = string
-  description = "The ID of the access context manager policy the perimeter lies in"
+  description = "The ID of the access context manager policy the perimeter lies in. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format=\"value(name)\"`."
 }
 
 /******************************************

--- a/4-projects/business_unit_1/nonprod/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_1/nonprod/example_restricted_shared_vpc_project.tf
@@ -27,7 +27,7 @@ module "restricted_shared_vpc_project" {
 
   activate_apis                      = ["accesscontextmanager.googleapis.com"]
   vpc_service_control_attach_enabled = "true"
-  vpc_service_control_perimeter_name = "accessPolicies/${var.policy_id}/servicePerimeters/${var.perimeter_name}"
+  vpc_service_control_perimeter_name = "accessPolicies/${var.access_context_manager_policy_id}/servicePerimeters/${var.perimeter_name}"
 
   # Metadata
   project_prefix    = "bu1-n-sample-restricted"

--- a/4-projects/business_unit_1/nonprod/variables.tf
+++ b/4-projects/business_unit_1/nonprod/variables.tf
@@ -41,9 +41,9 @@ variable "skip_gcloud_download" {
   default     = true
 }
 
-variable "policy_id" {
+variable "access_context_manager_policy_id" {
   type        = string
-  description = "The ID of the access context manager policy the perimeter lies in"
+  description = "The ID of the access context manager policy the perimeter lies in. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format=\"value(name)\"`."
 }
 
 /******************************************

--- a/4-projects/business_unit_1/prod/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_1/prod/example_restricted_shared_vpc_project.tf
@@ -27,7 +27,7 @@ module "restricted_shared_vpc_project" {
 
   activate_apis                      = ["accesscontextmanager.googleapis.com"]
   vpc_service_control_attach_enabled = "true"
-  vpc_service_control_perimeter_name = "accessPolicies/${var.policy_id}/servicePerimeters/${var.perimeter_name}"
+  vpc_service_control_perimeter_name = "accessPolicies/${var.access_context_manager_policy_id}/servicePerimeters/${var.perimeter_name}"
 
   # Metadata
   project_prefix    = "bu1-p-sample-restricted"

--- a/4-projects/business_unit_1/prod/variables.tf
+++ b/4-projects/business_unit_1/prod/variables.tf
@@ -47,9 +47,9 @@ variable "env_code" {
   default     = "p"
 }
 
-variable "policy_id" {
+variable "access_context_manager_policy_id" {
   type        = string
-  description = "The ID of the access context manager policy the perimeter lies in"
+  description = "The ID of the access context manager policy the perimeter lies in. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format=\"value(name)\"`."
 }
 
 /******************************************

--- a/4-projects/business_unit_2/dev/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_2/dev/example_restricted_shared_vpc_project.tf
@@ -27,7 +27,7 @@ module "restricted_shared_vpc_project" {
 
   activate_apis                      = ["accesscontextmanager.googleapis.com"]
   vpc_service_control_attach_enabled = "true"
-  vpc_service_control_perimeter_name = "accessPolicies/${var.policy_id}/servicePerimeters/${var.perimeter_name}"
+  vpc_service_control_perimeter_name = "accessPolicies/${var.access_context_manager_policy_id}/servicePerimeters/${var.perimeter_name}"
 
   # Metadata
   project_prefix    = "bu2-d-sample-restricted"

--- a/4-projects/business_unit_2/dev/variables.tf
+++ b/4-projects/business_unit_2/dev/variables.tf
@@ -41,9 +41,9 @@ variable "skip_gcloud_download" {
   default     = true
 }
 
-variable "policy_id" {
+variable "access_context_manager_policy_id" {
   type        = string
-  description = "The ID of the access context manager policy the perimeter lies in"
+  description = "The ID of the access context manager policy the perimeter lies in. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format=\"value(name)\"`."
 }
 
 /******************************************

--- a/4-projects/business_unit_2/nonprod/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_2/nonprod/example_restricted_shared_vpc_project.tf
@@ -27,7 +27,7 @@ module "restricted_shared_vpc_project" {
 
   activate_apis                      = ["accesscontextmanager.googleapis.com"]
   vpc_service_control_attach_enabled = "true"
-  vpc_service_control_perimeter_name = "accessPolicies/${var.policy_id}/servicePerimeters/${var.perimeter_name}"
+  vpc_service_control_perimeter_name = "accessPolicies/${var.access_context_manager_policy_id}/servicePerimeters/${var.perimeter_name}"
 
   # Metadata
   project_prefix    = "bu2-n-sample-restricted"

--- a/4-projects/business_unit_2/nonprod/variables.tf
+++ b/4-projects/business_unit_2/nonprod/variables.tf
@@ -41,9 +41,9 @@ variable "skip_gcloud_download" {
   default     = true
 }
 
-variable "policy_id" {
+variable "access_context_manager_policy_id" {
   type        = string
-  description = "The ID of the access context manager policy the perimeter lies in"
+  description = "The ID of the access context manager policy the perimeter lies in. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format=\"value(name)\"`."
 }
 
 /******************************************

--- a/4-projects/business_unit_2/prod/example_restricted_shared_vpc_project.tf
+++ b/4-projects/business_unit_2/prod/example_restricted_shared_vpc_project.tf
@@ -27,7 +27,7 @@ module "restricted_shared_vpc_project" {
 
   activate_apis                      = ["accesscontextmanager.googleapis.com"]
   vpc_service_control_attach_enabled = "true"
-  vpc_service_control_perimeter_name = "accessPolicies/${var.policy_id}/servicePerimeters/${var.perimeter_name}"
+  vpc_service_control_perimeter_name = "accessPolicies/${var.access_context_manager_policy_id}/servicePerimeters/${var.perimeter_name}"
 
   # Metadata
   project_prefix    = "bu2-p-sample-restricted"

--- a/4-projects/business_unit_2/prod/variables.tf
+++ b/4-projects/business_unit_2/prod/variables.tf
@@ -41,9 +41,9 @@ variable "skip_gcloud_download" {
   default     = true
 }
 
-variable "policy_id" {
+variable "access_context_manager_policy_id" {
   type        = string
-  description = "The ID of the access context manager policy the perimeter lies in"
+  description = "The ID of the access context manager policy the perimeter lies in. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format=\"value(name)\"`."
 }
 
 /******************************************

--- a/4-projects/terraform.example.tfvars
+++ b/4-projects/terraform.example.tfvars
@@ -22,6 +22,8 @@ terraform_service_account = "org-terraform@example-project-2334.iam.gserviceacco
 
 default_region = "australia-southeast1"
 
+access_context_manager_policy_id = "000000000000"
+
 /******************************************
   Private DNS Management (Optional)
  *****************************************/

--- a/4-projects/variables.tf
+++ b/4-projects/variables.tf
@@ -35,6 +35,11 @@ variable "default_region" {
   default     = "us-west1"
 }
 
+variable "access_context_manager_policy_id" {
+  type        = string
+  description = "The ID of the access context manager policy the perimeter lies in. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format=\"value(name)\"`."
+}
+
 /******************************************
   Private DNS Management (Optional)
  *****************************************/

--- a/test/fixtures/projects/main.tf
+++ b/test/fixtures/projects/main.tf
@@ -15,63 +15,63 @@
  */
 
 module "projects_bu1_dev" {
-  source                    = "../../../4-projects/business_unit_1/dev"
-  terraform_service_account = var.terraform_sa_email
-  org_id                    = var.org_id
-  billing_account           = var.billing_account
-  policy_id                 = var.policy_id
-  parent_folder             = var.parent_folder
-  perimeter_name            = var.dev_restricted_service_perimeter_name
+  source                           = "../../../4-projects/business_unit_1/dev"
+  terraform_service_account        = var.terraform_sa_email
+  org_id                           = var.org_id
+  billing_account                  = var.billing_account
+  access_context_manager_policy_id = var.policy_id
+  parent_folder                    = var.parent_folder
+  perimeter_name                   = var.dev_restricted_service_perimeter_name
 }
 
 module "projects_bu1_nonprod" {
-  source                    = "../../../4-projects/business_unit_1/nonprod"
-  terraform_service_account = var.terraform_sa_email
-  org_id                    = var.org_id
-  billing_account           = var.billing_account
-  policy_id                 = var.policy_id
-  parent_folder             = var.parent_folder
-  perimeter_name            = var.nonprod_restricted_service_perimeter_name
+  source                           = "../../../4-projects/business_unit_1/nonprod"
+  terraform_service_account        = var.terraform_sa_email
+  org_id                           = var.org_id
+  billing_account                  = var.billing_account
+  access_context_manager_policy_id = var.policy_id
+  parent_folder                    = var.parent_folder
+  perimeter_name                   = var.nonprod_restricted_service_perimeter_name
 }
 
 
 module "projects_bu1_prod" {
-  source                    = "../../../4-projects/business_unit_1/prod"
-  terraform_service_account = var.terraform_sa_email
-  org_id                    = var.org_id
-  billing_account           = var.billing_account
-  policy_id                 = var.policy_id
-  parent_folder             = var.parent_folder
-  perimeter_name            = var.prod_restricted_service_perimeter_name
+  source                           = "../../../4-projects/business_unit_1/prod"
+  terraform_service_account        = var.terraform_sa_email
+  org_id                           = var.org_id
+  billing_account                  = var.billing_account
+  access_context_manager_policy_id = var.policy_id
+  parent_folder                    = var.parent_folder
+  perimeter_name                   = var.prod_restricted_service_perimeter_name
 }
 
 module "projects_bu2_dev" {
-  source                    = "../../../4-projects/business_unit_2/dev"
-  terraform_service_account = var.terraform_sa_email
-  org_id                    = var.org_id
-  billing_account           = var.billing_account
-  policy_id                 = var.policy_id
-  parent_folder             = var.parent_folder
-  perimeter_name            = var.dev_restricted_service_perimeter_name
+  source                           = "../../../4-projects/business_unit_2/dev"
+  terraform_service_account        = var.terraform_sa_email
+  org_id                           = var.org_id
+  billing_account                  = var.billing_account
+  access_context_manager_policy_id = var.policy_id
+  parent_folder                    = var.parent_folder
+  perimeter_name                   = var.dev_restricted_service_perimeter_name
 }
 
 module "projects_bu2_nonprod" {
-  source                    = "../../../4-projects/business_unit_2/nonprod"
-  terraform_service_account = var.terraform_sa_email
-  org_id                    = var.org_id
-  billing_account           = var.billing_account
-  policy_id                 = var.policy_id
-  parent_folder             = var.parent_folder
-  perimeter_name            = var.nonprod_restricted_service_perimeter_name
+  source                           = "../../../4-projects/business_unit_2/nonprod"
+  terraform_service_account        = var.terraform_sa_email
+  org_id                           = var.org_id
+  billing_account                  = var.billing_account
+  access_context_manager_policy_id = var.policy_id
+  parent_folder                    = var.parent_folder
+  perimeter_name                   = var.nonprod_restricted_service_perimeter_name
 }
 
 
 module "projects_bu2_prod" {
-  source                    = "../../../4-projects/business_unit_2/prod"
-  terraform_service_account = var.terraform_sa_email
-  org_id                    = var.org_id
-  billing_account           = var.billing_account
-  policy_id                 = var.policy_id
-  parent_folder             = var.parent_folder
-  perimeter_name            = var.prod_restricted_service_perimeter_name
+  source                           = "../../../4-projects/business_unit_2/prod"
+  terraform_service_account        = var.terraform_sa_email
+  org_id                           = var.org_id
+  billing_account                  = var.billing_account
+  access_context_manager_policy_id = var.policy_id
+  parent_folder                    = var.parent_folder
+  perimeter_name                   = var.prod_restricted_service_perimeter_name
 }

--- a/test/fixtures/projects/variables.tf
+++ b/test/fixtures/projects/variables.tf
@@ -31,7 +31,7 @@ variable "billing_account" {
 
 variable "policy_id" {
   type        = string
-  description = "The ID of the access context manager policy the perimeter lies in"
+  description = "The ID of the access context manager policy the perimeter lies in. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format=\"value(name)\"`."
 }
 
 variable "parent_folder" {


### PR DESCRIPTION
This change makes access context manager policy id usage consistent between 3-networks and 4-projects.