### PR TITLE
Clone policies repo once

### DIFF
--- a/build/tf-wrapper.sh
+++ b/build/tf-wrapper.sh
@@ -138,10 +138,9 @@ tf_validate() {
       cd "$path" || exit
       terraform show -json "${tmp_plan}/${tf_component}-${tf_env}.tfplan" > "${tf_env}.json" || exit 32
       if [[ "$policy_type" == "CLOUDSOURCE" ]]; then
-        if [ ! -f /workspace/.policies-cloned ]; then
-          # only clone the policies repo once
+        # Check if $policy_file_path is empty so we clone the policies repo only once
+        if [ -z "$(ls -A ${policy_file_path} 2> /dev/null)" ]; then
           gcloud source repos clone gcp-policies "${policy_file_path}" --project="${project_id}" || exit 34
-          touch /workspace/.policies-cloned
         fi
       fi
       terraform-validator validate "${tf_env}.json" --policy-path="${policy_file_path}" --project="${project_id}" || exit 33

--- a/build/tf-wrapper.sh
+++ b/build/tf-wrapper.sh
@@ -138,7 +138,11 @@ tf_validate() {
       cd "$path" || exit
       terraform show -json "${tmp_plan}/${tf_component}-${tf_env}.tfplan" > "${tf_env}.json" || exit 32
       if [[ "$policy_type" == "CLOUDSOURCE" ]]; then
-        gcloud source repos clone gcp-policies "${policy_file_path}" --project="${project_id}" || exit 34
+        if [ ! -f /workspace/.policies-cloned ]; then
+          # only clone the policies repo once
+          gcloud source repos clone gcp-policies "${policy_file_path}" --project="${project_id}" || exit 34
+          touch /workspace/.policies-cloned
+        fi
       fi
       terraform-validator validate "${tf_env}.json" --policy-path="${policy_file_path}" --project="${project_id}" || exit 33
       cd "$base_dir" || exit

--- a/build/tf-wrapper.sh
+++ b/build/tf-wrapper.sh
@@ -139,7 +139,7 @@ tf_validate() {
       terraform show -json "${tmp_plan}/${tf_component}-${tf_env}.tfplan" > "${tf_env}.json" || exit 32
       if [[ "$policy_type" == "CLOUDSOURCE" ]]; then
         # Check if $policy_file_path is empty so we clone the policies repo only once
-        if [ -z "$(ls -A ${policy_file_path} 2> /dev/null)" ]; then
+        if [ -z "$(ls -A "${policy_file_path}" 2> /dev/null)" ]; then
           gcloud source repos clone gcp-policies "${policy_file_path}" --project="${project_id}" || exit 34
         fi
       fi


### PR DESCRIPTION
Currently `tf_plan_validate_all` calls `tf_validate` multiple times, which means the policies repo getting cloned multiple times. This results in an error the second time the clone is attempted since the path already exists

With this PR, `tf-wrapper.sh` verifies the existence of `/workspace/.policies-cloned` before attempting to clone.
