### PR TITLE
Update google cloud sdk min version to 319.0.0 and use GA version of gcloud scc notifications

### DIFF
--- a/0-bootstrap/README.md
+++ b/0-bootstrap/README.md
@@ -62,8 +62,7 @@ The purpose of this step is to bootstrap a Google Cloud organization, creating a
 To run the commands described in this document, you need to have the following
 installed:
 
-- The [Google Cloud SDK](https://cloud.google.com/sdk/install) version
-   206.0.0 or later
+- The [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
 - [Terraform](https://www.terraform.io/downloads.html) version 0.13.6.
 - An existing project which the user has access to be used by terraform-validator.
 

--- a/1-org/envs/shared/scc_notification.tf
+++ b/1-org/envs/shared/scc_notification.tf
@@ -37,7 +37,7 @@ module "scc_notification" {
 
   create_cmd_entrypoint = "gcloud"
   create_cmd_body       = <<-EOF
-    alpha scc notifications create ${var.scc_notification_name} --organization ${var.org_id} \
+    scc notifications create ${var.scc_notification_name} --organization ${var.org_id} \
     --description "SCC Notification for all active findings" \
     --pubsub-topic projects/${module.scc_notifications.project_id}/topics/${google_pubsub_topic.scc_notification_topic.name} \
     --filter "${var.scc_notification_filter}" \
@@ -47,7 +47,7 @@ EOF
 
   destroy_cmd_entrypoint = "gcloud"
   destroy_cmd_body       = <<-EOF
-  alpha scc notifications delete organizations/${var.org_id}/notificationConfigs/${var.scc_notification_name} \
+  scc notifications delete organizations/${var.org_id}/notificationConfigs/${var.scc_notification_name} \
   --impersonate-service-account ${var.terraform_service_account} \
   --project "${module.scc_notifications.project_id}" \
   --quiet

--- a/test/clean_org.sh
+++ b/test/clean_org.sh
@@ -20,6 +20,6 @@ source /usr/local/bin/task_helper_functions.sh && source_test_env && init_creden
 gcloud config set project "${TF_VAR_project_id:?}"
 # sleep 60s to give time for permissions in prepare step to take effect
 sleep 60
-gcloud alpha scc notifications delete test-scc-notification --organization "${TF_VAR_org_id:?}" -q || true
+gcloud scc notifications delete test-scc-notification --organization "${TF_VAR_org_id:?}" -q || true
 POLICY_ID=$(gcloud access-context-manager policies list --organization="${TF_VAR_org_id:?}" --format="value(name)")
 gcloud access-context-manager policies delete "${POLICY_ID}" -q || true

--- a/test/integration/org/controls/gcloud_scc.rb
+++ b/test/integration/org/controls/gcloud_scc.rb
@@ -19,7 +19,7 @@ org_id = attribute('org_id')
 control 'gcloud_scc' do
   title 'step 1-org scc notifications tests'
 
-  describe command("gcloud alpha scc notifications describe #{scc_notification_name} --organization=#{org_id} --format=json") do
+  describe command("gcloud scc notifications describe #{scc_notification_name} --organization=#{org_id} --format=json") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq '' }
 


### PR DESCRIPTION
This PR:
- Update google cloud sdk min version to 319.0.0 (the same version of the docker image for developer-tools:0.13  )
- Use GA version of `gcloud scc notifications`