### PR TITLE
fix: Pin network-peering for terraform 0.12

### DIFF
--- a/4-projects/business_unit_1/development/example_peering_project.tf
+++ b/4-projects/business_unit_1/development/example_peering_project.tf
@@ -64,8 +64,8 @@ module "peering_network" {
 }
 
 module "peering" {
-  source = "terraform-google-modules/network/google//modules/network-peering"
-
+  source        = "terraform-google-modules/network/google//modules/network-peering"
+  version       = "~> 2.0"
   prefix        = "bu1-d"
   local_network = module.peering_network.network_self_link
   peer_network  = data.google_compute_network.shared_vpc.self_link

--- a/4-projects/business_unit_1/non-production/example_peering_project.tf
+++ b/4-projects/business_unit_1/non-production/example_peering_project.tf
@@ -64,8 +64,8 @@ module "peering_network" {
 }
 
 module "peering" {
-  source = "terraform-google-modules/network/google//modules/network-peering"
-
+  source        = "terraform-google-modules/network/google//modules/network-peering"
+  version       = "~> 2.0"
   prefix        = "bu1-n"
   local_network = module.peering_network.network_self_link
   peer_network  = data.google_compute_network.shared_vpc.self_link

--- a/4-projects/business_unit_1/production/example_peering_project.tf
+++ b/4-projects/business_unit_1/production/example_peering_project.tf
@@ -65,6 +65,7 @@ module "peering_network" {
 
 module "peering" {
   source        = "terraform-google-modules/network/google//modules/network-peering"
+  version       = "~> 2.0"
   prefix        = "bu1-p"
   local_network = module.peering_network.network_self_link
   peer_network  = data.google_compute_network.shared_vpc.self_link

--- a/4-projects/business_unit_2/development/example_peering_project.tf
+++ b/4-projects/business_unit_2/development/example_peering_project.tf
@@ -64,8 +64,8 @@ module "peering_network" {
 }
 
 module "peering" {
-  source = "terraform-google-modules/network/google//modules/network-peering"
-
+  source        = "terraform-google-modules/network/google//modules/network-peering"
+  version       = "~> 2.0"
   prefix        = "bu2-d"
   local_network = module.peering_network.network_self_link
   peer_network  = data.google_compute_network.shared_vpc.self_link

--- a/4-projects/business_unit_2/non-production/example_peering_project.tf
+++ b/4-projects/business_unit_2/non-production/example_peering_project.tf
@@ -65,6 +65,7 @@ module "peering_network" {
 
 module "peering" {
   source        = "terraform-google-modules/network/google//modules/network-peering"
+  version       = "~> 2.0"
   prefix        = "bu2-n"
   local_network = module.peering_network.network_self_link
   peer_network  = data.google_compute_network.shared_vpc.self_link

--- a/4-projects/business_unit_2/production/example_peering_project.tf
+++ b/4-projects/business_unit_2/production/example_peering_project.tf
@@ -65,6 +65,7 @@ module "peering_network" {
 
 module "peering" {
   source        = "terraform-google-modules/network/google//modules/network-peering"
+  version       = "~> 2.0"
   prefix        = "bu2-p"
   local_network = module.peering_network.network_self_link
   peer_network  = data.google_compute_network.shared_vpc.self_link


### PR DESCRIPTION
The release of `network-peering` 3 which rolled to `terraform` 0.13 broke current master:

```
Step #1 - "tf plan validate all": Warning: Provider source not supported in Terraform v0.12
Step #1 - "tf plan validate all": 
Step #1 - "tf plan validate all":   on .terraform/modules/peering/modules/network-peering/versions.tf line 20, in terraform:
Step #1 - "tf plan validate all":   20:     google = {
Step #1 - "tf plan validate all":   21:       source  = "hashicorp/google"
Step #1 - "tf plan validate all":   22:       version = "<4.0,>= 2.12"
Step #1 - "tf plan validate all":   23:     }
Step #1 - "tf plan validate all": 
Step #1 - "tf plan validate all": A source was declared for provider google. Terraform v0.12 does not support
Step #1 - "tf plan validate all": the provider source attribute. It will be ignored.
Step #1 - "tf plan validate all": 
Step #1 - "tf plan validate all": 
Step #1 - "tf plan validate all": Error: Unsupported block type
Step #1 - "tf plan validate all": 
Step #1 - "tf plan validate all":   on .terraform/modules/peering/modules/network-peering/versions.tf line 26, in terraform:
Step #1 - "tf plan validate all":   26:   provider_meta "google" {
Step #1 - "tf plan validate all": 
Step #1 - "tf plan validate all": Blocks of type "provider_meta" are not expected here.
```

This PR fixed it for me.