### PR TITLE
fix: Always/safely use latest cloudsource policies

### DIFF
--- a/build/tf-wrapper.sh
+++ b/build/tf-wrapper.sh
@@ -138,6 +138,9 @@ tf_validate() {
       cd "$path" || exit
       terraform show -json "${tmp_plan}/${tf_component}-${tf_env}.tfplan" > "${tf_env}.json" || exit 32
       if [[ "$policy_type" == "CLOUDSOURCE" ]]; then
+        if [ -d "${policy_file_path}" ]; then
+          rm -rf "${policy_file_path}" || exit 34
+        fi
         gcloud source repos clone gcp-policies "${policy_file_path}" --project="${project_id}" || exit 34
       fi
       terraform-validator validate "${tf_env}.json" --policy-path="${policy_file_path}" --project="${project_id}" || exit 33


### PR DESCRIPTION
I think there are two issues with cloud source policy repos in `tf-wrapper.sh` we can quickly improve.

- We always want to use the latest version.
- There are scenarios when we fail due to `"${policy_file_path}"` existing from a previous invocation 

```
Step #1 - "tf plan validate all": *************** TERRAFORM VALIDATE ******************
Step #1 - "tf plan validate all":       At environment: envs/production 
Step #1 - "tf plan validate all":       Using policy from: /workspace/policy-library 
Step #1 - "tf plan validate all": *****************************************************
Step #1 - "tf plan validate all": WARNING: This command is using service account impersonation. All API calls will be executed as [org-terraform@cft-seed-xyz.iam.gserviceaccount.com].
Step #1 - "tf plan validate all": WARNING: This command is using service account impersonation. All API calls will be executed as [org-terraform@cft-seed-xyz.iam.gserviceaccount.com].
Step #1 - "tf plan validate all": WARNING: This command is using service account impersonation. All API calls will be executed as [org-terraform@cft-seed-xyz.iam.gserviceaccount.com].
Step #1 - "tf plan validate all": ERROR: (gcloud.source.repos.clone) Directory path specified exists and is not empty
Finished Step #1 - "tf plan validate all"
ERROR
ERROR: build step 1 "gcr.io/cft-cloudbuild-fabc/terraform" failed: step exited with non-zero status: 1
```