### PR TITLE
add DNS zone for artifact registry

### DIFF
--- a/3-networks/modules/base_shared_vpc/dns.tf
+++ b/3-networks/modules/base_shared_vpc/dns.tf
@@ -116,6 +116,39 @@ module "base_gcr" {
   ]
 }
 
+/***********************************************
+  Private Artifact Registry DNS Zone & records.
+ ***********************************************/
+
+module "base_pkg_dev" {
+  source      = "terraform-google-modules/cloud-dns/google"
+  version     = "~> 3.1"
+  project_id  = var.project_id
+  type        = "private"
+  name        = "dz-${var.environment_code}-shared-base-pkg-dev"
+  domain      = "pkg.dev."
+  description = "Private DNS zone to configure pkg.dev"
+
+  private_visibility_config_networks = [
+    module.main.network_self_link
+  ]
+
+  recordsets = [
+    {
+      name    = "*"
+      type    = "CNAME"
+      ttl     = 300
+      records = ["pkg.dev."]
+    },
+    {
+      name    = ""
+      type    = "A"
+      ttl     = 300
+      records = ["199.36.153.8", "199.36.153.9", "199.36.153.10", "199.36.153.11"]
+    },
+  ]
+}
+
 /******************************************
  Creates DNS Peering to DNS HUB
 *****************************************/

--- a/3-networks/modules/restricted_shared_vpc/dns.tf
+++ b/3-networks/modules/restricted_shared_vpc/dns.tf
@@ -117,6 +117,39 @@ module "restricted_gcr" {
   ]
 }
 
+/**************************************************
+  Restricted Artifact Registry DNS Zone & records.
+ **************************************************/
+
+module "restricted_pkg_dev" {
+  source      = "terraform-google-modules/cloud-dns/google"
+  version     = "~> 3.0"
+  project_id  = var.project_id
+  type        = "private"
+  name        = "dz-${var.environment_code}-shared-restricted-pkg-dev"
+  domain      = "pkg.dev."
+  description = "Private DNS zone to configure pkg.dev"
+
+  private_visibility_config_networks = [
+    module.main.network_self_link
+  ]
+
+  recordsets = [
+    {
+      name    = "*"
+      type    = "CNAME"
+      ttl     = 300
+      records = ["pkg.dev."]
+    },
+    {
+      name    = ""
+      type    = "A"
+      ttl     = 300
+      records = ["199.36.153.4", "199.36.153.5", "199.36.153.6", "199.36.153.7"]
+    },
+  ]
+}
+
 /******************************************
  Creates DNS Peering to DNS HUB
 *****************************************/

--- a/test/integration/networks/controls/gcp_networks.rb
+++ b/test/integration/networks/controls/gcp_networks.rb
@@ -57,6 +57,7 @@ control 'gcp_networks' do
 
       dns_zone_googleapis = "dz-#{environment_code}-shared-#{type}-apis"
       dns_zone_gcr = "dz-#{environment_code}-shared-#{type}-gcr"
+      dns_zone_pkg_dev = "dz-#{environment_code}-shared-#{type}-pkg-dev"
       dns_zone_peering_zone = "dz-#{environment_code}-shared-#{type}-to-dns-hub"
 
       subnet_name1 = "sb-#{environment_code}-shared-#{type}-#{default_region1}"
@@ -92,6 +93,13 @@ control 'gcp_networks' do
       describe google_dns_managed_zone(
         project: projects_id[environment_code][type],
         zone: dns_zone_gcr
+      ) do
+        it { should exist }
+      end
+
+      describe google_dns_managed_zone(
+        project: projects_id[environment_code][type],
+        zone: dns_zone_pkg_dev
       ) do
         it { should exist }
       end


### PR DESCRIPTION
This Pull Request adds a DNS zone for `pkg.dev` in the base and restricted networks to allow usage of Google Artifact Registry.