### PR TITLE
Bugfix/fix 4-projects issues

### DIFF
--- a/4-projects/README.md
+++ b/4-projects/README.md
@@ -27,15 +27,18 @@ If your user does not have access to run the commands above and you are in the o
 1. Rename `non-production.auto.example.tfvars` to `non-production.auto.tfvars` and update the file with the `perimeter_name` that starts with `sp_n_shared_restricted`.
 1. Rename `production.auto.example.tfvars` to `production.auto.tfvars` and update the file with the `perimeter_name` that starts with `sp_p_shared_restricted`.
 1. Rename `access_context.auto.example.tfvars` to `access_context.auto.tfvars` and update the file with the `access_context_manager_policy_id`.
-1. Commit changes with `git add .` and `git commit -m 'Your message'`.
-1. You will need only once to manually plan + apply the `shared` environment since `development`, `non-production` and `production` depend on it.
+1. You will need only once to manually plan + apply the `business_unit_1/shared` environment since `development`, `non-production` and `production` depend on it.
     1. Run `cd ./business_unit_1/shared/`.
     1. Update `backend.tf` with your bucket name from the bootstrap step.
     1. Run `terraform init`.
     1. Run `terraform plan` and review output.
     1. Run `terraform apply`.
+    1. Run `terraform output cloudbuild_sa` to get the cloudbuild service account from the apply step.
     1. If you would like the bucket to be replaced by cloud build at run time, change the bucket name back to `UPDATE_ME`
-1. Once you have done the instructions from the previous step, you need to repeat same steps on business_unit_2 folder.
+1. Once you have done the instructions for the `business_unit_1`, you need to repeat same steps for `business_unit_2` folder.
+1. Rename `business_unit_1.auto.example.tfvars` to `business_unit_1.auto.tfvars` and update the file with the `app_infra_pipeline_cloudbuild_sa` wich is the output of `cloudbuild_sa` from `business_unit_1` shared steps.
+1. Rename `business_unit_2.auto.example.tfvars` to `business_unit_2.auto.tfvars` and update the file with the `app_infra_pipeline_cloudbuild_sa` wich is the output of `cloudbuild_sa` from `business_unit_2` shared steps.
+1. Commit changes with `git add .` and `git commit -m 'Your message'`.
 1. Push your plan branch to trigger a plan `git push --set-upstream origin plan` (the branch `plan` is not a special one. Any branch which name is different from `development`, `non-production` or `production` will trigger a terraform plan).
     1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
 1. Merge changes to production with `git checkout -b production` and `git push origin production`.

--- a/4-projects/README.md
+++ b/4-projects/README.md
@@ -26,7 +26,16 @@ If your user does not have access to run the commands above and you are in the o
 1. Rename `development.auto.example.tfvars` to `development.auto.tfvars` and update the file with the `perimeter_name` that starts with `sp_d_shared_restricted`.
 1. Rename `non-production.auto.example.tfvars` to `non-production.auto.tfvars` and update the file with the `perimeter_name` that starts with `sp_n_shared_restricted`.
 1. Rename `production.auto.example.tfvars` to `production.auto.tfvars` and update the file with the `perimeter_name` that starts with `sp_p_shared_restricted`.
+1. Rename `access_context.auto.example.tfvars` to `access_context.auto.tfvars` and update the file with the `access_context_manager_policy_id`.
 1. Commit changes with `git add .` and `git commit -m 'Your message'`.
+1. You will need only once to manually plan + apply the `shared` environment since `development`, `non-production` and `production` depend on it.
+    1. Run `cd ./business_unit_1/shared/`.
+    1. Update `backend.tf` with your bucket name from the bootstrap step.
+    1. Run `terraform init`.
+    1. Run `terraform plan` and review output.
+    1. Run `terraform apply`.
+    1. If you would like the bucket to be replaced by cloud build at run time, change the bucket name back to `UPDATE_ME`
+1. Once you have done the instructions from the previous step, you need to repeat same steps on business_unit_2 folder.
 1. Push your plan branch to trigger a plan `git push --set-upstream origin plan` (the branch `plan` is not a special one. Any branch which name is different from `development`, `non-production` or `production` will trigger a terraform plan).
     1. Review the plan output in your cloud build project https://console.cloud.google.com/cloud-build/builds?project=YOUR_CLOUD_BUILD_PROJECT_ID
 1. Merge changes to production with `git checkout -b production` and `git push origin production`.

