### PR TITLE
Fix CMEK project name and root readme project names

### DIFF
--- a/0-bootstrap/README-Jenkins.md
+++ b/0-bootstrap/README-Jenkins.md
@@ -6,12 +6,12 @@ Another CICD option is to use Cloud Build & Cloud Source Repos. If you don't hav
 
 ## Overview
 
-The objective of the instructions below is to configure the infrastructure that allows you to run CICD deployments for the next stages (`1-org, 2-environments, 3-networks, 4-projects`) using Jenkins. The infrastructure consists in two Google Cloud Platform projects (`prj-seed` and `prj-cicd`) and VPN configuration to connect to your on-prem environment.
+The objective of the instructions below is to configure the infrastructure that allows you to run CICD deployments for the next stages (`1-org, 2-environments, 3-networks, 4-projects`) using Jenkins. The infrastructure consists in two Google Cloud Platform projects (`prj-b-seed` and `prj-cicd`) and VPN configuration to connect to your on-prem environment.
 
-It is a best practice to have two separate projects here (`prj-seed` and `prj-cicd`) for separation of concerns. On one hand, `prj-seed` stores terraform state and has the Service Account able to create / modify infrastructure. On the other hand, the deployment of that infrastructure is coordinated by Jenkins, which is implemented in `prj-cicd` and connected to your Master on-prem.
+It is a best practice to have two separate projects here (`prj-b-seed` and `prj-cicd`) for separation of concerns. On one hand, `prj-b-seed` stores terraform state and has the Service Account able to create / modify infrastructure. On the other hand, the deployment of that infrastructure is coordinated by Jenkins, which is implemented in `prj-cicd` and connected to your Master on-prem.
 
 **After following the instructions below, you will have:**
-- The `prj-seed` project, which contains:
+- The `prj-b-seed` project, which contains:
   - Terraform state bucket
   - Custom Service Account used by Terraform to create new resources in GCP
 - The `prj-cicd` project, which contains:
