### PR TITLE
chore: added link to FAQ in 1-org

### DIFF
--- a/1-org/README.md
+++ b/1-org/README.md
@@ -62,6 +62,7 @@ The purpose of this step is to set up top-level shared folders, monitoring and n
 2. Cloud Identity / Google Workspace group for security admins.
 3. Membership in the security admins group for the user running Terraform.
 4. Security Command Center notifications require that you choose a Security Command Center tier and create and grant permissions for the Security Command Center service account as outlined in [Setting up Security Command Center](https://cloud.google.com/security-command-center/docs/quickstart-security-command-center)
+5. Ensure that you have requested for sufficient projects quota, as the Terraform scripts will create multiple projects from this point onwards. For more information, please [see the FAQ](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/docs/FAQ.md).
 
 **Note:** Make sure that you use the same version of Terraform throughout this
 series, otherwise you might experience Terraform state snapshot lock errors.


### PR DESCRIPTION
In this PR,

- I added a note in the prerequisites of `1-org` to inform users that they should request for sufficient projects quota and linked it to the detailed explanation in `FAQ.md`.

The reason for doing so is because I personally did not read the `FAQ.md` document nor the troubleshooting guide (I wasn't aware of those documents until I searched the error codes I was receiving on Google Search) and just followed the instructions as-is. On a fresh Cloud Identity org, `1-org` is where I hit the projects quota.

Now, I understand there are several issues related to this even with a fix in https://github.com/terraform-google-modules/terraform-example-foundation/pull/290 although I'm not sure why that note is gone and there was no mention of any prerequisites to check if you have enough projects quota in the `0-bootstrap` or `1-org`'s prerequisites.

That PR #290 was in November 2020 and even until today, I've noticed - after crawling through existing GitHub issues - that our users are still facing the same problem:

- https://github.com/terraform-google-modules/terraform-example-foundation/issues/378
- https://github.com/terraform-google-modules/terraform-example-foundation/issues/494

It's a simple note, and I believe it would help a lot, especially for people who may be new to cloud security foundations. Appreciate any feedback. Thanks!