--- a/4-projects/access_context.auto.example.tfvars
+++ b/4-projects/access_context.auto.example.tfvars
@@ -14,13 +14,4 @@
  * limitations under the License.
  */
 
-billing_account = "000000-000000-000000"
-
-org_id = "000000000000"
-
-terraform_service_account = "org-terraform@example-project-2334.iam.gserviceaccount.com"
-
-access_context_manager_policy_id = "000000000000"
-
-//Optional - for development.  Will place all resources under a specific folder instead of org root
-//parent_folder = "01234567890"
+access_context_manager_policy_id = 000000000000

--- a/4-projects/business_unit_1.auto.example.tfvars
+++ b/4-projects/business_unit_1.auto.example.tfvars
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+app_infra_pipeline_cloudbuild_sa = "project-service-account@prj-bu1-s-sample-infra-<random>.iam.gserviceaccount.com"

--- a/4-projects/business_unit_1/development/access_context.tfvars
+++ b/4-projects/business_unit_1/development/access_context.tfvars
@@ -1,0 +1,1 @@
+../../access_context.auto.tfvars

--- a/4-projects/business_unit_1/development/business_unit_1.auto.tfvars
+++ b/4-projects/business_unit_1/development/business_unit_1.auto.tfvars
@@ -1,0 +1,1 @@
+../../business_unit_1.auto.tfvars

--- a/4-projects/business_unit_1/development/providers.tf
+++ b/4-projects/business_unit_1/development/providers.tf
@@ -31,7 +31,7 @@ data "google_service_account_access_token" "default" {
   provider               = google.impersonate
   target_service_account = local.tf_sa
   scopes                 = ["userinfo-email", "cloud-platform"]
-  lifetime               = "900s"
+  lifetime               = "1200s"
 }
 
 /******************************************

--- a/4-projects/business_unit_1/non-production/access_context.tfvars
+++ b/4-projects/business_unit_1/non-production/access_context.tfvars
@@ -1,0 +1,1 @@
+../../access_context.auto.tfvars

--- a/4-projects/business_unit_1/non-production/business_unit_1.auto.tfvars
+++ b/4-projects/business_unit_1/non-production/business_unit_1.auto.tfvars
@@ -1,0 +1,1 @@
+../../business_unit_1.auto.tfvars

--- a/4-projects/business_unit_1/non-production/providers.tf
+++ b/4-projects/business_unit_1/non-production/providers.tf
@@ -31,7 +31,7 @@ data "google_service_account_access_token" "default" {
   provider               = google.impersonate
   target_service_account = local.tf_sa
   scopes                 = ["userinfo-email", "cloud-platform"]
-  lifetime               = "900s"
+  lifetime               = "1200s"
 }
 
 /******************************************

--- a/4-projects/business_unit_1/production/access_context.tfvars
+++ b/4-projects/business_unit_1/production/access_context.tfvars
@@ -1,0 +1,1 @@
+../../access_context.auto.tfvars

--- a/4-projects/business_unit_1/production/business_unit_1.auto.tfvars
+++ b/4-projects/business_unit_1/production/business_unit_1.auto.tfvars
@@ -1,0 +1,1 @@
+../../business_unit_1.auto.tfvars

--- a/4-projects/business_unit_1/production/providers.tf
+++ b/4-projects/business_unit_1/production/providers.tf
@@ -31,7 +31,7 @@ data "google_service_account_access_token" "default" {
   provider               = google.impersonate
   target_service_account = local.tf_sa
   scopes                 = ["userinfo-email", "cloud-platform"]
-  lifetime               = "900s"
+  lifetime               = "1200s"
 }
 
 /******************************************

--- a/4-projects/business_unit_1/shared/backend.tf
+++ b/4-projects/business_unit_1/shared/backend.tf
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  backend "gcs" {
+    bucket = "UPDATE_ME"
+    prefix = "terraform/projects/business_unit_1/shared"
+  }
+}

--- a/4-projects/business_unit_1/shared/common.auto.tfvars
+++ b/4-projects/business_unit_1/shared/common.auto.tfvars
@@ -1,1 +1,1 @@
-../common.auto.example.tfvars
+../../common.auto.tfvars

--- a/4-projects/business_unit_1/shared/providers.tf
+++ b/4-projects/business_unit_1/shared/providers.tf
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  tf_sa = var.terraform_service_account
+}
+
+provider "google" {
+  alias = "impersonate"
+
+  scopes = [
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/userinfo.email",
+  ]
+}
+
+data "google_service_account_access_token" "default" {
+  provider               = google.impersonate
+  target_service_account = local.tf_sa
+  scopes                 = ["userinfo-email", "cloud-platform"]
+  lifetime               = "600s"
+}
+
+/******************************************
+  Provider credential configuration
+ *****************************************/
+provider "google" {
+  access_token = data.google_service_account_access_token.default.access_token
+}
+
+provider "google-beta" {
+  access_token = data.google_service_account_access_token.default.access_token
+}
+

