### PR TITLE
fix: Remove 'gcp-bootstrap' repository

### DIFF
--- a/0-bootstrap/main.tf
+++ b/0-bootstrap/main.tf
@@ -154,7 +154,6 @@ module "cloudbuild_bootstrap" {
   }
 
   cloud_source_repos = [
-    "gcp-bootstrap",
     "gcp-org",
     "gcp-environments",
     "gcp-networks",

--- a/test/integration/bootstrap/controls/gcloud_cloudbuild.rb
+++ b/test/integration/bootstrap/controls/gcloud_cloudbuild.rb
@@ -15,7 +15,6 @@
 cloudbuild_project_id = attribute('cloudbuild_project_id')
 branches_regex = '^(development|non\\-production|production)$'
 cloud_source_repos = [
-  'gcp-bootstrap',
   'gcp-org',
   'gcp-environments',
   'gcp-networks',

--- a/test/integration/bootstrap/controls/gcp_cloudbuild.rb
+++ b/test/integration/bootstrap/controls/gcp_cloudbuild.rb
@@ -15,7 +15,6 @@
 cloudbuild_project_id = attribute('cloudbuild_project_id')
 gcs_bucket_cloudbuild_artifacts = attribute('gcs_bucket_cloudbuild_artifacts')
 cloud_source_repos = [
-  'gcp-bootstrap',
   'gcp-org',
   'gcp-environments',
   'gcp-networks',


### PR DESCRIPTION
As `0-bootstrap` is meant to be run only once manually, it may be worthwhile removing the repository.

Closes #293 