### PR TITLE
fix: remove shielded VM org policy

### DIFF
--- a/1-org/envs/shared/README.md
+++ b/1-org/envs/shared/README.md
@@ -16,7 +16,6 @@
 | dns\_hub\_project\_budget\_amount | The amount to use as the budget for the DNS hub project. | `number` | `1000` | no |
 | domains\_to\_allow | The list of domains to allow users from in IAM. | `list(string)` | n/a | yes |
 | enable\_os\_login\_policy | Enable OS Login policy. | `bool` | `false` | no |
-| enable\_shielded\_vm\_policy | Enable Shielded VMs policy. | `bool` | `false` | no |
 | interconnect\_project\_alert\_pubsub\_topic | The name of the Cloud Pub/Sub topic where budget related messages will be published, in the form of `projects/{project_id}/topics/{topic_id}` for the interconnect project. | `string` | `null` | no |
 | interconnect\_project\_alert\_spent\_percents | A list of percentages of the budget to alert on when threshold is exceeded for the interconnect project. | `list(number)` | <pre>[<br>  0.5,<br>  0.75,<br>  0.9,<br>  0.95<br>]</pre> | no |
 | interconnect\_project\_budget\_amount | The amount to use as the budget for the interconnect project. | `number` | `1000` | no |

--- a/1-org/envs/shared/org_policy.tf
+++ b/1-org/envs/shared/org_policy.tf
@@ -91,18 +91,6 @@ module "org_shared_vpc_lien_removal" {
   constraint      = "constraints/compute.restrictXpnProjectLienRemoval"
 }
 
-module "org_shared_require_shielded_vm" {
-  source          = "terraform-google-modules/org-policy/google"
-  count           = var.enable_shielded_vm_policy ? 1 : 0
-  version         = "~> 3.0"
-  organization_id = local.organization_id
-  folder_id       = local.folder_id
-  policy_for      = local.policy_for
-  policy_type     = "boolean"
-  enforce         = "true"
-  constraint      = "constraints/compute.requireShieldedVm"
-}
-
 module "org_shared_require_os_login" {
   source          = "terraform-google-modules/org-policy/google"
   count           = var.enable_os_login_policy ? 1 : 0

--- a/1-org/envs/shared/variables.tf
+++ b/1-org/envs/shared/variables.tf
@@ -49,12 +49,6 @@ variable "domains_to_allow" {
   type        = list(string)
 }
 
-variable "enable_shielded_vm_policy" {
-  description = "Enable Shielded VMs policy."
-  type        = bool
-  default     = false
-}
-
 variable "enable_os_login_policy" {
   description = "Enable OS Login policy."
   type        = bool

--- a/test/fixtures/org/main.tf
+++ b/test/fixtures/org/main.tf
@@ -33,6 +33,5 @@ module "test" {
   create_access_context_manager_access_policy = false
   audit_logs_table_delete_contents_on_destroy = true
   log_export_storage_force_destroy            = true
-  enable_shielded_vm_policy                   = true
   enable_os_login_policy                      = true
 }

--- a/test/integration/org/controls/gcloud_policy.rb
+++ b/test/integration/org/controls/gcloud_policy.rb
@@ -22,7 +22,6 @@ boolean_policy_constraints = [
   'constraints/compute.vmExternalIpAccess',
   'constraints/compute.skipDefaultNetworkCreation',
   'constraints/compute.requireOsLogin',
-  'constraints/compute.requireShieldedVm',
   'constraints/compute.restrictXpnProjectLienRemoval',
   'constraints/sql.restrictPublicIp',
   'constraints/iam.disableServiceAccountKeyCreation',


### PR DESCRIPTION
Remove shielded VM organization policy as it is no longer necessary