### PR TITLE
Fix hub and spoke transitivity issues

### DIFF
--- a/3-networks/envs/shared/net-hubs-transitivity.tf
+++ b/3-networks/envs/shared/net-hubs-transitivity.tf
@@ -67,6 +67,8 @@ module "base_transitivity" {
     # SNAT traffic not to the local eth0 interface
     "iptables -t nat -A POSTROUTING ! -d $(curl -H \"Metadata-Flavor: Google\" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip) -j MASQUERADE",
   ]
+
+  depends_on = [module.base_shared_vpc]
 }
 
 /*
@@ -98,4 +100,6 @@ module "restricted_transitivity" {
     # SNAT traffic not to the local eth0 interface
     "iptables -t nat -A POSTROUTING ! -d $(curl -H \"Metadata-Flavor: Google\" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip) -j MASQUERADE",
   ]
+
+  depends_on = [module.restricted_shared_vpc]
 }

--- a/3-networks/modules/transitivity/main.tf
+++ b/3-networks/modules/transitivity/main.tf
@@ -65,7 +65,7 @@ module "migs" {
       max_surge_fixed              = 4
       max_surge_percent            = null
       instance_redistribution_type = "NONE"
-      max_unavailable_fixed        = 3
+      max_unavailable_fixed        = 4
       max_unavailable_percent      = null
       min_ready_sec                = 180
       minimal_action               = "RESTART"

--- a/3-networks/modules/transitivity/main.tf
+++ b/3-networks/modules/transitivity/main.tf
@@ -62,7 +62,7 @@ module "migs" {
   instance_template = module.templates[each.key].self_link
   update_policy = [
     {
-      max_surge_fixed              = 3
+      max_surge_fixed              = 4
       max_surge_percent            = null
       instance_redistribution_type = "NONE"
       max_unavailable_fixed        = 3

--- a/test/fixtures/shared/main.tf
+++ b/test/fixtures/shared/main.tf
@@ -15,14 +15,15 @@
  */
 
 module "shared" {
-  source                           = "../../../3-networks/envs/shared"
-  default_region1                  = "us-central1"
-  default_region2                  = "us-west1"
-  domain                           = var.domain
-  access_context_manager_policy_id = var.policy_id
-  target_name_server_addresses     = ["192.168.0.1", "192.168.0.2"]
-  terraform_service_account        = var.terraform_service_account
-  parent_folder                    = var.parent_folder
-  enable_hub_and_spoke             = var.enable_hub_and_spoke
-  org_id                           = var.org_id
+  source                            = "../../../3-networks/envs/shared"
+  default_region1                   = "us-central1"
+  default_region2                   = "us-west1"
+  domain                            = var.domain
+  access_context_manager_policy_id  = var.policy_id
+  target_name_server_addresses      = ["192.168.0.1", "192.168.0.2"]
+  terraform_service_account         = var.terraform_service_account
+  parent_folder                     = var.parent_folder
+  enable_hub_and_spoke              = var.enable_hub_and_spoke
+  enable_hub_and_spoke_transitivity = var.enable_hub_and_spoke_transitivity
+  org_id                            = var.org_id
 }

--- a/test/fixtures/shared/variables.tf
+++ b/test/fixtures/shared/variables.tf
@@ -44,3 +44,9 @@ variable "enable_hub_and_spoke" {
   type        = bool
   default     = false
 }
+
+variable "enable_hub_and_spoke_transitivity" {
+  description = "Enable transitivity via gateway VMs on Hub-and-Spoke architecture."
+  type        = bool
+  default     = false
+}

--- a/test/setup/outputs.tf
+++ b/test/setup/outputs.tf
@@ -52,3 +52,7 @@ output "group_email" {
 output "enable_hub_and_spoke" {
   value = var.example_foundations_mode == "HubAndSpoke" ? "true" : "false"
 }
+
+output "enable_hub_and_spoke_transitivity" {
+  value = var.example_foundations_mode == "HubAndSpoke" ? "true" : "false"
+}


### PR DESCRIPTION
This PR Fixes some issues when enabling hub and spoke transitivity.

- [x] reproduce error that happens in manual deploy in the integration build.
- [x] add `depends_on` in the call to the transitivity module.
- [x] Fix google_compute_region_instance_group_manager fixed `max_surge_fixed` for regional managed instance group issue
- [x] Fix google_compute_region_instance_group_manager fixed `max_unavailable_fixed` for regional managed instance group issue