### PR TITLE
Add missing link in shared env

### DIFF
--- a/3-networks/envs/shared/access_context.auto.tfvars
+++ b/3-networks/envs/shared/access_context.auto.tfvars
@@ -1,0 +1,1 @@
+../../access_context.auto.tfvars


### PR DESCRIPTION
Add symbolic link from the shared env to the top level access_context.auto.tfvars. The instructions in 3-networks/README.md assume this link exists, and step 11 fails if you don't create it.