### PR TITLE
fix: Update terraform-google-project-factory module to 10.1

### DIFF
--- a/0-bootstrap/modules/jenkins-agent/main.tf
+++ b/0-bootstrap/modules/jenkins-agent/main.tf
@@ -30,7 +30,7 @@ resource "random_id" "suffix" {
 *******************************************/
 module "cicd_project" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 10.0"
+  version                     = "~> 10.1"
   name                        = local.cicd_project_name
   random_project_id           = true
   disable_services_on_destroy = false

--- a/1-org/envs/shared/projects.tf
+++ b/1-org/envs/shared/projects.tf
@@ -20,7 +20,7 @@
 
 module "org_audit_logs" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 10.0"
+  version                     = "~> 10.1"
   random_project_id           = "true"
   impersonate_service_account = var.terraform_service_account
   default_service_account     = "deprivilege"
@@ -46,7 +46,7 @@ module "org_audit_logs" {
 
 module "org_billing_logs" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 10.0"
+  version                     = "~> 10.1"
   random_project_id           = "true"
   impersonate_service_account = var.terraform_service_account
   default_service_account     = "deprivilege"

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -25,7 +25,7 @@ resource "google_folder" "test_folder" {
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 10.0"
+  version = "~> 10.1"
 
   name              = "ci-foundation"
   random_project_id = true


### PR DESCRIPTION
This PR updates `terraform-google-project-factory` pessimistic version constraint to `10.1`. Previously both `10.0` and `10.1` were used.