@@ -20,7 +20,7 @@ It is a best practice to have two separate projects here (`prj-seed` and `prj-ci
   - FW rules to allow communication over port 22
   - VPN connection with on-prem (or where ever your Jenkins Master is located)
   - Custom service account `sa-jenkins-agent-gce@prj-cicd-xxxx.iam.gserviceaccount.com` for the GCE instance.
-      - This service account is granted the access to generate tokens on the Terraform custom service account in the `prj-seed` project
+      - This service account is granted the access to generate tokens on the Terraform custom service account in the `prj-b-seed` project
 
 - **Note: these instructions do not indicate how to create a Jenkins Master.** To deploy a Jenkins Master, you should follow [Jenkins Architecture](https://www.jenkins.io/doc/book/architecting-for-scale/) recommendations.
 
@@ -135,7 +135,7 @@ You arrived to these instructions because you are using the `jenkins_bootstrap` 
     1. Open the link in your browser and accept.
 
 1. Run terraform commands.
-    - After the credentials are configured, we will create the `prj-seed` project (which contains the GCS state bucket and Terraform custom service account) and the `prj-cicd` project (which contains the Jenkins Agent, its custom service account and where we will add VPN configuration)
+    - After the credentials are configured, we will create the `prj-b-seed` project (which contains the GCS state bucket and Terraform custom service account) and the `prj-cicd` project (which contains the Jenkins Agent, its custom service account and where we will add VPN configuration)
     - **WARNING: Make sure you have commented-out the `cloudbuild_bootstrap` module and enabled the `jenkins_bootstrap` module in the `./main.tf` file**
     - **Use Terraform 0.13.6** to run the terraform script with the commands below
     ```

--- a/0-bootstrap/modules/jenkins-agent/README.md
+++ b/0-bootstrap/modules/jenkins-agent/README.md
@@ -1,12 +1,12 @@
 ## Overview
 
-The objective of this module is to deploy a Google Cloud Platform project `prj-cicd` to host a Jenkins Agent that can connect with your current Jenkins Master on-prem. This module is a replica of the [cloudbuild module](https://github.com/terraform-google-modules/terraform-google-bootstrap/tree/master/modules/cloudbuild), but re-purposed to use Jenkins instead. This module creates:
-- The `prj-cicd` project, which includes:
+The objective of this module is to deploy a Google Cloud Platform project `prj-b-cicd` to host a Jenkins Agent that can connect with your current Jenkins Master on-prem. This module is a replica of the [cloudbuild module](https://github.com/terraform-google-modules/terraform-google-bootstrap/tree/master/modules/cloudbuild), but re-purposed to use Jenkins instead. This module creates:
+- The `prj-b-cicd` project, which includes:
     - GCE Instance for the Jenkins Agent, which you will configure to connect to your current Jenkins Master using SSH.
     - VPC to connect the Jenkins GCE Instance to
     - FW rules to allow communication over port 22
     - VPN connection with on-prem (or where ever your Jenkins Master is located)
-    - Custom service account `sa-jenkins-agent-gce@prj-cicd-xxxx.iam.gserviceaccount.com` for the GCE instance. This service account is granted the access to generate tokens on the provided Terraform custom service account
+    - Custom service account `sa-jenkins-agent-gce@prj-b-cicd-xxxx.iam.gserviceaccount.com` for the GCE instance. This service account is granted the access to generate tokens on the provided Terraform custom service account
 Please note this module does not include an option to create a Jenkins Master. To deploy a Jenkins Master, you should follow one of the available user guides about [Jenkins in GCP](https://cloud.google.com/jenkins).
 
 **If you don't have a Jenkins implementation and don't want one**, then we recommend you to [use the Cloud Build module](../../README.md) instead.

--- a/0-bootstrap/modules/jenkins-agent/main.tf
+++ b/0-bootstrap/modules/jenkins-agent/main.tf
@@ -15,7 +15,7 @@
  */
 
 locals {
-  cicd_project_name           = format("%s-%s", var.project_prefix, "cicd")
+  cicd_project_name           = format("%s-%s", var.project_prefix, "b-cicd")
   impersonation_enabled_count = var.sa_enable_impersonation ? 1 : 0
   activate_apis               = distinct(concat(var.activate_apis, ["billingbudgets.googleapis.com"]))
   jenkins_gce_fw_tags         = ["ssh-jenkins-agent"]

--- a/4-projects/business_unit_1/development/example_storage_cmek.tf
+++ b/4-projects/business_unit_1/development/example_storage_cmek.tf
@@ -25,6 +25,7 @@ module "env_secrets_project" {
   alert_pubsub_topic          = var.alert_pubsub_topic
   budget_amount               = var.budget_amount
   project_suffix              = var.secrets_prj_suffix
+  project_prefix              = var.project_prefix
 
   activate_apis = ["logging.googleapis.com", "secretmanager.googleapis.com", "cloudkms.googleapis.com"]
 

--- a/4-projects/business_unit_1/non-production/example_storage_cmek.tf
+++ b/4-projects/business_unit_1/non-production/example_storage_cmek.tf
@@ -25,6 +25,7 @@ module "env_secrets_project" {
   alert_pubsub_topic          = var.alert_pubsub_topic
   budget_amount               = var.budget_amount
   project_suffix              = var.secrets_prj_suffix
+  project_prefix              = var.project_prefix
 
   activate_apis = ["logging.googleapis.com", "secretmanager.googleapis.com", "cloudkms.googleapis.com"]
 

--- a/4-projects/business_unit_1/production/example_storage_cmek.tf
+++ b/4-projects/business_unit_1/production/example_storage_cmek.tf
@@ -25,6 +25,7 @@ module "env_secrets_project" {
   alert_pubsub_topic          = var.alert_pubsub_topic
   budget_amount               = var.budget_amount
   project_suffix              = var.secrets_prj_suffix
+  project_prefix              = var.project_prefix
 
   activate_apis = ["logging.googleapis.com", "secretmanager.googleapis.com", "cloudkms.googleapis.com"]
 

--- a/4-projects/business_unit_2/development/example_storage_cmek.tf
+++ b/4-projects/business_unit_2/development/example_storage_cmek.tf
@@ -25,6 +25,7 @@ module "env_secrets_project" {
   alert_pubsub_topic          = var.alert_pubsub_topic
   budget_amount               = var.budget_amount
   project_suffix              = var.secrets_prj_suffix
+  project_prefix              = var.project_prefix
 
   activate_apis = ["logging.googleapis.com", "secretmanager.googleapis.com", "cloudkms.googleapis.com"]
 

--- a/4-projects/business_unit_2/non-production/example_storage_cmek.tf
+++ b/4-projects/business_unit_2/non-production/example_storage_cmek.tf
@@ -25,6 +25,7 @@ module "env_secrets_project" {
   alert_pubsub_topic          = var.alert_pubsub_topic
   budget_amount               = var.budget_amount
   project_suffix              = var.secrets_prj_suffix
+  project_prefix              = var.project_prefix
 
   activate_apis = ["logging.googleapis.com", "secretmanager.googleapis.com", "cloudkms.googleapis.com"]
 

--- a/4-projects/business_unit_2/production/example_storage_cmek.tf
+++ b/4-projects/business_unit_2/production/example_storage_cmek.tf
@@ -25,6 +25,7 @@ module "env_secrets_project" {
   alert_pubsub_topic          = var.alert_pubsub_topic
   budget_amount               = var.budget_amount
   project_suffix              = var.secrets_prj_suffix
+  project_prefix              = var.project_prefix
 
   activate_apis = ["logging.googleapis.com", "secretmanager.googleapis.com", "cloudkms.googleapis.com"]
 

--- a/README.md
+++ b/README.md
@@ -164,28 +164,34 @@ Running this code as-is should generate a structure as shown below:
 ```
 example-organization/
 └── fldr-development
+    ├── prj-bu1-d-env-secrets
     ├── prj-bu1-d-sample-floating
     ├── prj-bu1-d-sample-base
     ├── prj-bu1-d-sample-restrict
     ├── prj-bu1-d-sample-peering
+    ├── prj-bu2-d-env-secrets
     ├── prj-bu2-d-sample-floating
     ├── prj-bu2-d-sample-base
     ├── prj-bu2-d-sample-restrict
     └── prj-bu2-d-sample-peering
 └── fldr-non-production
+    ├── prj-bu1-n-env-secrets
     ├── prj-bu1-n-sample-floating
     ├── prj-bu1-n-sample-base
     ├── prj-bu1-n-sample-restrict
     ├── prj-bu1-n-sample-peering
+    ├── prj-bu2-n-env-secrets
     ├── prj-bu2-n-sample-floating
     ├── prj-bu2-n-sample-base
     ├── prj-bu2-n-sample-restrict
     └── prj-bu2-n-sample-peering
 └── fldr-production
+    ├── prj-bu1-p-env-secrets
     ├── prj-bu1-p-sample-floating
     ├── prj-bu1-p-sample-base
     ├── prj-bu1-p-sample-restrict
     ├── prj-bu1-p-sample-peering
+    ├── prj-bu2-p-env-secrets
     ├── prj-bu2-p-sample-floating
     ├── prj-bu2-p-sample-base
     ├── prj-bu2-p-sample-restrict
@@ -194,6 +200,7 @@ example-organization/
     ├── prj-bu1-c-infra-pipeline
     └── prj-bu2-c-infra-pipeline
 ```
+
 The code in this step includes two options for creating projects.
 The first is the standard projects module which creates a project per environment and the second creates a standalone project for one environment.
 If relevant for your use case, there are also two optional submodules which can be used to create a subnet per project and a dedicated private DNS zone per project.
@@ -218,10 +225,12 @@ example-organization
     ├── prj-bu1-c-infra-pipeline
     └── prj-bu2-c-infra-pipeline
 └── fldr-development
+    ├── prj-bu1-d-env-secrets
     ├── prj-bu1-d-sample-floating
     ├── prj-bu1-d-sample-base
     ├── prj-bu1-d-sample-restrict
     ├── prj-bu1-d-sample-peering
+    ├── prj-bu2-d-env-secrets
     ├── prj-bu2-d-sample-floating
     ├── prj-bu2-d-sample-base
     ├── prj-bu2-d-sample-restrict
@@ -231,10 +240,12 @@ example-organization
     ├── prj-d-shared-base
     └── prj-d-shared-restricted
 └── fldr-non-production
+    ├── prj-bu1-n-env-secrets
     ├── prj-bu1-n-sample-floating
     ├── prj-bu1-n-sample-base
     ├── prj-bu1-n-sample-restrict
     ├── prj-bu1-n-sample-peering
+    ├── prj-bu2-n-env-secrets
     ├── prj-bu2-n-sample-floating
     ├── prj-bu2-n-sample-base
     ├── prj-bu2-n-sample-restrict
@@ -244,10 +255,12 @@ example-organization
     ├── prj-n-shared-base
     └── prj-n-shared-restricted
 └── fldr-production
+    ├── prj-bu1-p-env-secrets
     ├── prj-bu1-p-sample-floating
     ├── prj-bu1-p-sample-base
     ├── prj-bu1-p-sample-restrict
     ├── prj-bu1-p-sample-peering
+    ├── prj-bu2-p-env-secrets
     ├── prj-bu2-p-sample-floating
     ├── prj-bu2-p-sample-base
     ├── prj-bu2-p-sample-restrict
@@ -260,6 +273,7 @@ example-organization
     ├── prj-cloudbuild (prj-cicd if using Jenkins)
     └── prj-seed
 ```
+
 ### Branching strategy
 
 There are three main named branches - `development`, `non-production` and `production` that reflect the corresponding environments. These branches should be [protected](https://docs.github.com/en/github/administering-a-repository/about-protected-branches). When the CI/CD pipeline (Jenkins/CloudBuild) runs on a particular named branch (say for instance `development`), only the corresponding environment (`development`) is applied. An exception is the `shared` environment which is only applied when triggered on the `production` branch. This is because any changes in the `shared` environment may affect resources in other environments and can have adverse effects if not validated correctly.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The bootstrap step includes:
 - The `prj-b-seed` project, which contains:
   - Terraform state bucket
   - Custom Service Account used by Terraform to create new resources in GCP
-- The `prj-b-cicd` project (`prj-cicd` if using Jenkins), which contains:
+- The `prj-b-cicd` project, which contains:
   - A CI/CD pipeline implemented with either Cloud Build or Jenkins
   - If using Cloud Build:
     - Cloud Source Repository
@@ -28,10 +28,10 @@ The bootstrap step includes:
 
 It is a best practice to separate concerns by having two projects here: one for the CFT resources and one for the CI/CD tool.
 The `prj-b-seed` project stores Terraform state and has the Service Account able to create / modify infrastructure.
-On the other hand, the deployment of that infrastructure is coordinated by a CI/CD tool of your choice allocated in a second project (named `prj-b-cicd` project if using Google Cloud Build and `prj-cicd` project if using Jenkins).
+On the other hand, the deployment of that infrastructure is coordinated by a CI/CD tool of your choice allocated in a second project named `prj-b-cicd`.
 
 To further separate the concerns at the IAM level as well, the service account of the CI/CD tool is given different permissions than the Terraform account.
-The CI/CD tool account (`@cloudbuild.gserviceaccount.com` if using Cloud Build and `sa-jenkins-agent-gce@prj-cicd-xxxx.iam.gserviceaccount.com` if using Jenkins) is granted access to generate tokens over the Terraform custom service account.
+The CI/CD tool account (`@cloudbuild.gserviceaccount.com` if using Cloud Build and `sa-jenkins-agent-gce@prj-b-cicd-xxxx.iam.gserviceaccount.com` if using Jenkins) is granted access to generate tokens over the Terraform custom service account.
 In this configuration, the baseline permissions of the CI/CD tool are limited and the Terraform custom Service Account is granted the IAM permissions required to build the foundation.
 
 After executing this step, you will have the following structure:
@@ -39,7 +39,7 @@ After executing this step, you will have the following structure:
 ```
 example-organization/
 └── fldr-bootstrap
-    ├── prj-b-cicd (prj-cicd if using Jenkins)
+    ├── prj-b-cicd
     └── prj-b-seed
 ```
 
@@ -270,7 +270,7 @@ example-organization
     ├── prj-p-shared-base
     └── prj-p-shared-restricted
 └── fldr-bootstrap
-    ├── prj-b-cicd (prj-cicd if using Jenkins)
+    ├── prj-b-cicd
     └── prj-b-seed
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ This stage executes the [CFT Bootstrap module](https://github.com/terraform-goog
 For CI/CD pipelines, you can use either Cloud Build (by default) or Jenkins. If you want to use Jenkins instead of Cloud Build, please see [README-Jenkins](./0-bootstrap/README-Jenkins.md) on how to use the included Jenkins sub-module.
 
 The bootstrap step includes:
-- The `prj-seed` project, which contains:
+- The `prj-b-seed` project, which contains:
   - Terraform state bucket
   - Custom Service Account used by Terraform to create new resources in GCP
-- The `prj-cloudbuild` project (`prj-cicd` if using Jenkins), which contains:
+- The `prj-b-cicd` project (`prj-cicd` if using Jenkins), which contains:
   - A CI/CD pipeline implemented with either Cloud Build or Jenkins
   - If using Cloud Build:
     - Cloud Source Repository
@@ -27,8 +27,8 @@ The bootstrap step includes:
     - VPN connection with on-prem (or where ever your Jenkins Master is located)
 
 It is a best practice to separate concerns by having two projects here: one for the CFT resources and one for the CI/CD tool.
-The `prj-seed` project stores Terraform state and has the Service Account able to create / modify infrastructure.
-On the other hand, the deployment of that infrastructure is coordinated by a CI/CD tool of your choice allocated in a second project (named `prj-cloudbuild` project if using Google Cloud Build and `prj-cicd` project if using Jenkins).
+The `prj-b-seed` project stores Terraform state and has the Service Account able to create / modify infrastructure.
+On the other hand, the deployment of that infrastructure is coordinated by a CI/CD tool of your choice allocated in a second project (named `prj-b-cicd` project if using Google Cloud Build and `prj-cicd` project if using Jenkins).
 
 To further separate the concerns at the IAM level as well, the service account of the CI/CD tool is given different permissions than the Terraform account.
 The CI/CD tool account (`@cloudbuild.gserviceaccount.com` if using Cloud Build and `sa-jenkins-agent-gce@prj-cicd-xxxx.iam.gserviceaccount.com` if using Jenkins) is granted access to generate tokens over the Terraform custom service account.
@@ -39,8 +39,8 @@ After executing this step, you will have the following structure:
 ```
 example-organization/
 └── fldr-bootstrap
-    ├── prj-cloudbuild (prj-cicd if using Jenkins)
-    └── prj-seed
+    ├── prj-b-cicd (prj-cicd if using Jenkins)
+    └── prj-b-seed
 ```
 
 When this step uses the Cloud Build submodule, it sets up Cloud Build and Cloud Source Repositories for each of the stages below.
@@ -270,8 +270,8 @@ example-organization
     ├── prj-p-shared-base
     └── prj-p-shared-restricted
 └── fldr-bootstrap
-    ├── prj-cloudbuild (prj-cicd if using Jenkins)
-    └── prj-seed
+    ├── prj-b-cicd (prj-cicd if using Jenkins)
+    └── prj-b-seed
 ```
 
 ### Branching strategy


### PR DESCRIPTION
This PR closes https://github.com/terraform-google-modules/terraform-example-foundation/issues/410 , https://github.com/terraform-google-modules/terraform-example-foundation/issues/411 ,  https://github.com/terraform-google-modules/terraform-example-foundation/issues/412 

Also this PR unifies the name of the CICD project in **Jenkins** and **Cloud Build** to be `prj-b-cicd`