### PR TITLE
[WIP] Set hipaa audit controls

### DIFF
--- a/1-org/envs/shared/log_sinks.tf
+++ b/1-org/envs/shared/log_sinks.tf
@@ -39,7 +39,7 @@ resource "random_string" "suffix" {
 
 module "log_export_to_biqquery" {
   source                 = "terraform-google-modules/log-export/google"
-  version                = "~> 4.0"
+  version                = "~> 5.0"
   destination_uri        = module.bigquery_destination.destination_uri
   filter                 = local.all_logs_filter
   log_sink_name          = "sk-c-logging-bq"
@@ -51,11 +51,11 @@ module "log_export_to_biqquery" {
 
 module "bigquery_destination" {
   source                      = "terraform-google-modules/log-export/google//modules/bigquery"
-  version                     = "~> 4.0"
+  version                     = "~> 5.0"
   project_id                  = module.org_audit_logs.project_id
   dataset_name                = "audit_logs"
   log_sink_writer_identity    = module.log_export_to_biqquery.writer_identity
-  default_table_expiration_ms = var.audit_logs_table_expiration_ms
+  default_table_expiration_ms = var.bigquery_audit_logs_expiration_days * 8.64 * pow(10, 7)
 }
 
 /******************************************
@@ -64,7 +64,7 @@ module "bigquery_destination" {
 
 module "log_export_to_storage" {
   source                 = "terraform-google-modules/log-export/google"
-  version                = "~> 4.0"
+  version                = "~> 5.0"
   destination_uri        = module.storage_destination.destination_uri
   filter                 = local.all_logs_filter
   log_sink_name          = "sk-c-logging-bkt"
@@ -76,12 +76,13 @@ module "log_export_to_storage" {
 
 module "storage_destination" {
   source                   = "terraform-google-modules/log-export/google//modules/storage"
-  version                  = "~> 4.0"
+  version                  = "~> 5.0"
   project_id               = module.org_audit_logs.project_id
   storage_bucket_name      = "bkt-${module.org_audit_logs.project_id}-org-logs-${random_string.suffix.result}"
   log_sink_writer_identity = module.log_export_to_storage.writer_identity
-  bucket_policy_only       = true
   location                 = var.log_export_storage_location
+  expiration_days          = var.storage_audit_logs_expiration_days
+  storage_class            = "COLDLINE"
 }
 
 /******************************************
@@ -90,7 +91,7 @@ module "storage_destination" {
 
 module "log_export_to_pubsub" {
   source                 = "terraform-google-modules/log-export/google"
-  version                = "~> 4.0"
+  version                = "~> 5.0"
   destination_uri        = module.pubsub_destination.destination_uri
   filter                 = local.all_logs_filter
   log_sink_name          = "sk-c-logging-pub"
@@ -102,7 +103,7 @@ module "log_export_to_pubsub" {
 
 module "pubsub_destination" {
   source                   = "terraform-google-modules/log-export/google//modules/pubsub"
-  version                  = "~> 4.0"
+  version                  = "~> 5.0"
   project_id               = module.org_audit_logs.project_id
   topic_name               = "tp-org-logs-${random_string.suffix.result}"
   log_sink_writer_identity = module.log_export_to_pubsub.writer_identity

--- a/1-org/envs/shared/log_sinks.tf
+++ b/1-org/envs/shared/log_sinks.tf
@@ -34,7 +34,8 @@ resource "random_string" "suffix" {
 }
 
 /******************************************
-  Send logs to BigQury
+  Send logs to BigQuery.
+  These logs should be used for general querying beyond Stackdriver.
 *****************************************/
 
 module "log_export_to_biqquery" {
@@ -60,6 +61,7 @@ module "bigquery_destination" {
 
 /******************************************
   Send logs to Storage
+  These logs should be used for long term retention for compliance requirements.
 *****************************************/
 
 module "log_export_to_storage" {

--- a/1-org/envs/shared/variables.tf
+++ b/1-org/envs/shared/variables.tf
@@ -49,10 +49,16 @@ variable "domains_to_allow" {
   type        = list(string)
 }
 
-variable "audit_logs_table_expiration_ms" {
-  description = "Period before tables expire for all audit logs in milliseconds. Default is 30 days."
+variable "bigquery_audit_logs_expiration_days" {
+  description = "Days to retain logs in BigQuery."
   type        = number
-  default     = 2592000000
+  default     = 365 # 1 year
+}
+
+variable "storage_audit_logs_expiration_days" {
+  description = "Days to retain logs in GCS."
+  type        = number
+  default     = 7*365 # 7 years
 }
 
 variable "scc_notification_name" {


### PR DESCRIPTION
HIPAA requires 6 years of audit log retention (see e.g. https://www.aptible.com/documentation/faq/comply/hipaa-audit-logs.html). Thus, we set the retention to 7 years forGCS to ensure compliance and use COLDLINE storage class for cost efficiency. 

We use BigQuery for general log querying and thus set this to 1 year retention.

Dependencies:
https://github.com/terraform-google-modules/terraform-google-log-export/pull/63
https://github.com/terraform-google-modules/terraform-google-log-export/pull/64