### PR TITLE
Replace container registery with artifact registry in CloudBuild

### DIFF
--- a/build/cloudbuild-tf-apply.yaml
+++ b/build/cloudbuild-tf-apply.yaml
@@ -17,7 +17,7 @@ substitutions:
   _POLICY_REPO: '/workspace/policy-library' # add path to policies here https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#how-to-use-terraform-validator
 steps:
 - id: 'setup'
-  name: gcr.io/$PROJECT_ID/terraform
+  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/prj-tf-runners/terraform
   entrypoint: /bin/bash
   args:
   - -c
@@ -32,7 +32,7 @@ steps:
 
 # [START tf-init]
 - id: 'tf init'
-  name: gcr.io/${PROJECT_ID}/terraform
+  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/prj-tf-runners/terraform
   entrypoint: /bin/bash
   args:
   - -c
@@ -41,7 +41,7 @@ steps:
 
 # [START tf-plan]
 - id: 'tf plan'
-  name: gcr.io/${PROJECT_ID}/terraform
+  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/prj-tf-runners/terraform
   entrypoint: /bin/bash
   args:
   - -c
@@ -50,7 +50,7 @@ steps:
 
 # [START tf-validate]
 - id: 'tf validate'
-  name: gcr.io/${PROJECT_ID}/terraform
+  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/prj-tf-runners/terraform
   entrypoint: /bin/bash
   args:
   - -c
@@ -59,7 +59,7 @@ steps:
 
 # [START tf-apply]
 - id: 'tf apply'
-  name: gcr.io/${PROJECT_ID}/terraform
+  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/prj-tf-runners/terraform
   entrypoint: /bin/bash
   args:
   - -c

--- a/build/cloudbuild-tf-apply.yaml
+++ b/build/cloudbuild-tf-apply.yaml
@@ -21,7 +21,7 @@ steps:
   entrypoint: /bin/bash
   args:
   - -c
-  - |''
+  - |
    tf_sa_email=${_TF_SA_EMAIL}
     if [[ -n ${tf_sa_email} ]]; then
       echo "Setting up gcloud for impersonation"

--- a/build/cloudbuild-tf-apply.yaml
+++ b/build/cloudbuild-tf-apply.yaml
@@ -17,11 +17,11 @@ substitutions:
   _POLICY_REPO: '/workspace/policy-library' # add path to policies here https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#how-to-use-terraform-validator
 steps:
 - id: 'setup'
-  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/prj-tf-runners/terraform
+  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/$_GAR_REPOSITORY/terraform
   entrypoint: /bin/bash
   args:
   - -c
-  - |
+  - |''
    tf_sa_email=${_TF_SA_EMAIL}
     if [[ -n ${tf_sa_email} ]]; then
       echo "Setting up gcloud for impersonation"
@@ -32,7 +32,7 @@ steps:
 
 # [START tf-init]
 - id: 'tf init'
-  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/prj-tf-runners/terraform
+  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/$_GAR_REPOSITORY/terraform
   entrypoint: /bin/bash
   args:
   - -c
@@ -41,7 +41,7 @@ steps:
 
 # [START tf-plan]
 - id: 'tf plan'
-  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/prj-tf-runners/terraform
+  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/$_GAR_REPOSITORY/terraform
   entrypoint: /bin/bash
   args:
   - -c
@@ -50,7 +50,7 @@ steps:
 
 # [START tf-validate]
 - id: 'tf validate'
-  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/prj-tf-runners/terraform
+  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/$_GAR_REPOSITORY/terraform
   entrypoint: /bin/bash
   args:
   - -c
@@ -59,7 +59,7 @@ steps:
 
 # [START tf-apply]
 - id: 'tf apply'
-  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/prj-tf-runners/terraform
+  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/$_GAR_REPOSITORY/terraform
   entrypoint: /bin/bash
   args:
   - -c

--- a/build/cloudbuild-tf-plan.yaml
+++ b/build/cloudbuild-tf-plan.yaml
@@ -17,7 +17,7 @@ substitutions:
   _POLICY_REPO: '/workspace/policy-library' # add path to policies here https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#how-to-use-terraform-validator
 steps:
 - id: 'setup'
-  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/prj-tf-runners/terraform
+  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/$_GAR_REPOSITORY/terraform
   entrypoint: /bin/bash
   args:
   - -c
@@ -32,7 +32,7 @@ steps:
 
 # [START tf-plan_validate_all]
 - id: 'tf plan validate all'
-  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/prj-tf-runners/terraform
+  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/$_GAR_REPOSITORY/terraform
   entrypoint: /bin/bash
   args:
   - -c

--- a/build/cloudbuild-tf-plan.yaml
+++ b/build/cloudbuild-tf-plan.yaml
@@ -17,7 +17,7 @@ substitutions:
   _POLICY_REPO: '/workspace/policy-library' # add path to policies here https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#how-to-use-terraform-validator
 steps:
 - id: 'setup'
-  name: gcr.io/$PROJECT_ID/terraform
+  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/prj-tf-runners/terraform
   entrypoint: /bin/bash
   args:
   - -c
@@ -32,7 +32,7 @@ steps:
 
 # [START tf-plan_validate_all]
 - id: 'tf plan validate all'
-  name: gcr.io/${PROJECT_ID}/terraform
+  name: $_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/prj-tf-runners/terraform
   entrypoint: /bin/bash
   args:
   - -c


### PR DESCRIPTION
Fixes https://github.com/terraform-google-modules/terraform-example-foundation/issues/366

This PR replaces `gcr.io/$PROJECT_ID/terraform` with `$_DEFAULT_REGION-docker.pkg.dev/$PROJECT_ID/prj-tf-runners/terraform` in the CloudBuild files.

Result with the fix:

```
Starting Step #0 - "setup"
Step #0 - "setup": Pulling image: us-east1-docker.pkg.dev/prj-cloudbuild-34b9/prj-tf-runners/terraform
Step #0 - "setup": Using default tag: latest
Step #0 - "setup": latest: Pulling from prj-cloudbuild-34b9/prj-tf-runners/terraform
Step #0 - "setup": 75f546e73d8b: Already exists
```