### PR TITLE
Fixing version of network_peering in step 4-projects

### DIFF
--- a/4-projects/business_unit_1/development/example_peering_project.tf
+++ b/4-projects/business_unit_1/development/example_peering_project.tf
@@ -68,11 +68,11 @@ module "peering_network" {
 }
 
 module "peering" {
-  source = "terraform-google-modules/network/google//modules/network-peering"
-  version                                = "~> 2.0"
-  prefix        = "bu1-d"
-  local_network = module.peering_network.network_self_link
-  peer_network  = data.google_compute_network.shared_vpc.self_link
+  source            = "terraform-google-modules/network/google//modules/network-peering"
+  version           = "~> 2.0"
+  prefix            = "bu1-d"
+  local_network     = module.peering_network.network_self_link
+  peer_network      = data.google_compute_network.shared_vpc.self_link
   module_depends_on = var.peering_module_depends_on
 }
 

--- a/4-projects/business_unit_1/development/example_peering_project.tf
+++ b/4-projects/business_unit_1/development/example_peering_project.tf
@@ -69,11 +69,10 @@ module "peering_network" {
 
 module "peering" {
   source = "terraform-google-modules/network/google//modules/network-peering"
-
+  version                                = "~> 2.0"
   prefix        = "bu1-d"
   local_network = module.peering_network.network_self_link
   peer_network  = data.google_compute_network.shared_vpc.self_link
-
   module_depends_on = var.peering_module_depends_on
 }
 

--- a/4-projects/business_unit_1/development/example_peering_project.tf
+++ b/4-projects/business_unit_1/development/example_peering_project.tf
@@ -59,7 +59,7 @@ module "peering_project" {
 
 module "peering_network" {
   source                                 = "terraform-google-modules/network/google"
-  version                                = "~> 2.0"
+  version                                = "~> 3.0"
   project_id                             = module.peering_project.project_id
   network_name                           = "vpc-d-peering-base"
   shared_vpc_host                        = "false"
@@ -69,7 +69,7 @@ module "peering_network" {
 
 module "peering" {
   source            = "terraform-google-modules/network/google//modules/network-peering"
-  version           = "~> 2.0"
+  version           = "~> 3.0"
   prefix            = "bu1-d"
   local_network     = module.peering_network.network_self_link
   peer_network      = data.google_compute_network.shared_vpc.self_link

--- a/4-projects/business_unit_1/non-production/example_peering_project.tf
+++ b/4-projects/business_unit_1/non-production/example_peering_project.tf
@@ -68,11 +68,11 @@ module "peering_network" {
 }
 
 module "peering" {
-  source = "terraform-google-modules/network/google//modules/network-peering"
-  version                                = "~> 2.0"
-  prefix        = "bu1-n"
-  local_network = module.peering_network.network_self_link
-  peer_network  = data.google_compute_network.shared_vpc.self_link
+  source            = "terraform-google-modules/network/google//modules/network-peering"
+  version           = "~> 2.0"
+  prefix            = "bu1-n"
+  local_network     = module.peering_network.network_self_link
+  peer_network      = data.google_compute_network.shared_vpc.self_link
   module_depends_on = var.peering_module_depends_on
 }
 

--- a/4-projects/business_unit_1/non-production/example_peering_project.tf
+++ b/4-projects/business_unit_1/non-production/example_peering_project.tf
@@ -59,7 +59,7 @@ module "peering_project" {
 
 module "peering_network" {
   source                                 = "terraform-google-modules/network/google"
-  version                                = "~> 2.0"
+  version                                = "~> 3.0"
   project_id                             = module.peering_project.project_id
   network_name                           = "vpc-n-peering-base"
   shared_vpc_host                        = "false"
@@ -69,7 +69,7 @@ module "peering_network" {
 
 module "peering" {
   source            = "terraform-google-modules/network/google//modules/network-peering"
-  version           = "~> 2.0"
+  version           = "~> 3.0"
   prefix            = "bu1-n"
   local_network     = module.peering_network.network_self_link
   peer_network      = data.google_compute_network.shared_vpc.self_link

--- a/4-projects/business_unit_1/non-production/example_peering_project.tf
+++ b/4-projects/business_unit_1/non-production/example_peering_project.tf
@@ -69,11 +69,10 @@ module "peering_network" {
 
 module "peering" {
   source = "terraform-google-modules/network/google//modules/network-peering"
-
+  version                                = "~> 2.0"
   prefix        = "bu1-n"
   local_network = module.peering_network.network_self_link
   peer_network  = data.google_compute_network.shared_vpc.self_link
-
   module_depends_on = var.peering_module_depends_on
 }
 

--- a/4-projects/business_unit_1/production/example_peering_project.tf
+++ b/4-projects/business_unit_1/production/example_peering_project.tf
@@ -69,10 +69,10 @@ module "peering_network" {
 
 module "peering" {
   source        = "terraform-google-modules/network/google//modules/network-peering"
+  version                                = "~> 2.0"
   prefix        = "bu1-p"
   local_network = module.peering_network.network_self_link
   peer_network  = data.google_compute_network.shared_vpc.self_link
-
   module_depends_on = var.peering_module_depends_on
 }
 

--- a/4-projects/business_unit_1/production/example_peering_project.tf
+++ b/4-projects/business_unit_1/production/example_peering_project.tf
@@ -68,11 +68,11 @@ module "peering_network" {
 }
 
 module "peering" {
-  source        = "terraform-google-modules/network/google//modules/network-peering"
-  version                                = "~> 2.0"
-  prefix        = "bu1-p"
-  local_network = module.peering_network.network_self_link
-  peer_network  = data.google_compute_network.shared_vpc.self_link
+  source            = "terraform-google-modules/network/google//modules/network-peering"
+  version           = "~> 2.0"
+  prefix            = "bu1-p"
+  local_network     = module.peering_network.network_self_link
+  peer_network      = data.google_compute_network.shared_vpc.self_link
   module_depends_on = var.peering_module_depends_on
 }
 

--- a/4-projects/business_unit_1/production/example_peering_project.tf
+++ b/4-projects/business_unit_1/production/example_peering_project.tf
@@ -59,7 +59,7 @@ module "peering_project" {
 
 module "peering_network" {
   source                                 = "terraform-google-modules/network/google"
-  version                                = "~> 2.0"
+  version                                = "~> 3.0"
   project_id                             = module.peering_project.project_id
   network_name                           = "vpc-p-peering-base"
   shared_vpc_host                        = "false"
@@ -69,7 +69,7 @@ module "peering_network" {
 
 module "peering" {
   source            = "terraform-google-modules/network/google//modules/network-peering"
-  version           = "~> 2.0"
+  version           = "~> 3.0"
   prefix            = "bu1-p"
   local_network     = module.peering_network.network_self_link
   peer_network      = data.google_compute_network.shared_vpc.self_link

--- a/4-projects/business_unit_2/development/example_peering_project.tf
+++ b/4-projects/business_unit_2/development/example_peering_project.tf
@@ -59,7 +59,7 @@ module "peering_project" {
 
 module "peering_network" {
   source                                 = "terraform-google-modules/network/google"
-  version                                = "~> 2.0"
+  version                                = "~> 3.0"
   project_id                             = module.peering_project.project_id
   network_name                           = "vpc-d-peering-base"
   shared_vpc_host                        = "false"
@@ -69,7 +69,7 @@ module "peering_network" {
 
 module "peering" {
   source            = "terraform-google-modules/network/google//modules/network-peering"
-  version           = "~> 2.0"
+  version           = "~> 3.0"
   prefix            = "bu2-d"
   local_network     = module.peering_network.network_self_link
   peer_network      = data.google_compute_network.shared_vpc.self_link

--- a/4-projects/business_unit_2/development/example_peering_project.tf
+++ b/4-projects/business_unit_2/development/example_peering_project.tf
@@ -69,11 +69,10 @@ module "peering_network" {
 
 module "peering" {
   source = "terraform-google-modules/network/google//modules/network-peering"
-
+  version                                = "~> 2.0"
   prefix        = "bu2-d"
   local_network = module.peering_network.network_self_link
   peer_network  = data.google_compute_network.shared_vpc.self_link
-
   module_depends_on = var.peering_module_depends_on
 }
 

--- a/4-projects/business_unit_2/development/example_peering_project.tf
+++ b/4-projects/business_unit_2/development/example_peering_project.tf
@@ -68,11 +68,11 @@ module "peering_network" {
 }
 
 module "peering" {
-  source = "terraform-google-modules/network/google//modules/network-peering"
-  version                                = "~> 2.0"
-  prefix        = "bu2-d"
-  local_network = module.peering_network.network_self_link
-  peer_network  = data.google_compute_network.shared_vpc.self_link
+  source            = "terraform-google-modules/network/google//modules/network-peering"
+  version           = "~> 2.0"
+  prefix            = "bu2-d"
+  local_network     = module.peering_network.network_self_link
+  peer_network      = data.google_compute_network.shared_vpc.self_link
   module_depends_on = var.peering_module_depends_on
 }
 

--- a/4-projects/business_unit_2/non-production/example_peering_project.tf
+++ b/4-projects/business_unit_2/non-production/example_peering_project.tf
@@ -69,10 +69,10 @@ module "peering_network" {
 
 module "peering" {
   source        = "terraform-google-modules/network/google//modules/network-peering"
+  version                                = "~> 2.0"  
   prefix        = "bu2-n"
   local_network = module.peering_network.network_self_link
   peer_network  = data.google_compute_network.shared_vpc.self_link
-
   module_depends_on = var.peering_module_depends_on
 }
 

--- a/4-projects/business_unit_2/non-production/example_peering_project.tf
+++ b/4-projects/business_unit_2/non-production/example_peering_project.tf
@@ -68,11 +68,11 @@ module "peering_network" {
 }
 
 module "peering" {
-  source        = "terraform-google-modules/network/google//modules/network-peering"
-  version                                = "~> 2.0"  
-  prefix        = "bu2-n"
-  local_network = module.peering_network.network_self_link
-  peer_network  = data.google_compute_network.shared_vpc.self_link
+  source            = "terraform-google-modules/network/google//modules/network-peering"
+  version           = "~> 2.0"
+  prefix            = "bu2-n"
+  local_network     = module.peering_network.network_self_link
+  peer_network      = data.google_compute_network.shared_vpc.self_link
   module_depends_on = var.peering_module_depends_on
 }
 

--- a/4-projects/business_unit_2/non-production/example_peering_project.tf
+++ b/4-projects/business_unit_2/non-production/example_peering_project.tf
@@ -59,7 +59,7 @@ module "peering_project" {
 
 module "peering_network" {
   source                                 = "terraform-google-modules/network/google"
-  version                                = "~> 2.0"
+  version                                = "~> 3.0"
   project_id                             = module.peering_project.project_id
   network_name                           = "vpc-n-peering-base"
   shared_vpc_host                        = "false"
@@ -69,7 +69,7 @@ module "peering_network" {
 
 module "peering" {
   source            = "terraform-google-modules/network/google//modules/network-peering"
-  version           = "~> 2.0"
+  version           = "~> 3.0"
   prefix            = "bu2-n"
   local_network     = module.peering_network.network_self_link
   peer_network      = data.google_compute_network.shared_vpc.self_link

--- a/4-projects/business_unit_2/production/example_peering_project.tf
+++ b/4-projects/business_unit_2/production/example_peering_project.tf
@@ -69,10 +69,10 @@ module "peering_network" {
 
 module "peering" {
   source        = "terraform-google-modules/network/google//modules/network-peering"
+  version                                = "~> 2.0"
   prefix        = "bu2-p"
   local_network = module.peering_network.network_self_link
   peer_network  = data.google_compute_network.shared_vpc.self_link
-
   module_depends_on = var.peering_module_depends_on
 }
 

--- a/4-projects/business_unit_2/production/example_peering_project.tf
+++ b/4-projects/business_unit_2/production/example_peering_project.tf
@@ -59,7 +59,7 @@ module "peering_project" {
 
 module "peering_network" {
   source                                 = "terraform-google-modules/network/google"
-  version                                = "~> 2.0"
+  version                                = "~> 3.0"
   project_id                             = module.peering_project.project_id
   network_name                           = "vpc-p-peering-base"
   shared_vpc_host                        = "false"
@@ -69,7 +69,7 @@ module "peering_network" {
 
 module "peering" {
   source            = "terraform-google-modules/network/google//modules/network-peering"
-  version           = "~> 2.0"
+  version           = "~> 3.0"
   prefix            = "bu2-p"
   local_network     = module.peering_network.network_self_link
   peer_network      = data.google_compute_network.shared_vpc.self_link

--- a/4-projects/business_unit_2/production/example_peering_project.tf
+++ b/4-projects/business_unit_2/production/example_peering_project.tf
@@ -68,11 +68,11 @@ module "peering_network" {
 }
 
 module "peering" {
-  source        = "terraform-google-modules/network/google//modules/network-peering"
-  version                                = "~> 2.0"
-  prefix        = "bu2-p"
-  local_network = module.peering_network.network_self_link
-  peer_network  = data.google_compute_network.shared_vpc.self_link
+  source            = "terraform-google-modules/network/google//modules/network-peering"
+  version           = "~> 2.0"
+  prefix            = "bu2-p"
+  local_network     = module.peering_network.network_self_link
+  peer_network      = data.google_compute_network.shared_vpc.self_link
   module_depends_on = var.peering_module_depends_on
 }
 


### PR DESCRIPTION
Fix for [issue 313](https://github.com/terraform-google-modules/terraform-example-foundation/issues/313) - _Pin peering module version in networks_

Added version in _peering module_ for business unit 1 and 2 in _example_peering_project.tf_ .