### PR TITLE
Fix typos, instruction order and project name

### DIFF
--- a/0-bootstrap/README.md
+++ b/0-bootstrap/README.md
@@ -25,8 +25,9 @@ If you are using the `jenkins_bootstrap` sub-module, please see [README-Jenkins]
 1. Run `terraform init`
 1. Run `terraform plan` and review output
 1. Run `terraform apply`
-1. Copy the backend by running `cp backend.tf.example backend.tf` and update `backend.tf` with your bucket from the apply step (The value from `terraform output gcs_bucket_tfstate`)
-1. Re-run `terraform init` agree to copy state to gcs when prompted
+1. Run `terraform output gcs_bucket_tfstate` to get your GCS bucket from the apply step
+1. Copy the backend by running `cp backend.tf.example backend.tf` and update `backend.tf` with your GCS bucket.
+1. Re-run `terraform init` agree to copy state to GCS when prompted
     1. (Optional) Run `terraform apply` to verify state is configured correctly
 
 ### (Optional) State backends for running terraform locally

--- a/1-org/README.md
+++ b/1-org/README.md
@@ -1,6 +1,6 @@
 # 1-org
 
-The purpose of this step is to setup top level shared folders, monitoring & networking projects, org level logging and set baseline security settings through organizational policy.
+The purpose of this step is to set up top level shared folders, monitoring & networking projects, org level logging and set baseline security settings through organizational policy.
 
 ## Prerequisites
 
@@ -23,7 +23,7 @@ You can choose not to enable the Data Access logs by setting variable `data_acce
 1. Copy terraform wrapper script `cp ../terraform-example-foundation/build/tf-wrapper.sh . ` to the root of your new repository (modify accordingly based on your current directory).
 1. Ensure wrapper script can be executed `chmod 755 ./tf-wrapper.sh`.
 1. Check if your organization already has a Access Context Manager Policy `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format="value(name)"`.
-1. Rename `terraform.example.tfvars` to `terraform.tfvars` and update the file with values from your environment and bootstrap (you can re-run `terraform output` in the 0-bootstrap directory to find these values). Make sure that `default_region` is set to a valid [BigQuery dataset region](https://cloud.google.com/bigquery/docs/locations). Also if the previous step showed a numeric value, make sure to un-comment the variable `create_access_context_manager_access_policy = false`.
+1. Rename `./envs/shared/terraform.example.tfvars` to `./envs/shared/terraform.tfvars` and update the file with values from your environment and bootstrap (you can re-run `terraform output` in the 0-bootstrap directory to find these values). Make sure that `default_region` is set to a valid [BigQuery dataset region](https://cloud.google.com/bigquery/docs/locations). Also if the previous step showed a numeric value, make sure to un-comment the variable `create_access_context_manager_access_policy = false`.
 1. Commit changes with `git add .` and `git commit -m 'Your message'`
 1. Push your plan branch to trigger a plan `git push --set-upstream origin plan` (the branch `plan` is not a special one. Any branch which name is different from `development`, `non-production` or `production` will trigger a terraform plan).
     1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
@@ -44,7 +44,7 @@ You can choose not to enable the Data Access logs by setting variable `data_acce
 1. Copy terraform wrapper script `cp ../terraform-example-foundation/build/tf-wrapper.sh . ` to the root of your new repository (modify accordingly based on your current directory).
 1. Ensure wrapper script can be executed `chmod 755 ./tf-wrapper.sh`.
 1. Check if your organization already has a Access Context Manager Policy `gcloud access-context-manager policies list --organization YOUR-ORGANIZATION_ID --format="value(name)"`.
