### PR TITLE
pin tools image to 0.12.0

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -135,4 +135,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'


### PR DESCRIPTION
- pin tools image to 0.12.0 to prevent CI breakage with tf 0.13
- we can revert this once most modules have the version constraints relaxed