### PR TITLE
fix google-beta provider source info

### DIFF
--- a/1-org/envs/shared/versions.tf
+++ b/1-org/envs/shared/versions.tf
@@ -22,7 +22,7 @@ terraform {
       version = ">= 3.50"
     }
     google-beta = {
-      source  = "hashicorp/google"
+      source  = "hashicorp/google-beta"
       version = ">= 3.50"
     }
   }

--- a/2-environments/envs/development/versions.tf
+++ b/2-environments/envs/development/versions.tf
@@ -22,7 +22,7 @@ terraform {
       version = ">= 3.50"
     }
     google-beta = {
-      source  = "hashicorp/google"
+      source  = "hashicorp/google-beta"
       version = ">= 3.50"
     }
   }

--- a/2-environments/envs/non-production/versions.tf
+++ b/2-environments/envs/non-production/versions.tf
@@ -22,7 +22,7 @@ terraform {
       version = ">= 3.50"
     }
     google-beta = {
-      source  = "hashicorp/google"
+      source  = "hashicorp/google-beta"
       version = ">= 3.50"
     }
   }

--- a/2-environments/envs/production/versions.tf
+++ b/2-environments/envs/production/versions.tf
@@ -22,7 +22,7 @@ terraform {
       version = ">= 3.50"
     }
     google-beta = {
-      source  = "hashicorp/google"
+      source  = "hashicorp/google-beta"
       version = ">= 3.50"
     }
   }

--- a/3-networks/envs/development/versions.tf
+++ b/3-networks/envs/development/versions.tf
@@ -22,7 +22,7 @@ terraform {
       version = ">= 3.50"
     }
     google-beta = {
-      source  = "hashicorp/google"
+      source  = "hashicorp/google-beta"
       version = ">= 3.50"
     }
   }

--- a/3-networks/envs/non-production/versions.tf
+++ b/3-networks/envs/non-production/versions.tf
@@ -22,7 +22,7 @@ terraform {
       version = ">= 3.50"
     }
     google-beta = {
-      source  = "hashicorp/google"
+      source  = "hashicorp/google-beta"
       version = ">= 3.50"
     }
   }

--- a/3-networks/envs/production/versions.tf
+++ b/3-networks/envs/production/versions.tf
@@ -22,7 +22,7 @@ terraform {
       version = ">= 3.50"
     }
     google-beta = {
-      source  = "hashicorp/google"
+      source  = "hashicorp/google-beta"
       version = ">= 3.50"
     }
   }

--- a/3-networks/envs/shared/versions.tf
+++ b/3-networks/envs/shared/versions.tf
@@ -22,7 +22,7 @@ terraform {
       version = ">= 3.50"
     }
     google-beta = {
-      source  = "hashicorp/google"
+      source  = "hashicorp/google-beta"
       version = ">= 3.50"
     }
   }

--- a/4-projects/business_unit_1/development/versions.tf
+++ b/4-projects/business_unit_1/development/versions.tf
@@ -22,7 +22,7 @@ terraform {
       version = ">= 3.50"
     }
     google-beta = {
-      source  = "hashicorp/google"
+      source  = "hashicorp/google-beta"
       version = ">= 3.50"
     }
   }

--- a/4-projects/business_unit_1/non-production/versions.tf
+++ b/4-projects/business_unit_1/non-production/versions.tf
@@ -22,7 +22,7 @@ terraform {
       version = ">= 3.50"
     }
     google-beta = {
-      source  = "hashicorp/google"
+      source  = "hashicorp/google-beta"
       version = ">= 3.50"
     }
   }

--- a/4-projects/business_unit_1/production/versions.tf
+++ b/4-projects/business_unit_1/production/versions.tf
@@ -22,7 +22,7 @@ terraform {
       version = ">= 3.50"
     }
     google-beta = {
-      source  = "hashicorp/google"
+      source  = "hashicorp/google-beta"
       version = ">= 3.50"
     }
   }

--- a/4-projects/business_unit_2/development/versions.tf
+++ b/4-projects/business_unit_2/development/versions.tf
@@ -22,7 +22,7 @@ terraform {
       version = ">= 3.50"
     }
     google-beta = {
-      source  = "hashicorp/google"
+      source  = "hashicorp/google-beta"
       version = ">= 3.50"
     }
   }

--- a/4-projects/business_unit_2/non-production/versions.tf
+++ b/4-projects/business_unit_2/non-production/versions.tf
@@ -22,7 +22,7 @@ terraform {
       version = ">= 3.50"
     }
     google-beta = {
-      source  = "hashicorp/google"
+      source  = "hashicorp/google-beta"
       version = ">= 3.50"
     }
   }

--- a/4-projects/business_unit_2/production/versions.tf
+++ b/4-projects/business_unit_2/production/versions.tf
@@ -22,7 +22,7 @@ terraform {
       version = ">= 3.50"
     }
     google-beta = {
-      source  = "hashicorp/google"
+      source  = "hashicorp/google-beta"
       version = ">= 3.50"
     }
   }


### PR DESCRIPTION
This pull request Fixes https://github.com/terraform-google-modules/terraform-example-foundation/issues/359

`google-beta` provider was pointing to the wrong source in the `version.tf` files:

It was:
```
    google-beta = {
      source  = "hashicorp/google"
      version = ">= 3.50"
    }
```

but it must be:

```
    google-beta = {
      source  = "hashicorp/google-beta"
      version = ">= 3.50"
    }
```
