### PR TITLE
chore(deps): Remove unused dependencies, update bootstrap TF module to 3.0

### DIFF
--- a/0-bootstrap/main.tf
+++ b/0-bootstrap/main.tf
@@ -31,7 +31,7 @@ resource "google_folder" "bootstrap" {
 
 module "seed_bootstrap" {
   source                         = "terraform-google-modules/bootstrap/google"
-  version                        = "~> 2.1"
+  version                        = "~> 3.0"
   org_id                         = var.org_id
   folder_id                      = google_folder.bootstrap.id
   project_id                     = "${var.project_prefix}-b-seed"
@@ -102,7 +102,7 @@ resource "google_billing_account_iam_member" "tf_billing_admin" {
 // Comment-out the cloudbuild_bootstrap module and its outputs if you want to use Jenkins instead of Cloud Build
 module "cloudbuild_bootstrap" {
   source                      = "terraform-google-modules/bootstrap/google//modules/cloudbuild"
-  version                     = "~> 2.3"
+  version                     = "~> 3.0"
   org_id                      = var.org_id
   folder_id                   = google_folder.bootstrap.id
   project_id                  = "${var.project_prefix}-b-cicd"

--- a/0-bootstrap/versions.tf
+++ b/0-bootstrap/versions.tf
@@ -21,15 +21,6 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 3.50"
     }
-    null = {
-      source  = "hashicorp/null"
-      version = "~> 2.1"
-    }
-
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 2.3"
-    }
   }
 
   provider_meta "google" {


### PR DESCRIPTION
This PR:

- Removes unused Terraform provider dependencies in `0-bootstrap`. This would close https://github.com/terraform-google-modules/terraform-example-foundation/pull/527, https://github.com/terraform-google-modules/terraform-example-foundation/pull/531 as dependent modules list older versions as constraints.
- Update `terraform-google-modules/bootstrap/google` and `terraform-google-modules/bootstrap/google//modules/cloudbuild` to `3.0`.