### PR TITLE
Use terraform 0.13.6 in build and readme

### DIFF
--- a/0-bootstrap/README-Jenkins.md
+++ b/0-bootstrap/README-Jenkins.md
@@ -125,7 +125,7 @@ You arrived to these instructions because you are using the `jenkins_bootstrap` 
 ### II. Create the SEED and CICD projects using Terraform
 
 - Required information:
-  - Terraform version 0.12.24 - See [Requirements](#requirements) section for more details.
+  - Terraform version 0.13.6 - See [Requirements](#requirements) section for more details.
   - The `terraform.tfvars` file with all the necessary values.
 
 1. Get the appropriate credentials: run the following command with an account that has the [necessary permissions](./modules/jenkins-agent/README.md#Permissions).
@@ -137,7 +137,7 @@ You arrived to these instructions because you are using the `jenkins_bootstrap` 
 1. Run terraform commands.
     - After the credentials are configured, we will create the `cft-seed` project (which contains the GCS state bucket and Terraform custom service account) and the `prj-cicd` project (which contains the Jenkins Agent, its custom service account and where we will add VPN configuration)
     - **WARNING: Make sure you have commented-out the `cloudbuild_bootstrap` module and enabled the `jenkins_bootstrap` module in the `./main.tf` file**
-    - **Use Terraform 0.12.24** to run the terraform script with the commands below
+    - **Use Terraform 0.13.6** to run the terraform script with the commands below
     ```
     terraform init
     terraform plan

--- a/0-bootstrap/README.md
+++ b/0-bootstrap/README.md
@@ -92,5 +92,5 @@ Currently, the bucket information is replaced in the state backends as a part of
 ### Software
 
 - [gcloud sdk](https://cloud.google.com/sdk/install) >= 206.0.0
-- [Terraform](https://www.terraform.io/downloads.html) >= 0.12.6
+- [Terraform](https://www.terraform.io/downloads.html) >= 0.13.6
     - You should use the same version in the manual steps during 0-bootstrap to avoid possible  [Terraform State Snapshot Lock](https://github.com/hashicorp/terraform/issues/23290) errors caused by differences in terraform versions. This can usually be resolved with a version upgrade.

--- a/0-bootstrap/main.tf
+++ b/0-bootstrap/main.tf
@@ -115,8 +115,8 @@ module "cloudbuild_bootstrap" {
   project_prefix              = var.project_prefix
   cloud_source_repos          = var.cloud_source_repos
   terraform_validator_release = "2021-01-21"
-  terraform_version           = "0.13.5"
-  terraform_version_sha256sum = "f7b7a7b1bfbf5d78151cfe3d1d463140b5fd6a354e71a7de2b5644e652ca5147"
+  terraform_version           = "0.13.6"
+  terraform_version_sha256sum = "55f2db00b05675026be9c898bdd3e8230ff0c5c78dd12d743ca38032092abfc9"
 
   activate_apis = [
     "serviceusage.googleapis.com",

--- a/0-bootstrap/modules/jenkins-agent/README.md
+++ b/0-bootstrap/modules/jenkins-agent/README.md
@@ -79,8 +79,8 @@ module "jenkins_bootstrap" {
 | terraform\_sa\_email | Email for terraform service account. It must be supplied by the seed project | `string` | n/a | yes |
 | terraform\_sa\_name | Fully-qualified name of the terraform service account. It must be supplied by the seed project | `string` | n/a | yes |
 | terraform\_state\_bucket | Default state bucket, used in Cloud Build substitutions. It must be supplied by the seed project | `string` | n/a | yes |
-| terraform\_version | Default terraform version. | `string` | `"0.12.24"` | no |
-| terraform\_version\_sha256sum | sha256sum for default terraform version. | `string` | `"602d2529aafdaa0f605c06adb7c72cfb585d8aa19b3f4d8d189b42589e27bf11"` | no |
+| terraform\_version | Default terraform version. | `string` | `"0.13.6"` | no |
+| terraform\_version\_sha256sum | sha256sum for default terraform version. | `string` | `"55f2db00b05675026be9c898bdd3e8230ff0c5c78dd12d743ca38032092abfc9"` | no |
 | tunnel0\_bgp\_peer\_address | BGP peer address for tunnel 0 | `string` | n/a | yes |
 | tunnel0\_bgp\_session\_range | BGP session range for tunnel 0 | `string` | n/a | yes |
 | tunnel1\_bgp\_peer\_address | BGP peer address for tunnel 1 | `string` | n/a | yes |
@@ -105,8 +105,8 @@ module "jenkins_bootstrap" {
 ### Software
 
 - [gcloud sdk](https://cloud.google.com/sdk/install) >= 206.0.0
-- [Terraform](https://www.terraform.io/downloads.html) = 0.12.24
-    - The scripts in this codebase use Terraform v0.12.24. You should use the same version in the manual steps to avoid [Terraform State Snapshot Lock](https://github.com/hashicorp/terraform/issues/23290) errors caused by differences in terraform versions.
+- [Terraform](https://www.terraform.io/downloads.html) = 0.13.6
+    - The scripts in this codebase use Terraform v0.13.6. You should use the same version in the manual steps to avoid [Terraform State Snapshot Lock](https://github.com/hashicorp/terraform/issues/23290) errors caused by differences in terraform versions.
 
 ### Infrastructure
 

--- a/0-bootstrap/modules/jenkins-agent/variables.tf
+++ b/0-bootstrap/modules/jenkins-agent/variables.tf
@@ -224,11 +224,11 @@ variable "folder_id" {
 variable "terraform_version" {
   description = "Default terraform version."
   type        = string
-  default     = "0.12.24"
+  default     = "0.13.6"
 }
 
 variable "terraform_version_sha256sum" {
   description = "sha256sum for default terraform version."
   type        = string
-  default     = "602d2529aafdaa0f605c06adb7c72cfb585d8aa19b3f4d8d189b42589e27bf11"
+  default     = "55f2db00b05675026be9c898bdd3e8230ff0c5c78dd12d743ca38032092abfc9"
 }

--- a/3-networks/modules/base_shared_vpc/versions.tf
+++ b/3-networks/modules/base_shared_vpc/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/3-networks/modules/restricted_shared_vpc/versions.tf
+++ b/3-networks/modules/restricted_shared_vpc/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/4-projects/modules/infra_pipelines/cloudbuild_builder/cloudbuild.yaml
+++ b/4-projects/modules/infra_pipelines/cloudbuild_builder/cloudbuild.yaml
@@ -27,7 +27,7 @@ steps:
 - name: 'gcr.io/${PROJECT_ID}/terraform'
   args: ['version']
 substitutions:
-  _TERRAFORM_VERSION: '0.12.29' # default value
-  _TERRAFORM_VERSION_SHA256SUM: '872245d9c6302b24dc0d98a1e010aef1e4ef60865a2d1f60102c8ad03e9d5a1d' # default value
+  _TERRAFORM_VERSION: '0.13.6' # default value
+  _TERRAFORM_VERSION_SHA256SUM: '55f2db00b05675026be9c898bdd3e8230ff0c5c78dd12d743ca38032092abfc9' # default value
   _TERRAFORM_VALIDATOR_RELEASE: '2020-09-24'
 images: ['gcr.io/${PROJECT_ID}/terraform']

--- a/test/bundle.hcl
+++ b/test/bundle.hcl
@@ -1,5 +1,5 @@
 terraform {
-  version = "0.13.5"
+  version = "0.13.6"
 }
 
 providers {


### PR DESCRIPTION
This PR sets the `terraform` version to `0.13.6` in the code and and in the references in the READMEs.