### PR TITLE
Change module name to match module references

### DIFF
--- a/1-org/envs/shared/scc_notification.tf
+++ b/1-org/envs/shared/scc_notification.tf
@@ -29,7 +29,7 @@ resource "google_pubsub_subscription" "scc_notification_subscription" {
   project = module.scc_notifications.project_id
 }
 
-module "scc_notification" {
+module "scc_notifications" {
   source  = "terraform-google-modules/gcloud/google"
   version = "~> 1.1.0"
 


### PR DESCRIPTION
Module name "scc_notification" does not match later references to "module.scc.notifications