### PR TITLE
add standalone repo for terraform-validator policies

### DIFF
--- a/0-bootstrap/README.md
+++ b/0-bootstrap/README.md
@@ -61,7 +61,7 @@ Currently, the bucket information is replaced in the state backends as a part of
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | billing\_account | The ID of the billing account to associate projects with. | `string` | n/a | yes |
-| cloud\_source\_repos | List of Cloud Source Repositories created during bootstrap project build stage | `list(string)` | <pre>[<br>  "gcp-org",<br>  "gcp-environments",<br>  "gcp-networks",<br>  "gcp-projects",<br>  "gcp-policies"<br>]</pre> | no |
+| cloud\_source\_repos | List of Cloud Source Repositories created during bootstrap project build stage for use with Cloud Build. | `list(string)` | <pre>[<br>  "gcp-org",<br>  "gcp-environments",<br>  "gcp-networks",<br>  "gcp-projects"<br>]</pre> | no |
 | default\_region | Default region to create resources where applicable. | `string` | `"us-central1"` | no |
 | folder\_prefix | Name prefix to use for folders created. | `string` | `"fldr"` | no |
 | group\_billing\_admins | Google Group for GCP Billing Administrators | `string` | n/a | yes |
@@ -85,6 +85,7 @@ Currently, the bucket information is replaced in the state backends as a part of
 | seed\_project\_id | Project where service accounts and core APIs will be enabled. |
 | terraform\_sa\_name | Fully qualified name for privileged service account for Terraform. |
 | terraform\_service\_account | Email for privileged service account for Terraform. |
+| terraform\_validator\_policies\_repo | Cloud Source Repository created for terraform-validator policies. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/0-bootstrap/main.tf
+++ b/0-bootstrap/main.tf
@@ -153,8 +153,8 @@ module "cloudbuild_bootstrap" {
 // Standalone repo for Terraform-validator policies.
 // This repo does not need to trigger builds in Cloud Build.
 resource "google_sourcerepo_repository" "gcp_policies" {
-  project  = module.cloudbuild_bootstrap.cloudbuild_project_id
-  name     = "gcp-policies"
+  project = module.cloudbuild_bootstrap.cloudbuild_project_id
+  name    = "gcp-policies"
 
   depends_on = [module.cloudbuild_bootstrap.csr_repos]
 }

--- a/0-bootstrap/main.tf
+++ b/0-bootstrap/main.tf
@@ -150,6 +150,15 @@ module "cloudbuild_bootstrap" {
   ]
 }
 
+// Standalone repo for Terraform-validator policies.
+// This repo does not need to trigger builds in Cloud Build.
+resource "google_sourcerepo_repository" "gcp_policies" {
+  project  = module.cloudbuild_bootstrap.cloudbuild_project_id
+  name     = "gcp-policies"
+
+  depends_on = [module.cloudbuild_bootstrap.csr_repos]
+}
+
 resource "google_project_iam_member" "project_source_reader" {
   project = module.cloudbuild_bootstrap.cloudbuild_project_id
   role    = "roles/source.reader"

--- a/0-bootstrap/outputs.tf
+++ b/0-bootstrap/outputs.tf
@@ -53,6 +53,11 @@ output "csr_repos" {
   value       = module.cloudbuild_bootstrap.csr_repos
 }
 
+output "terraform_validator_policies_repo" {
+  description = "Cloud Source Repository created for terraform-validator policies."
+  value       = google_sourcerepo_repository.gcp_policies
+}
+
 output "kms_keyring" {
   description = "KMS Keyring created by the module."
   value       = module.cloudbuild_bootstrap.kms_keyring

--- a/0-bootstrap/variables.tf
+++ b/0-bootstrap/variables.tf
@@ -70,9 +70,9 @@ variable "folder_prefix" {
   default     = "fldr"
 }
 variable "cloud_source_repos" {
-  description = "List of Cloud Source Repositories created during bootstrap project build stage"
+  description = "List of Cloud Source Repositories created during bootstrap project build stage for use with Cloud Build."
   type        = list(string)
-  default     = ["gcp-org", "gcp-environments", "gcp-networks", "gcp-projects", "gcp-policies"]
+  default     = ["gcp-org", "gcp-environments", "gcp-networks", "gcp-projects"]
 }
 
 /* ----------------------------------------

--- a/test/integration/bootstrap/controls/gcp_cloudbuild.rb
+++ b/test/integration/bootstrap/controls/gcp_cloudbuild.rb
@@ -18,7 +18,8 @@ cloud_source_repos = [
   'gcp-org',
   'gcp-environments',
   'gcp-networks',
-  'gcp-projects'
+  'gcp-projects',
+  'gcp-policies'
 ]
 
 control 'gcp_cloudbuild' do


### PR DESCRIPTION
This PR replaces the Google source repo created by the bootstrap cloud build module `gcp-policies` by a standalone `gcp-policies` repo because this repo does not need to have  Cloud Build triggers configured for it. 