### PR TITLE
add standard project labels for 1-org and 2-environments projects

### DIFF
--- a/1-org/envs/shared/projects.tf
+++ b/1-org/envs/shared/projects.tf
@@ -32,8 +32,13 @@ module "org_audit_logs" {
   activate_apis               = ["logging.googleapis.com", "bigquery.googleapis.com"]
 
   labels = {
-    environment      = "prod"
-    application_name = "org-logging"
+    environment       = "prod"
+    application_name  = "org-logging"
+    billing_code      = "1234"
+    primary_contact   = "example1"
+    secondary_contact = "example2"
+    business_code     = "abcd"
+    env_code          = "p"
   }
 }
 
@@ -51,8 +56,13 @@ module "org_billing_logs" {
   activate_apis               = ["logging.googleapis.com", "bigquery.googleapis.com"]
 
   labels = {
-    environment      = "prod"
-    application_name = "org-billing-logs"
+    environment       = "prod"
+    application_name  = "org-billing-logs"
+    billing_code      = "1234"
+    primary_contact   = "example1"
+    secondary_contact = "example2"
+    business_code     = "abcd"
+    env_code          = "p"
   }
 }
 
@@ -74,8 +84,13 @@ module "org_secrets" {
   activate_apis               = ["logging.googleapis.com", "secretmanager.googleapis.com"]
 
   labels = {
-    environment      = "prod"
-    application_name = "org-secrets"
+    environment       = "prod"
+    application_name  = "org-secrets"
+    billing_code      = "1234"
+    primary_contact   = "example1"
+    secondary_contact = "example2"
+    business_code     = "abcd"
+    env_code          = "p"
   }
 }
 
@@ -96,8 +111,13 @@ module "interconnect" {
   skip_gcloud_download        = var.skip_gcloud_download
 
   labels = {
-    environment      = "prod"
-    application_name = "org-interconnect"
+    environment       = "prod"
+    application_name  = "org-interconnect"
+    billing_code      = "1234"
+    primary_contact   = "example1"
+    secondary_contact = "example2"
+    business_code     = "abcd"
+    env_code          = "p"
   }
 }
 
@@ -119,8 +139,13 @@ module "scc_notifications" {
   skip_gcloud_download        = var.skip_gcloud_download
 
   labels = {
-    environment      = "prod"
-    application_name = "org-scc"
+    environment       = "prod"
+    application_name  = "org-scc"
+    billing_code      = "1234"
+    primary_contact   = "example1"
+    secondary_contact = "example2"
+    business_code     = "abcd"
+    env_code          = "p"
   }
 }
 
@@ -149,7 +174,12 @@ module "dns_hub" {
   ]
 
   labels = {
-    environment      = "prod"
-    application_name = "org-dns-hub"
+    environment       = "prod"
+    application_name  = "org-dns-hub"
+    billing_code      = "1234"
+    primary_contact   = "example1"
+    secondary_contact = "example2"
+    business_code     = "abcd"
+    env_code          = "p"
   }
 }

--- a/2-environments/modules/env_baseline/monitoring.tf
+++ b/2-environments/modules/env_baseline/monitoring.tf
@@ -35,7 +35,12 @@ module "monitoring_project" {
   ]
 
   labels = {
-    environment      = var.env
-    application_name = "env-monitoring"
+    environment       = var.env
+    application_name  = "env-monitoring"
+    billing_code      = "1234"
+    primary_contact   = "example1"
+    secondary_contact = "example2"
+    business_code     = "abcd"
+    env_code          = var.environment_code
   }
 }

--- a/2-environments/modules/env_baseline/networking.tf
+++ b/2-environments/modules/env_baseline/networking.tf
@@ -38,8 +38,13 @@ module "base_shared_vpc_host_project" {
   ]
 
   labels = {
-    environment      = var.env
-    application_name = "base-shared-vpc-host"
+    environment       = var.env
+    application_name  = "base-shared-vpc-host"
+    billing_code      = "1234"
+    primary_contact   = "example1"
+    secondary_contact = "example2"
+    business_code     = "abcd"
+    env_code          = var.environment_code
   }
 }
 
@@ -65,7 +70,12 @@ module "restricted_shared_vpc_host_project" {
   ]
 
   labels = {
-    environment      = var.env
-    application_name = "restricted-shared-vpc-host"
+    environment       = var.env
+    application_name  = "restricted-shared-vpc-host"
+    billing_code      = "1234"
+    primary_contact   = "example1"
+    secondary_contact = "example2"
+    business_code     = "abcd"
+    env_code          = var.environment_code
   }
 }

--- a/2-environments/modules/env_baseline/secrets.tf
+++ b/2-environments/modules/env_baseline/secrets.tf
@@ -34,7 +34,12 @@ module "env_secrets" {
   skip_gcloud_download        = var.skip_gcloud_download
 
   labels = {
-    environment      = var.env
-    application_name = "env-secrets"
+    environment       = var.env
+    application_name  = "env-secrets"
+    billing_code      = "1234"
+    primary_contact   = "example1"
+    secondary_contact = "example2"
+    business_code     = "abcd"
+    env_code          = var.environment_code
   }
 }


### PR DESCRIPTION
adding standard project labels for 1-org and 2-environments projects:

- 1-org
  - logging
  - billing
  - secrets
  - interconnect
  - scc
  - dns hub  
- 2-environments
  - secrets
  - monitoring
  - base shared vpc
  - restricted shared vpc

Fixes #189 