-1. Rename `terraform.example.tfvars` to `terraform.tfvars` and update the file with values from your environment and bootstrap (you can re-run `terraform output` in the 0-bootstrap directory to find these values). Make sure that `default_region` is set to a valid [BigQuery dataset region](https://cloud.google.com/bigquery/docs/locations). Also if the previous step showed a numeric value, make sure to un-comment the variable `create_access_context_manager_access_policy = false`.
+1. Rename `./envs/shared/terraform.example.tfvars` to `./envs/shared/terraform.tfvars` and update the file with values from your environment and bootstrap (you can re-run `terraform output` in the 0-bootstrap directory to find these values). Make sure that `default_region` is set to a valid [BigQuery dataset region](https://cloud.google.com/bigquery/docs/locations). Also if the previous step showed a numeric value, make sure to un-comment the variable `create_access_context_manager_access_policy = false`.
 1. Commit changes with `git add .` and `git commit -m 'Your message'`
 1. Push your plan branch `git push --set-upstream origin plan`. The branch `plan` is not a special one. Any branch which name is different from `development`, `non-production` or `production` will trigger a terraform plan.
     - Assuming you configured an automatic trigger in your Jenkins Master (see [Jenkins sub-module README](../0-bootstrap/modules/jenkins-agent)), this will trigger a plan. You can also trigger a Jenkins job manually. Given the many options to do this in Jenkins, it is out of the scope of this document see [Jenkins website](http://www.jenkins.io) for more details.

--- a/2-environments/README.md
+++ b/2-environments/README.md
@@ -1,6 +1,6 @@
 # 2-environments
 
-The purpose of this step is to set updevelopment,non-production, and production environments within the GCP organization.
+The purpose of this step is to set up development, non-production and production environments within the GCP organization.
 
 ## Prerequisites
 
@@ -20,8 +20,6 @@ The purpose of this step is to set updevelopment,non-production, and production 
 1. Ensure wrapper script can be executed `chmod 755 ./tf-wrapper.sh`.
 1. Rename `terraform.example.tfvars` to `terraform.tfvars` and update the file with values from your environment and bootstrap (you can re-run `terraform output` in the 0-bootstrap directory to find these values).
 1. Commit changes with `git add .` and `git commit -m 'Your message'`
-
-#### If using Cloud Build
 1. Push your plan branch to trigger a plan for all environments `git push --set-upstream origin plan` (the branch `plan` is not a special one. Any branch which name is different from `development`, `non-production` or `production` will trigger a terraform plan).
     1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
 1. Merge changes to development with `git checkout -b development` and `git push origin development`

--- a/3-networks/README.md
+++ b/3-networks/README.md
@@ -24,7 +24,6 @@ If you are not able to use dedicated interconnect, you can also use an HA VPN to
 1. Update in the file `vpn.tf` the values for `environment`, `vpn_psk_secret_name`, `on_prem_router_ip_address1`, `on_prem_router_ip_address2` and `bgp_peer_asn`.
 1. Verify other default values are valid for your environment.
 
-
 ### Setup to run via Cloud Build
 
 1. Clone repo `gcloud source repos clone gcp-networks --project=YOUR_CLOUD_BUILD_PROJECT_ID`

--- a/3-networks/envs/development/README.md
+++ b/3-networks/envs/development/README.md
@@ -1,6 +1,6 @@
 # 3-networks/development
 
-The purpose of this step is to setup base and restricted shared VPCs with default DNS, NAT (optional), Private Service networking, VPC service controls, onprem dedicated interconnect, onprem VPN and baseline firewall rules for environment development.
+The purpose of this step is to set up base and restricted shared VPCs with default DNS, NAT (optional), Private Service networking, VPC service controls, onprem dedicated interconnect, onprem VPN and baseline firewall rules for environment development.
 
 ## Prerequisites
 

--- a/3-networks/envs/non-production/README.md
+++ b/3-networks/envs/non-production/README.md
@@ -1,6 +1,6 @@
 # 3-networks/non-production
 
-The purpose of this step is to setup base and restricted shared VPCs with default DNS, NAT (optional), Private Service networking, VPC service controls, onprem dedicated interconnect, onprem VPN and baseline firewall rules for environment non-production.
+The purpose of this step is to set up base and restricted shared VPCs with default DNS, NAT (optional), Private Service networking, VPC service controls, onprem dedicated interconnect, onprem VPN and baseline firewall rules for environment non-production.
 
 ## Prerequisites
 

--- a/3-networks/envs/production/README.md
+++ b/3-networks/envs/production/README.md
@@ -1,6 +1,6 @@
 # 3-networks/production
 
-The purpose of this step is to setup base and restricted shared VPCs with default DNS, NAT (optional), Private Service networking, VPC service controls, onprem dedicated interconnect, onprem VPN and baseline firewall rules for environment production.
+The purpose of this step is to set up base and restricted shared VPCs with default DNS, NAT (optional), Private Service networking, VPC service controls, onprem dedicated interconnect, onprem VPN and baseline firewall rules for environment production.
 
 ## Prerequisites
 

--- a/3-networks/envs/shared/README.md
+++ b/3-networks/envs/shared/README.md
@@ -1,6 +1,6 @@
 # 3-networks/shared
 
-The purpose of this step is to setup the global [DNS Hub](https://cloud.google.com/blog/products/networking/cloud-forwarding-peering-and-zones) that will be used by all environments.
+The purpose of this step is to set up the global [DNS Hub](https://cloud.google.com/blog/products/networking/cloud-forwarding-peering-and-zones) that will be used by all environments.
 
 ## Prerequisites
 

--- a/4-projects/README.md
+++ b/4-projects/README.md
@@ -1,6 +1,6 @@
 # 4-projects
 
-The purpose of this step is to setup folder structure and projects for applications, which are connected as service projects to the shared VPC created in the previous stage. Optionally, you can also create dedicated DNS zones and subnets for these applications.
+The purpose of this step is to set up folder structure and projects for applications, which are connected as service projects to the shared VPC created in the previous stage.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ This will create the following folder & project structure:
 example-organization
 └── fldr-common
     ├── prj-c-logging
-    ├── prj-c-org-billing-logs
+    ├── prj-c-billing-logs
     ├── prj-c-dns-hub
-    ├── prj-c-org-interconnect
+    ├── prj-c-interconnect
     ├── prj-c-scc
-    └── prj-c-org-secrets
+    └── prj-c-secrets
 ```
 
 #### Logs
@@ -158,19 +158,19 @@ example-organization/
     ├── prj-bu2-d-sample-base
     └── prj-bu2-d-sample-restrict
 └── fldr-non-production
-    ├── prj-bu1-d-sample-floating
-    ├── prj-bu1-d-sample-base
-    ├── prj-bu1-d-sample-restrict
-    ├── prj-bu2-d-sample-floating
-    ├── prj-bu2-d-sample-base
-    └── prj-bu2-d-sample-restrict
+    ├── prj-bu1-n-sample-floating
+    ├── prj-bu1-n-sample-base
+    ├── prj-bu1-n-sample-restrict
+    ├── prj-bu2-n-sample-floating
+    ├── prj-bu2-n-sample-base
+    └── prj-bu2-n-sample-restrict
 └── fldr-production
-    ├── prj-bu1-d-sample-floating
-    ├── prj-bu1-d-sample-base
-    ├── prj-bu1-d-sample-restrict
-    ├── prj-bu2-d-sample-floating
-    ├── prj-bu2-d-sample-base
-    └── prj-bu2-d-sample-restrict
+    ├── prj-bu1-p-sample-floating
+    ├── prj-bu1-p-sample-base
+    ├── prj-bu1-p-sample-restrict
+    ├── prj-bu2-p-sample-floating
+    ├── prj-bu2-p-sample-base
+    └── prj-bu2-p-sample-restrict
 ```
 The code in this step includes two options for creating projects.
 The first is the standard projects module which creates a project per environment and the second creates a standalone project for one environment.
@@ -185,12 +185,12 @@ Once all steps above have been executed your GCP organization should represent t
 ```
 example-organization
 └── fldr-common
-    ├── prj-p-org-audit-logs
-    ├── prj-p-org-billing-logs
-    ├── prj-p-org-dns-hub
-    ├── prj-p-org-interconnect
-    ├── prj-p-org-scc
-    └── prj-p-org-secrets
+    ├── prj-c-logging
+    ├── prj-c-billing-logs
+    ├── prj-c-dns-hub
+    ├── prj-c-interconnect
+    ├── prj-c-scc
+    └── prj-c-secrets
 └── fldr-development
     ├── prj-bu1-d-sample-floating
     ├── prj-bu1-d-sample-base
@@ -203,23 +203,23 @@ example-organization
     ├── prj-d-shared-base
     └── prj-d-shared-restricted
 └── fldr-non-production
-    ├── prj-bu1-d-sample-floating
-    ├── prj-bu1-d-sample-base
-    ├── prj-bu1-d-sample-restrict
-    ├── prj-bu2-d-sample-floating
-    ├── prj-bu2-d-sample-base
-    ├── prj-bu2-d-sample-restrict
+    ├── prj-bu1-n-sample-floating
+    ├── prj-bu1-n-sample-base
+    ├── prj-bu1-n-sample-restrict
+    ├── prj-bu2-n-sample-floating
+    ├── prj-bu2-n-sample-base
+    ├── prj-bu2-n-sample-restrict
     ├── prj-n-monitoring
     ├── prj-n-secrets
     ├── prj-n-shared-base
     └── prj-n-shared-restricted
 └── fldr-production
-    ├── prj-bu1-d-sample-floating
-    ├── prj-bu1-d-sample-base
-    ├── prj-bu1-d-sample-restrict
-    ├── prj-bu2-d-sample-floating
-    ├── prj-bu2-d-sample-base
-    ├── prj-bu2-d-sample-restrict
+    ├── prj-bu1-p-sample-floating
+    ├── prj-bu1-p-sample-base
+    ├── prj-bu1-p-sample-restrict
+    ├── prj-bu2-p-sample-floating
+    ├── prj-bu2-p-sample-base
+    ├── prj-bu2-p-sample-restrict
     ├── prj-p-monitoring
     ├── prj-p-secrets
     ├── prj-p-shared-base


### PR DESCRIPTION
Fixes for:
- typos
- `to setup` -> `to set up`
- project name
- remove extra heading
- add full path to tfvars file