--- a/4-projects/business_unit_1/shared/providers.tf
+++ b/4-projects/business_unit_1/shared/providers.tf
@@ -31,7 +31,7 @@ data "google_service_account_access_token" "default" {
   provider               = google.impersonate
   target_service_account = local.tf_sa
   scopes                 = ["userinfo-email", "cloud-platform"]
-  lifetime               = "600s"
+  lifetime               = "1200s"
 }
 
 /******************************************

--- a/4-projects/business_unit_1/shared/versions.tf
+++ b/4-projects/business_unit_1/shared/versions.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.50"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 3.50"
+    }
+  }
+}

--- a/4-projects/business_unit_2.auto.example.tfvars
+++ b/4-projects/business_unit_2.auto.example.tfvars
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+app_infra_pipeline_cloudbuild_sa = "project-service-account@prj-bu2-s-sample-infra-<random>.iam.gserviceaccount.com"

--- a/4-projects/business_unit_2/development/access_context.tfvars
+++ b/4-projects/business_unit_2/development/access_context.tfvars
@@ -1,0 +1,1 @@
+../../access_context.auto.tfvars

--- a/4-projects/business_unit_2/development/business_unit_2.auto.tfvars
+++ b/4-projects/business_unit_2/development/business_unit_2.auto.tfvars
@@ -1,0 +1,1 @@
+../../business_unit_2.auto.tfvars

--- a/4-projects/business_unit_2/development/providers.tf
+++ b/4-projects/business_unit_2/development/providers.tf
@@ -31,7 +31,7 @@ data "google_service_account_access_token" "default" {
   provider               = google.impersonate
   target_service_account = local.tf_sa
   scopes                 = ["userinfo-email", "cloud-platform"]
-  lifetime               = "900s"
+  lifetime               = "1200s"
 }
 
 /******************************************

--- a/4-projects/business_unit_2/non-production/access_context.tfvars
+++ b/4-projects/business_unit_2/non-production/access_context.tfvars
@@ -1,0 +1,1 @@
+../../access_context.auto.tfvars

--- a/4-projects/business_unit_2/non-production/business_unit_2.auto.tfvars
+++ b/4-projects/business_unit_2/non-production/business_unit_2.auto.tfvars
@@ -1,0 +1,1 @@
+../../business_unit_2.auto.tfvars

--- a/4-projects/business_unit_2/non-production/providers.tf
+++ b/4-projects/business_unit_2/non-production/providers.tf
@@ -31,7 +31,7 @@ data "google_service_account_access_token" "default" {
   provider               = google.impersonate
   target_service_account = local.tf_sa
   scopes                 = ["userinfo-email", "cloud-platform"]
-  lifetime               = "900s"
+  lifetime               = "1200s"
 }
 
 /******************************************

--- a/4-projects/business_unit_2/production/access_context.tfvars
+++ b/4-projects/business_unit_2/production/access_context.tfvars
@@ -1,0 +1,1 @@
+../../access_context.auto.tfvars

--- a/4-projects/business_unit_2/production/business_unit_2.auto.tfvars
+++ b/4-projects/business_unit_2/production/business_unit_2.auto.tfvars
@@ -1,0 +1,1 @@
+../../business_unit_2.auto.tfvars

--- a/4-projects/business_unit_2/production/providers.tf
+++ b/4-projects/business_unit_2/production/providers.tf
@@ -31,7 +31,7 @@ data "google_service_account_access_token" "default" {
   provider               = google.impersonate
   target_service_account = local.tf_sa
   scopes                 = ["userinfo-email", "cloud-platform"]
-  lifetime               = "900s"
+  lifetime               = "1200s"
 }
 
 /******************************************

--- a/4-projects/business_unit_2/shared/backend.tf
+++ b/4-projects/business_unit_2/shared/backend.tf
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  backend "gcs" {
+    bucket = "UPDATE_ME"
+    prefix = "terraform/projects/business_unit_2/shared"
+  }
+}

--- a/4-projects/business_unit_2/shared/common.auto.tfvars
+++ b/4-projects/business_unit_2/shared/common.auto.tfvars
@@ -1,1 +1,1 @@
-../common.auto.example.tfvars
+../../common.auto.tfvars

--- a/4-projects/business_unit_2/shared/providers.tf
+++ b/4-projects/business_unit_2/shared/providers.tf
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  tf_sa = var.terraform_service_account
+}
+
+provider "google" {
+  alias = "impersonate"
+
+  scopes = [
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/userinfo.email",
+  ]
+}
+
+data "google_service_account_access_token" "default" {
+  provider               = google.impersonate
+  target_service_account = local.tf_sa
+  scopes                 = ["userinfo-email", "cloud-platform"]
+  lifetime               = "600s"
+}
+
+/******************************************
+  Provider credential configuration
+ *****************************************/
+provider "google" {
+  access_token = data.google_service_account_access_token.default.access_token
+}
+
+provider "google-beta" {
+  access_token = data.google_service_account_access_token.default.access_token
+}
+

