### PR TITLE
feat/external ip for HTTP load balancing

### DIFF
--- a/3-networks/envs/development/main.tf
+++ b/3-networks/envs/development/main.tf
@@ -198,7 +198,7 @@ module "base_shared_vpc" {
   allow_all_ingress_ranges = local.enable_transitivity ? local.base_hub_subnet_ranges : null
   allow_all_egress_ranges  = local.enable_transitivity ? local.base_subnet_aggregates : null
 }
-  
+
 /******************************************
  External IP Address
 *****************************************/

--- a/3-networks/envs/development/main.tf
+++ b/3-networks/envs/development/main.tf
@@ -198,3 +198,15 @@ module "base_shared_vpc" {
   allow_all_ingress_ranges = local.enable_transitivity ? local.base_hub_subnet_ranges : null
   allow_all_egress_ranges  = local.enable_transitivity ? local.base_subnet_aggregates : null
 }
+  
+/******************************************
+ External IP Address
+*****************************************/
+
+resource "google_compute_address" "external_ip_for_http_load_balancing" {
+  name         = var.address_name
+  project      = local.base_project_id
+  address_type = var.address_type
+  description  = var.description
+  region       = var.region
+}

--- a/3-networks/envs/development/variables.tf
+++ b/3-networks/envs/development/variables.tf
@@ -145,3 +145,24 @@ variable "enable_hub_and_spoke_transitivity" {
   type        = bool
   default     = false
 }
+
+variable "address_name" {
+  description = "Name of the external IP address."
+  type        = string
+}
+
+variable "address_type" {
+  description = "Creates an external IP address that is required for HTTP load balancing."
+  type        = string
+  default     = "EXTERNAL"
+}
+   
+variable "description" {
+  description = "Describes what the external IP address will be used for."
+  type        = string
+}
+   
+variable "region" {
+  description = "The region that the external IP address will be created in."
+  type        = string
+}

--- a/3-networks/envs/development/variables.tf
+++ b/3-networks/envs/development/variables.tf
@@ -156,12 +156,12 @@ variable "address_type" {
   type        = string
   default     = "EXTERNAL"
 }
-   
+
 variable "description" {
   description = "Describes what the external IP address will be used for."
   type        = string
 }
-   
+
 variable "region" {
   description = "The region that the external IP address will be created in."
   type        = string


### PR DESCRIPTION
This PR is to add an external IP address that will be used for HTTP load balancing to the base shared VPC.