### PR TITLE
fix: rename symlinks to new naming convention for environments

### DIFF
--- a/4-projects/business_unit_1/development/dev.auto.tfvars
+++ b/4-projects/business_unit_1/development/dev.auto.tfvars
@@ -1,1 +1,0 @@
-../../dev.auto.tfvars

--- a/4-projects/business_unit_1/development/development.auto.tfvars
+++ b/4-projects/business_unit_1/development/development.auto.tfvars
@@ -1,0 +1,1 @@
+../../development.auto.tfvars

--- a/4-projects/business_unit_1/non-production/non-production.auto.tfvars
+++ b/4-projects/business_unit_1/non-production/non-production.auto.tfvars
@@ -1,0 +1,1 @@
+../../non-production.auto.tfvars

--- a/4-projects/business_unit_1/non-production/nonprod.auto.tfvars
+++ b/4-projects/business_unit_1/non-production/nonprod.auto.tfvars
@@ -1,1 +1,0 @@
-../../nonprod.auto.tfvars

--- a/4-projects/business_unit_1/production/prod.auto.tfvars
+++ b/4-projects/business_unit_1/production/prod.auto.tfvars
@@ -1,1 +1,0 @@
-../../prod.auto.tfvars

--- a/4-projects/business_unit_1/production/production.auto.tfvars
+++ b/4-projects/business_unit_1/production/production.auto.tfvars
@@ -1,0 +1,1 @@
+../../production.auto.tfvars

--- a/4-projects/business_unit_2/development/dev.auto.tfvars
+++ b/4-projects/business_unit_2/development/dev.auto.tfvars
@@ -1,1 +1,0 @@
-../../dev.auto.tfvars

--- a/4-projects/business_unit_2/development/development.auto.tfvars
+++ b/4-projects/business_unit_2/development/development.auto.tfvars
@@ -1,0 +1,1 @@
+../../development.auto.tfvars

--- a/4-projects/business_unit_2/non-production/non-production.auto.tfvars
+++ b/4-projects/business_unit_2/non-production/non-production.auto.tfvars
@@ -1,0 +1,1 @@
+../../non-production.auto.tfvars

--- a/4-projects/business_unit_2/non-production/nonprod.auto.tfvars
+++ b/4-projects/business_unit_2/non-production/nonprod.auto.tfvars
@@ -1,1 +1,0 @@
-../../nonprod.auto.tfvars

--- a/4-projects/business_unit_2/production/prod.auto.tfvars
+++ b/4-projects/business_unit_2/production/prod.auto.tfvars
@@ -1,1 +1,0 @@
-../../prod.auto.tfvars

--- a/4-projects/business_unit_2/production/production.auto.tfvars
+++ b/4-projects/business_unit_2/production/production.auto.tfvars
@@ -1,0 +1,1 @@
+../../production.auto.tfvars


### PR DESCRIPTION
Fixes https://github.com/terraform-google-modules/terraform-example-foundation/issues/199