--- a/4-projects/business_unit_2/shared/providers.tf
+++ b/4-projects/business_unit_2/shared/providers.tf
@@ -31,7 +31,7 @@ data "google_service_account_access_token" "default" {
   provider               = google.impersonate
   target_service_account = local.tf_sa
   scopes                 = ["userinfo-email", "cloud-platform"]
-  lifetime               = "600s"
+  lifetime               = "1200s"
 }
 
 /******************************************

--- a/4-projects/business_unit_2/shared/versions.tf
+++ b/4-projects/business_unit_2/shared/versions.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.50"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 3.50"
+    }
+  }
+}

--- a/4-projects/common.auto.example.tfvars
+++ b/4-projects/common.auto.example.tfvars
@@ -20,7 +20,5 @@ org_id = "000000000000"
 
 terraform_service_account = "org-terraform@example-project-2334.iam.gserviceaccount.com"
 
-access_context_manager_policy_id = "000000000000"
-
 //Optional - for development.  Will place all resources under a specific folder instead of org root
 //parent_folder = "01234567890"

--- a/4-projects/common.auto.tfvars
+++ b/4-projects/common.auto.tfvars
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+billing_account = "000000-000000-000000"
+
+org_id = "000000000000"
+
+terraform_service_account = "org-terraform@example-project-2334.iam.gserviceaccount.com"
+
+access_context_manager_policy_id = "000000000000"
+
+//Optional - for development.  Will place all resources under a specific folder instead of org root
+//parent_folder = "01234567890"


### PR DESCRIPTION
This PR contains the fix for the following issues:

- [350](https://github.com/terraform-google-modules/terraform-example-foundation/issues/350) -  common.auto.tfvars link pointing to an example file
- [351](https://github.com/terraform-google-modules/terraform-example-foundation/issues/351) - Missing backend.tf file from shared folder
- [352](https://github.com/terraform-google-modules/terraform-example-foundation/issues/352) - access_context_manager_policy_id but a value was found in file "common.auto.tfvars"
- [353](https://github.com/terraform-google-modules/terraform-example-foundation/issues/353) - billingbudgets.googleapis.com is not enabled for infra-cicd deployment 
- [365](https://github.com/terraform-google-modules/terraform-example-foundation/issues/365) - MIssing app_infra_pipeline_cloudbuild_sa variable on environments tfvars examples in step 4-projects