### PR TITLE
update target name servers ip examples

### DIFF
--- a/3-networks/README.md
+++ b/3-networks/README.md
@@ -34,7 +34,7 @@ If you are not able to use dedicated interconnect, you can also use an HA VPN to
 1. Copy terraform wrapper script `cp ../terraform-example-foundation/build/tf-wrapper.sh . ` (modify accordingly based on your current directory)
 1. Ensure wrapper script can be executed `chmod 755 ./tf-wrapper.sh`.
 1. Rename common.auto.example.tfvars to common.auto.tfvars and update the file with values from your environment and bootstrap.
-1. Rename shared.auto.example.tfvars to shared.auto.tfvars and update the file with the target_name_server_addresses.
+1. Rename shared.auto.example.tfvars to shared.auto.tfvars and update the file with the target_name_server_addresses (the list of target name servers for the DNS forwarding zone in the DNS Hub).
 1. Rename access_context.auto.example.tfvars to access_context.auto.tfvars and update the file with the access_context_manager_policy_id.
 1. Commit changes with `git add .` and `git commit -m 'Your message'`
 1. You will need only once to manually plan + apply the `shared` environment since dev, nonprod and prod depend on it.

--- a/3-networks/shared.auto.example.tfvars
+++ b/3-networks/shared.auto.example.tfvars
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-target_name_server_addresses = ["8.8.8.8", "8.8.8.4"]
+target_name_server_addresses = ["192.168.0.1", "192.168.0.2"]

--- a/test/fixtures/dns_hub/main.tf
+++ b/test/fixtures/dns_hub/main.tf
@@ -19,7 +19,7 @@ module "dns_hub" {
   default_region1              = "us-central1"
   default_region2              = "us-west1"
   domain                       = var.domain
-  target_name_server_addresses = ["8.8.8.8", "8.8.8.4"]
+  target_name_server_addresses = ["192.168.0.1", "192.168.0.2"]
   terraform_service_account    = var.terraform_sa_email
   parent_folder                = var.parent_folder
   org_id                       = var.org_id


### PR DESCRIPTION
This PR updates the values fro the examples for the target name servers used in the DNS forwarding zone of the DNS Hub