### PR TITLE
Add note regarding terraform version for manual steps

### DIFF
--- a/0-bootstrap/README.md
+++ b/0-bootstrap/README.md
@@ -66,8 +66,7 @@ installed:
 - [Terraform](https://www.terraform.io/downloads.html) version 0.13.7.
 - An existing project which the user has access to be used by terraform-validator.
 
-**Note:** Make sure that you use the same version of Terraform throughout this
-series. Otherwise, you might experience Terraform state snapshot lock errors.
+**Note:** Make sure that you use the same version of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
 
 Also make sure that you've done the following:
 
@@ -78,7 +77,7 @@ Also make sure that you've done the following:
 1. Created Cloud Identity or Google Workspace (formerly G Suite) groups for
    organization and billing admins.
 1. Added the user who will use Terraform to the `group_org_admins` group.
-   They must be in this group or they won't have
+   They must be in this group, or they won't have
    `roles/resourcemanager.projectCreator` access.
 1. For the user who will run the procedures in this document, granted the
    following roles:
@@ -89,7 +88,7 @@ Also make sure that you've done the following:
 
 If other users need to be able to run these procedures, add them to the group
 represented by the `org_project_creators` variable.
-For more information about the permissions that are required and the resources
+For more information about the permissions that are required, and the resources
 that are created, see the organization bootstrap module
 [documentation.](https://github.com/terraform-google-modules/terraform-google-bootstrap)
 

--- a/1-org/README.md
+++ b/1-org/README.md
@@ -64,8 +64,7 @@ The purpose of this step is to set up top-level shared folders, monitoring and n
 4. Security Command Center notifications require that you choose a Security Command Center tier and create and grant permissions for the Security Command Center service account as outlined in [Setting up Security Command Center](https://cloud.google.com/security-command-center/docs/quickstart-security-command-center)
 5. Ensure that you have requested for sufficient projects quota, as the Terraform scripts will create multiple projects from this point onwards. For more information, please [see the FAQ](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/docs/FAQ.md).
 
-**Note:** Make sure that you use the same version of Terraform throughout this
-series, otherwise you might experience Terraform state snapshot lock errors.
+**Note:** Make sure that you use the same version of Terraform throughout this series, otherwise you might experience Terraform state snapshot lock errors.
 
 ### Troubleshooting
 
@@ -253,7 +252,7 @@ to run the command as the Terraform service account.
 1. Run `chmod 755 ./tf-wrapper.sh`
 1. Change into 1-org/envs/shared/ folder.
 1. Rename `terraform.example.tfvars` to `terraform.tfvars` and update the file with values from your environment and bootstrap.
-1. Obtain your bucket name by running the following command in the 0-bootstap folder.
+1. Obtain your bucket name by running the following command in the 0-bootstrap folder.
    ```
    terraform output gcs_bucket_tfstate
    ```

--- a/2-environments/README.md
+++ b/2-environments/README.md
@@ -201,7 +201,7 @@ Please refer to [troubleshooting](../docs/TROUBLESHOOTING.md) if you run into is
    ```
    for i in `find -name 'backend.tf'`; do sed -i 's/UPDATE_ME/<YOUR-BUCKET-NAME>/' $i; done
    ```
-You can run `terraform output gcs_bucket_tfstate` in the 0-bootstap folder to obtain the bucket name.
+You can run `terraform output gcs_bucket_tfstate` in the 0-bootstrap folder to obtain the bucket name.
 
 We will now deploy each of our environments(development/production/non-production) using this script.
 When using Cloud Build or Jenkins as your CI/CD tool each environment corresponds to a branch is the repository for 2-environments step and only the corresponding environment is applied.

--- a/3-networks/README.md
+++ b/3-networks/README.md
@@ -66,9 +66,13 @@ The purpose of this step is to:
 1. 2-environments executed successfully.
 1. Obtain the value for the access_context_manager_policy_id variable. Can be obtained by running
 
-```
-gcloud access-context-manager policies list --organization YOUR_ORGANIZATION_ID --format="value(name)"
-```
+   ```bash
+   gcloud access-context-manager policies list --organization YOUR_ORGANIZATION_ID --format="value(name)"
+   ```
+
+1. For the manual step described in this document, you need [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 to be installed.
+
+   **Note:** Make sure that you use the same version of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
 
 ### Troubleshooting
 

--- a/4-projects/README.md
+++ b/4-projects/README.md
@@ -67,11 +67,11 @@ This pipeline can be utilized for deploying resources in projects across develop
 1. 2-environments executed successfully.
 1. 3-networks executed successfully.
 1. Obtain the value for the `access_context_manager_policy_id` variable.
-   
+
    ```bash
    gcloud access-context-manager policies list --organization YOUR_ORGANIZATION_ID --format="value(name)"
    ```
-   
+
 1. For the manual step described in this document, you need [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 to be installed.
 
    **Note:** Make sure that you use the same version of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.

--- a/4-projects/README.md
+++ b/4-projects/README.md
@@ -67,36 +67,43 @@ This pipeline can be utilized for deploying resources in projects across develop
 1. 2-environments executed successfully.
 1. 3-networks executed successfully.
 1. Obtain the value for the `access_context_manager_policy_id` variable.
-   ```
+   
+   ```bash
    gcloud access-context-manager policies list --organization YOUR_ORGANIZATION_ID --format="value(name)"
    ```
+   
+1. For the manual step described in this document, you need [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 to be installed.
+
+   **Note:** Make sure that you use the same version of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
+
 1. Obtain the values for the `perimeter_name` for each environment variable.
-   ```
+
+   ```bash
    gcloud access-context-manager perimeters list --policy ACCESS_CONTEXT_MANAGER_POLICY_ID --format="value(name)"
    ```
 
-**Note:** If you have more than one service perimeter for each environment, you can also get the values from the `restricted_service_perimeter_name` output from each of the`3-networks` environments.
+   **Note:** If you have more than one service perimeter for each environment, you can also get the values from the `restricted_service_perimeter_name` output from each of the`3-networks` environments.
 
-If you are using Cloud Build you can also search for the values in the outputs from the build logs:
+   If you are using Cloud Build you can also search for the values in the outputs from the build logs:
 
-```console
-gcloud builds list \
- --project=YOUR_CLOUD_BUILD_PROJECT_ID \
- --filter="status=SUCCESS \
- AND source.repoSource.repoName=gcp-networks \
- AND substitutions.BRANCH_NAME=development" \
- --format="value(id)"
-```
+   ```console
+   gcloud builds list \
+     --project=YOUR_CLOUD_BUILD_PROJECT_ID \
+     --filter="status=SUCCESS \
+       AND source.repoSource.repoName=gcp-networks \
+       AND substitutions.BRANCH_NAME=development" \
+     --format="value(id)"
+   ```
 
-Use the result of this command as the `BUILD_ID` value in the next command:
+   Use the result of this command as the `BUILD_ID` value in the next command:
 
-```console
-gcloud builds log BUILD_ID \
- --project=YOUR_CLOUD_BUILD_PROJECT_ID | \
- grep "restricted_service_perimeter_name = "
-```
+   ```console
+   gcloud builds log BUILD_ID \
+     --project=YOUR_CLOUD_BUILD_PROJECT_ID | \
+     grep "restricted_service_perimeter_name = "
+   ```
 
-Change the `BRANCH_NAME` from `development` to `non-production` or `production` for the other two service perimeters.
+   Change the `BRANCH_NAME` from `development` to `non-production` or `production` for the other two service perimeters.
 
 ### Troubleshooting
 

--- a/test/fixtures/bootstrap/variables.tf
+++ b/test/fixtures/bootstrap/variables.tf
@@ -31,7 +31,7 @@ variable "group_email" {
 }
 
 variable "org_project_creators" {
-  description = "Additional list of members to have project creator role accross the organization. Prefix of group: user: or serviceAccount: is required."
+  description = "Additional list of members to have project creator role across the organization. Prefix of group: user: or serviceAccount: is required."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
Closes #379 

This PR

- Adds notes in `3-networks` and `4-projects` regarding using same Terraform version for manual steps should be the same one that is used in the Cloud Build, otherwise the user may face a compatibility error if the versions are different.
- Fixes typos.