### PR TITLE
Updating infra pipelines to use GAR in step 4-projects

### DIFF
--- a/4-projects/modules/infra_pipelines/main.tf
+++ b/4-projects/modules/infra_pipelines/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/4-projects/modules/infra_pipelines/main.tf
+++ b/4-projects/modules/infra_pipelines/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,83 +15,147 @@
  */
 
 locals {
-  created_csrs         = toset([for repo in google_sourcerepo_repository.app_infra_repo : repo.name])
-  artifact_buckets     = { for created_csr in local.created_csrs : "${created_csr}-ab" => format("%s-%s-%s", created_csr, "cloudbuild-artifacts", random_id.suffix.hex) }
-  state_buckets        = { for created_csr in local.created_csrs : "${created_csr}-tfstate" => format("%s-%s-%s", created_csr, "tfstate", random_id.suffix.hex) }
-  apply_branches_regex = "^(${join("|", var.terraform_apply_branches)})$"
+  cloudbuild_project_id       = var.project_id != "" ? var.project_id : format("%s-%s", var.project_prefix, "cloudbuild")
+  gar_repo_name               = var.gar_repo_name != "" ? var.gar_repo_name : format("%s-%s", var.project_prefix, "tf-runners")
+  cloudbuild_apis             = ["cloudbuild.googleapis.com", "sourcerepo.googleapis.com", "cloudkms.googleapis.com", "artifactregistry.googleapis.com"]
+  impersonation_enabled_count = var.sa_enable_impersonation == true ? 1 : 0
+  activate_apis               = distinct(concat(var.activate_apis, local.cloudbuild_apis))
+  apply_branches_regex        = "^(${join("|", var.terraform_apply_branches)})$"
+  gar_name                    = split("/", google_artifact_registry_repository.tf-image-repo.name)[length(split("/", google_artifact_registry_repository.tf-image-repo.name)) - 1]
 }
 
-# Create CSRs
-resource "google_sourcerepo_repository" "app_infra_repo" {
-  for_each = toset(var.app_infra_repos)
-  project  = var.cloudbuild_project_id
-  name     = each.value
-}
-
-
-data "google_project" "cloudbuild_project" {
-  project_id = var.cloudbuild_project_id
-}
-
-# Buckets for state and artifacts
 resource "random_id" "suffix" {
   byte_length = 2
 }
 
