### PR TITLE
Enabling KMS API in step 0-bootstrap

### DIFF
--- a/0-bootstrap/main.tf
+++ b/0-bootstrap/main.tf
@@ -57,6 +57,7 @@ module "seed_bootstrap" {
   activate_apis = [
     "serviceusage.googleapis.com",
     "servicenetworking.googleapis.com",
+    "cloudkms.googleapis.com",
     "compute.googleapis.com",
     "logging.googleapis.com",
     "bigquery.googleapis.com",


### PR DESCRIPTION
Fix for [issue 381](https://github.com/terraform-google-modules/terraform-example-foundation/issues/381) - _KMS API is missing in seed_.

Added KMS Api in _main.tf_ in 0-bootstrap.

