### PR TITLE
add browser role to cloud build sa for provided folders

### DIFF
--- a/4-projects/modules/infra_pipelines/README.md
+++ b/4-projects/modules/infra_pipelines/README.md
@@ -10,6 +10,7 @@
 | cloudbuild\_plan\_filename | Path and name of Cloud Build YAML definition used for terraform plan. | `string` | `"cloudbuild-tf-plan.yaml"` | no |
 | cloudbuild\_project\_id | The project id where the pipelines and repos should be created | `string` | n/a | yes |
 | default\_region | Default region to create resources where applicable. | `string` | n/a | yes |
+| folders\_to\_grant\_browser\_role | List of folders to grant browser role to the cloud build service account. Used by terraform validator to able to load IAM policies. | `list(string)` | `[]` | no |
 | gar\_repo\_name | Custom name to use for GAR repo. | `string` | `""` | no |
 | impersonate\_service\_account | Service account email of the account to impersonate to run Terraform | `string` | n/a | yes |
 | project\_prefix | Name prefix to use for projects created. | `string` | `"prj"` | no |

--- a/4-projects/modules/infra_pipelines/main.tf
+++ b/4-projects/modules/infra_pipelines/main.tf
@@ -180,3 +180,11 @@ resource "google_artifact_registry_repository_iam_member" "terraform-image-iam" 
   role       = "roles/artifactregistry.writer"
   member     = "serviceAccount:${data.google_project.cloudbuild_project.number}@cloudbuild.gserviceaccount.com"
 }
+
+resource "google_folder_iam_member" "browser_cloud_build" {
+  for_each = toset(var.folders_to_grant_browser_role)
+
+  folder = each.value
+  role   = "roles/browser"
+  member = "serviceAccount:${data.google_project.cloudbuild_project.number}@cloudbuild.gserviceaccount.com"
+}

--- a/4-projects/modules/infra_pipelines/variables.tf
+++ b/4-projects/modules/infra_pipelines/variables.tf
@@ -95,3 +95,9 @@ variable "terraform_validator_release" {
   type        = string
   default     = "2021-03-22"
 }
+
+variable "folders_to_grant_browser_role" {
+  description = "List of folders to grant browser role to the cloud build service account. Used by terraform validator to able to load IAM policies."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Add an optional list of folders to which the Cloud build Service account created in step 4 will need browser role to load IAM policies for terraform validator. 