-resource "google_storage_bucket" "tfstate" {
-  for_each                    = local.state_buckets
-  project                     = var.cloudbuild_project_id
-  name                        = each.value
-  location                    = var.bucket_region
-  uniform_bucket_level_access = true
-  versioning {
-    enabled = true
-  }
+data "google_organization" "org" {
+  organization = var.org_id
 }
+
+
+/******************************************
+  Cloudbuild project
+*******************************************/
+
+module "cloudbuild_project" {
+  source                      = "terraform-google-modules/project-factory/google"
+  version                     = "~> 10.1.1"
+  name                        = local.cloudbuild_project_id
+  random_project_id           = true
+  disable_services_on_destroy = false
+  folder_id                   = var.folder_id
+  org_id                      = var.org_id
+  billing_account             = var.billing_account
+  activate_apis               = local.activate_apis
+  labels                      = var.project_labels
+}
+
+/******************************************
+  Cloudbuild IAM for admins
+*******************************************/
+
+resource "google_project_iam_member" "org_admins_cloudbuild_editor" {
+  project = module.cloudbuild_project.project_id
+  role    = "roles/cloudbuild.builds.editor"
+  member  = "group:${var.group_org_admins}"
+}
+
+resource "google_project_iam_member" "org_admins_cloudbuild_viewer" {
+  project = module.cloudbuild_project.project_id
+  role    = "roles/viewer"
+  member  = "group:${var.group_org_admins}"
+}
+
+/******************************************
+  Cloudbuild Artifact bucket
+*******************************************/
 
 resource "google_storage_bucket" "cloudbuild_artifacts" {
-  for_each                    = local.artifact_buckets
-  project                     = var.cloudbuild_project_id
-  name                        = each.value
-  location                    = var.bucket_region
+  project                     = module.cloudbuild_project.project_id
+  name                        = format("%s-%s-%s", var.project_prefix, "cloudbuild-artifacts", random_id.suffix.hex)
+  location                    = var.default_region
+  labels                      = var.storage_bucket_labels
   uniform_bucket_level_access = true
   versioning {
     enabled = true
   }
 }
 
-# IAM for Cloud Build SA to access cloudbuild_artifacts and tfstate buckets
-resource "google_storage_bucket_iam_member" "cloudbuild_artifacts_iam" {
-  for_each   = merge(local.artifact_buckets, local.state_buckets)
-  bucket     = each.value
-  role       = "roles/storage.admin"
-  member     = "serviceAccount:${data.google_project.cloudbuild_project.number}@cloudbuild.gserviceaccount.com"
-  depends_on = [google_storage_bucket.cloudbuild_artifacts, google_storage_bucket.tfstate]
+/******************************************
+  KMS Keyring
+ *****************************************/
+
+resource "google_kms_key_ring" "tf_keyring" {
+  project  = module.cloudbuild_project.project_id
+  name     = "tf-keyring"
+  location = var.default_region
 }
 
-# Create TF runner image
-resource "null_resource" "cloudbuild_terraform_builder" {
-  triggers = {
-    project_id_cloudbuild_project = var.cloudbuild_project_id
-    terraform_version_sha256sum   = var.terraform_version_sha256sum
-    terraform_version             = var.terraform_version
-  }
+/******************************************
+  KMS Key
+ *****************************************/
 
-  provisioner "local-exec" {
-    command = <<EOT
-      gcloud builds submit ${path.module}/cloudbuild_builder/ \
-      --project ${var.cloudbuild_project_id} \
-      --config=${path.module}/cloudbuild_builder/cloudbuild.yaml \
-      --substitutions=_TERRAFORM_VERSION=${var.terraform_version},_TERRAFORM_VERSION_SHA256SUM=${var.terraform_version_sha256sum},_TERRAFORM_VALIDATOR_RELEASE=${var.terraform_validator_release}
-  EOT
-  }
+resource "google_kms_crypto_key" "tf_key" {
+  name     = "tf-key"
+  key_ring = google_kms_key_ring.tf_keyring.self_link
 }
 
-# Cloud Build plan/apply triggers
-resource "google_cloudbuild_trigger" "main_trigger" {
-  for_each    = local.created_csrs
-  project     = var.cloudbuild_project_id
-  description = "${each.value}-terraform apply."
+/******************************************
+  Permissions to decrypt.
+ *****************************************/
+
+resource "google_kms_crypto_key_iam_binding" "cloudbuild_crypto_key_decrypter" {
+  crypto_key_id = google_kms_crypto_key.tf_key.self_link
+  role          = "roles/cloudkms.cryptoKeyDecrypter"
+
+  members = [
+    "serviceAccount:${module.cloudbuild_project.project_number}@cloudbuild.gserviceaccount.com",
+    "serviceAccount:${var.terraform_sa_email}"
+  ]
+}
+
+/******************************************
+  Permissions for org admins to encrypt.
+ *****************************************/
+
+resource "google_kms_crypto_key_iam_binding" "cloud_build_crypto_key_encrypter" {
+  crypto_key_id = google_kms_crypto_key.tf_key.self_link
+  role          = "roles/cloudkms.cryptoKeyEncrypter"
+
+  members = [
+    "group:${var.group_org_admins}",
+  ]
+}
+
+/******************************************
+  Create Cloud Source Repos
+*******************************************/
+
+resource "google_sourcerepo_repository" "gcp_repo" {
+  for_each = var.create_cloud_source_repos ? toset(var.cloud_source_repos) : []
+  project  = module.cloudbuild_project.project_id
+  name     = each.value
+}
+
+/******************************************
+  Cloud Source Repo IAM
+*******************************************/
+
+resource "google_project_iam_member" "org_admins_source_repo_admin" {
+  count   = var.create_cloud_source_repos ? 1 : 0
+  project = module.cloudbuild_project.project_id
+  role    = "roles/source.admin"
+  member  = "group:${var.group_org_admins}"
+}
+
+/***********************************************
+ Cloud Build - Master branch triggers
+ ***********************************************/
+
+resource "google_cloudbuild_trigger" "master_trigger" {
+  for_each    = var.create_cloud_source_repos ? toset(var.cloud_source_repos) : []
+  project     = module.cloudbuild_project.project_id
+  description = "${each.value} - terraform apply."
 
   trigger_template {
     branch_name = local.apply_branches_regex
@@ -99,32 +163,134 @@ resource "google_cloudbuild_trigger" "main_trigger" {
   }
 
   substitutions = {
+    _ORG_ID               = var.org_id
     _BILLING_ID           = var.billing_account
-    _STATE_BUCKET_NAME    = google_storage_bucket.tfstate["${each.value}-tfstate"].name
-    _ARTIFACT_BUCKET_NAME = google_storage_bucket.cloudbuild_artifacts["${each.value}-ab"].name
+    _DEFAULT_REGION       = var.default_region
+    _GAR_REPOSITORY       = local.gar_name
+    _TF_SA_EMAIL          = var.terraform_sa_email
+    _STATE_BUCKET_NAME    = var.terraform_state_bucket
+    _ARTIFACT_BUCKET_NAME = google_storage_bucket.cloudbuild_artifacts.name
     _TF_ACTION            = "apply"
   }
 
   filename = var.cloudbuild_apply_filename
+  depends_on = [
+    google_sourcerepo_repository.gcp_repo,
+  ]
 }
 
-resource "google_cloudbuild_trigger" "non_main_trigger" {
-  for_each    = local.created_csrs
-  project     = var.cloudbuild_project_id
-  description = "${each.value}-terraform plan."
+/***********************************************
+ Cloud Build - Non Master branch triggers
+ ***********************************************/
+
+resource "google_cloudbuild_trigger" "non_master_trigger" {
+  for_each    = var.create_cloud_source_repos ? toset(var.cloud_source_repos) : []
+  project     = module.cloudbuild_project.project_id
+  description = "${each.value} - terraform plan."
 
   trigger_template {
+    invert_regex = true
     branch_name  = local.apply_branches_regex
     repo_name    = each.value
-    invert_regex = true
   }
 
   substitutions = {
+    _ORG_ID               = var.org_id
     _BILLING_ID           = var.billing_account
-    _STATE_BUCKET_NAME    = google_storage_bucket.tfstate["${each.value}-tfstate"].name
-    _ARTIFACT_BUCKET_NAME = google_storage_bucket.cloudbuild_artifacts["${each.value}-ab"].name
+    _DEFAULT_REGION       = var.default_region
+    _GAR_REPOSITORY       = local.gar_name
+    _TF_SA_EMAIL          = var.terraform_sa_email
+    _STATE_BUCKET_NAME    = var.terraform_state_bucket
+    _ARTIFACT_BUCKET_NAME = google_storage_bucket.cloudbuild_artifacts.name
     _TF_ACTION            = "plan"
   }
 
   filename = var.cloudbuild_plan_filename
+  depends_on = [
+    google_sourcerepo_repository.gcp_repo,
+  ]
+}
+
+/***********************************************
+ Cloud Build - Terraform Image Repo
+ ***********************************************/
+resource "google_artifact_registry_repository" "tf-image-repo" {
+  provider = google-beta
+  project  = module.cloudbuild_project.project_id
+
+  location      = var.default_region
+  repository_id = local.gar_repo_name
+  description   = "Docker repository for Terraform runner images used by Cloud Build"
+  format        = "DOCKER"
+}
+
+/***********************************************
+ Cloud Build - Terraform builder
+ ***********************************************/
+
+resource "null_resource" "cloudbuild_terraform_builder" {
+  triggers = {
+    project_id_cloudbuild_project = module.cloudbuild_project.project_id
+    terraform_version_sha256sum   = var.terraform_version_sha256sum
+    terraform_version             = var.terraform_version
+    gar_name                      = local.gar_name
+    gar_location                  = google_artifact_registry_repository.tf-image-repo.location
+  }
+
+  provisioner "local-exec" {
+    command = <<EOT
+      gcloud builds submit ${path.module}/cloudbuild_builder/ \
+      --project ${module.cloudbuild_project.project_id} \
+      --config=${path.module}/cloudbuild_builder/cloudbuild.yaml \
+      --substitutions=_TERRAFORM_VERSION=${var.terraform_version},_TERRAFORM_VERSION_SHA256SUM=${var.terraform_version_sha256sum},_TERRAFORM_VALIDATOR_RELEASE=${var.terraform_validator_release},_REGION=${google_artifact_registry_repository.tf-image-repo.location},_REPOSITORY=${local.gar_name}
+  EOT
+  }
+  depends_on = [
+    google_artifact_registry_repository_iam_member.terraform-image-iam
+  ]
+}
+
+/***********************************************
+  Cloud Build - IAM
+ ***********************************************/
+
+resource "google_storage_bucket_iam_member" "cloudbuild_artifacts_iam" {
+  bucket = google_storage_bucket.cloudbuild_artifacts.name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${module.cloudbuild_project.project_number}@cloudbuild.gserviceaccount.com"
+}
+
+resource "google_artifact_registry_repository_iam_member" "terraform-image-iam" {
+  provider = google-beta
+  project  = module.cloudbuild_project.project_id
+
+  location   = google_artifact_registry_repository.tf-image-repo.location
+  repository = google_artifact_registry_repository.tf-image-repo.name
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${module.cloudbuild_project.project_number}@cloudbuild.gserviceaccount.com"
+}
+
+resource "google_service_account_iam_member" "cloudbuild_terraform_sa_impersonate_permissions" {
+  count = local.impersonation_enabled_count
+
+  service_account_id = var.terraform_sa_name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${module.cloudbuild_project.project_number}@cloudbuild.gserviceaccount.com"
+}
+
+resource "google_organization_iam_member" "cloudbuild_serviceusage_consumer" {
+  count = local.impersonation_enabled_count
+
+  org_id = var.org_id
+  role   = "roles/serviceusage.serviceUsageConsumer"
+  member = "serviceAccount:${module.cloudbuild_project.project_number}@cloudbuild.gserviceaccount.com"
+}
+
+# Required to allow cloud build to access state with impersonation.
+resource "google_storage_bucket_iam_member" "cloudbuild_state_iam" {
+  count = local.impersonation_enabled_count
+
+  bucket = var.terraform_state_bucket
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${module.cloudbuild_project.project_number}@cloudbuild.gserviceaccount.com"
 }


### PR DESCRIPTION
Fix for issue [377](https://github.com/terraform-google-modules/terraform-example-foundation/issues/377) - _infra pipelines should use GAR_ 

Updated _main.tf_ file to use GAR instead of Container Registry.