### PR TITLE
fix: branch so that regex still works for cloud build with new environment names

### DIFF
--- a/0-bootstrap/main.tf
+++ b/0-bootstrap/main.tf
@@ -162,7 +162,7 @@ module "cloudbuild_bootstrap" {
 
   terraform_apply_branches = [
     "development",
-    "non-production",
+    "non\\-production", //non-production needs a \ to ensure regex matches correct branches.
     "production"
   ]
 }

--- a/test/integration/bootstrap/controls/gcloud_cloudbuild.rb
+++ b/test/integration/bootstrap/controls/gcloud_cloudbuild.rb
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 cloudbuild_project_id = attribute('cloudbuild_project_id')
-apply_branches_regex = '(development|non-production|production)'
-plan_branches_regex = '[^development|non-production|production]'
+apply_branches_regex = '(development|non\-production|production)'
+plan_branches_regex = '[^development|non\-production|production]'
 cloud_source_repos = [
   'gcp-bootstrap',
   'gcp-org',


### PR DESCRIPTION
Currently the branch `non-production` triggers both apply and plan for cloud build, this change fixes that behavior. More details on bug raised on bootstrap module https://github.com/terraform-google-modules/terraform-google-bootstrap/issues/52