### PR TITLE
Replace project_prefix used in the integration tests

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -102,7 +102,7 @@ tags:
 options:
   env:
   - 'TF_VAR_example_foundations_mode=$_EXAMPLE_FOUNDATIONS_TEST_MODE'
-  - 'TF_VAR_project_prefix=tst'
+  - 'TF_VAR_project_prefix=t01'
   - 'TF_VAR_domain_to_allow=test.infra.cft.tips'
   - 'TF_VAR_domain=test.infra.cft.tips.'
   - 'TF_VAR_org_id=$_ORG_ID'


### PR DESCRIPTION
Replace project_prefix used in the integration tests.
Changed from `tst` to `t01`.

Collision of new projects with existing projects has become more frequent:

```
       Error: error creating project tst-p-shared-restricted-4d2b (tst-p-shared-restricted): googleapi: Error 409: Requested entity already exists, alreadyExists. If you received a 403 error, make sure you have the `roles/resourcemanager.projectCreator` permission
       
         on .terraform/modules/production.env.restricted_shared_vpc_host_project/modules/core_project_factory/main.tf line 65, in resource "google_project" "main":
         65: resource "google_project" "main" {    
``` 