### PR TITLE
add ports to IAP TCP forwarding rule

### DIFF
--- a/3-networks/envs/shared/hierarchical_firewall.tf
+++ b/3-networks/envs/shared/hierarchical_firewall.tf
@@ -57,11 +57,11 @@ module "hierarchical_firewall_policy" {
       logging                 = false
     }
     allow-iap-ssh-rdp = {
-      description             = "Always allow SSH and RDP from IAP"
-      direction               = "INGRESS"
-      action                  = "allow"
-      priority                = 5000
-      ranges                  = ["35.235.240.0/20"]
+      description = "Always allow SSH and RDP from IAP"
+      direction   = "INGRESS"
+      action      = "allow"
+      priority    = 5000
+      ranges      = ["35.235.240.0/20"]
       ports = {
         tcp = ["22", "3389"]
       }

--- a/3-networks/envs/shared/hierarchical_firewall.tf
+++ b/3-networks/envs/shared/hierarchical_firewall.tf
@@ -62,7 +62,9 @@ module "hierarchical_firewall_policy" {
       action                  = "allow"
       priority                = 5000
       ranges                  = ["35.235.240.0/20"]
-      ports                   = { "all" = [] }
+      ports = {
+        tcp = ["22", "3389"]
+      }
       target_service_accounts = null
       target_resources        = null
       logging                 = var.firewall_policies_enable_logging


### PR DESCRIPTION
This PR replaces the **allow all  protocols and ports** from the `allow-iap-ssh-rdp` rule
https://github.com/terraform-google-modules/terraform-example-foundation/blob/825d047679ec78ebd3f5b0fe72f6462bc029e573/3-networks/envs/shared/hierarchical_firewall.tf#L65

with the [recommended ports](https://cloud.google.com/iap/docs/using-tcp-forwarding#create-firewall-rule)

```
      ports = {
        tcp = ["22", "3389"]
      }
```