### PR TITLE
 1-org README.md add setting up Security Command Center to Prerequisites

### DIFF
--- a/1-org/README.md
+++ b/1-org/README.md
@@ -61,6 +61,7 @@ The purpose of this step is to set up top-level shared folders, monitoring and n
 1. 0-bootstrap executed successfully.
 2. Cloud Identity / Google Workspace group for security admins.
 3. Membership in the security admins group for the user running Terraform.
+4. Security Command Center notifications require that you choose a Security Command Center tier and create and grant permissions for the Security Command Center service account as outlined in [Setting up Security Command Center] (https://cloud.google.com/security-command-center/docs/quickstart-security-command-center)
 
 Note: Make sure that you use the same version of Terraform throughout this
 series, otherwise you might experience Terraform state snapshot lock errors.

--- a/1-org/README.md
+++ b/1-org/README.md
@@ -61,7 +61,7 @@ The purpose of this step is to set up top-level shared folders, monitoring and n
 1. 0-bootstrap executed successfully.
 2. Cloud Identity / Google Workspace group for security admins.
 3. Membership in the security admins group for the user running Terraform.
-4. Security Command Center notifications require that you choose a Security Command Center tier and create and grant permissions for the Security Command Center service account as outlined in [Setting up Security Command Center] (https://cloud.google.com/security-command-center/docs/quickstart-security-command-center)
+4. Security Command Center notifications require that you choose a Security Command Center tier and create and grant permissions for the Security Command Center service account as outlined in [Setting up Security Command Center](https://cloud.google.com/security-command-center/docs/quickstart-security-command-center)
 
 Note: Make sure that you use the same version of Terraform throughout this
 series, otherwise you might experience Terraform state snapshot lock errors.


### PR DESCRIPTION
Added setting up Security Command Center to  1-org README.md Prerequisites to address  [453](https://github.com/terraform-google-modules/terraform-example-foundation/issues/453)