### PR TITLE
chore(deps): Update TF project-factory module to 11.1

### DIFF
--- a/0-bootstrap/modules/jenkins-agent/main.tf
+++ b/0-bootstrap/modules/jenkins-agent/main.tf
@@ -30,7 +30,7 @@ resource "random_id" "suffix" {
 *******************************************/
 module "cicd_project" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 10.1"
+  version                     = "~> 11.1"
   name                        = local.cicd_project_name
   random_project_id           = true
   disable_services_on_destroy = false

--- a/1-org/envs/shared/projects.tf
+++ b/1-org/envs/shared/projects.tf
@@ -19,16 +19,15 @@
 *****************************************/
 
 module "org_audit_logs" {
-  source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 10.1"
-  random_project_id           = "true"
-  impersonate_service_account = var.terraform_service_account
-  default_service_account     = "deprivilege"
-  name                        = "${var.project_prefix}-c-logging"
-  org_id                      = var.org_id
-  billing_account             = var.billing_account
-  folder_id                   = google_folder.common.id
-  activate_apis               = ["logging.googleapis.com", "bigquery.googleapis.com", "billingbudgets.googleapis.com"]
+  source                  = "terraform-google-modules/project-factory/google"
+  version                 = "~> 11.1"
+  random_project_id       = "true"
+  default_service_account = "deprivilege"
+  name                    = "${var.project_prefix}-c-logging"
+  org_id                  = var.org_id
+  billing_account         = var.billing_account
+  folder_id               = google_folder.common.id
+  activate_apis           = ["logging.googleapis.com", "bigquery.googleapis.com", "billingbudgets.googleapis.com"]
 
   labels = {
     environment       = "production"
@@ -45,16 +44,15 @@ module "org_audit_logs" {
 }
 
 module "org_billing_logs" {
-  source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 10.1"
-  random_project_id           = "true"
-  impersonate_service_account = var.terraform_service_account
-  default_service_account     = "deprivilege"
-  name                        = "${var.project_prefix}-c-billing-logs"
-  org_id                      = var.org_id
-  billing_account             = var.billing_account
-  folder_id                   = google_folder.common.id
-  activate_apis               = ["logging.googleapis.com", "bigquery.googleapis.com", "billingbudgets.googleapis.com"]
+  source                  = "terraform-google-modules/project-factory/google"
+  version                 = "~> 11.1"
+  random_project_id       = "true"
+  default_service_account = "deprivilege"
+  name                    = "${var.project_prefix}-c-billing-logs"
+  org_id                  = var.org_id
+  billing_account         = var.billing_account
+  folder_id               = google_folder.common.id
+  activate_apis           = ["logging.googleapis.com", "bigquery.googleapis.com", "billingbudgets.googleapis.com"]
 
   labels = {
     environment       = "production"
@@ -75,16 +73,15 @@ module "org_billing_logs" {
 *****************************************/
 
 module "org_secrets" {
-  source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 10.1"
-  random_project_id           = "true"
-  impersonate_service_account = var.terraform_service_account
-  default_service_account     = "deprivilege"
-  name                        = "${var.project_prefix}-c-secrets"
-  org_id                      = var.org_id
-  billing_account             = var.billing_account
-  folder_id                   = google_folder.common.id
-  activate_apis               = ["logging.googleapis.com", "secretmanager.googleapis.com", "billingbudgets.googleapis.com"]
+  source                  = "terraform-google-modules/project-factory/google"
+  version                 = "~> 11.1"
+  random_project_id       = "true"
+  default_service_account = "deprivilege"
+  name                    = "${var.project_prefix}-c-secrets"
+  org_id                  = var.org_id
+  billing_account         = var.billing_account
+  folder_id               = google_folder.common.id
+  activate_apis           = ["logging.googleapis.com", "secretmanager.googleapis.com", "billingbudgets.googleapis.com"]
 
   labels = {
     environment       = "production"
@@ -105,16 +102,15 @@ module "org_secrets" {
 *****************************************/
 
 module "interconnect" {
-  source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 10.1"
-  random_project_id           = "true"
-  impersonate_service_account = var.terraform_service_account
-  default_service_account     = "deprivilege"
-  name                        = "${var.project_prefix}-c-interconnect"
-  org_id                      = var.org_id
-  billing_account             = var.billing_account
-  folder_id                   = google_folder.common.id
-  activate_apis               = ["billingbudgets.googleapis.com", "compute.googleapis.com"]
+  source                  = "terraform-google-modules/project-factory/google"
+  version                 = "~> 11.1"
+  random_project_id       = "true"
+  default_service_account = "deprivilege"
+  name                    = "${var.project_prefix}-c-interconnect"
+  org_id                  = var.org_id
+  billing_account         = var.billing_account
+  folder_id               = google_folder.common.id
+  activate_apis           = ["billingbudgets.googleapis.com", "compute.googleapis.com"]
 
   labels = {
     environment       = "production"
@@ -135,16 +131,15 @@ module "interconnect" {
 *****************************************/
 
 module "scc_notifications" {
-  source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 10.1"
-  random_project_id           = "true"
-  impersonate_service_account = var.terraform_service_account
-  default_service_account     = "deprivilege"
-  name                        = "${var.project_prefix}-c-scc"
-  org_id                      = var.org_id
-  billing_account             = var.billing_account
-  folder_id                   = google_folder.common.id
-  activate_apis               = ["logging.googleapis.com", "pubsub.googleapis.com", "securitycenter.googleapis.com", "billingbudgets.googleapis.com"]
+  source                  = "terraform-google-modules/project-factory/google"
+  version                 = "~> 11.1"
+  random_project_id       = "true"
+  default_service_account = "deprivilege"
+  name                    = "${var.project_prefix}-c-scc"
+  org_id                  = var.org_id
+  billing_account         = var.billing_account
+  folder_id               = google_folder.common.id
+  activate_apis           = ["logging.googleapis.com", "pubsub.googleapis.com", "securitycenter.googleapis.com", "billingbudgets.googleapis.com"]
 
   labels = {
     environment       = "production"
@@ -165,15 +160,14 @@ module "scc_notifications" {
 *****************************************/
 
 module "dns_hub" {
-  source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 10.1"
-  random_project_id           = "true"
-  impersonate_service_account = var.terraform_service_account
-  default_service_account     = "deprivilege"
-  name                        = "${var.project_prefix}-c-dns-hub"
-  org_id                      = var.org_id
-  billing_account             = var.billing_account
-  folder_id                   = google_folder.common.id
+  source                  = "terraform-google-modules/project-factory/google"
+  version                 = "~> 11.1"
+  random_project_id       = "true"
+  default_service_account = "deprivilege"
+  name                    = "${var.project_prefix}-c-dns-hub"
+  org_id                  = var.org_id
+  billing_account         = var.billing_account
+  folder_id               = google_folder.common.id
 
   activate_apis = [
     "compute.googleapis.com",
@@ -203,16 +197,15 @@ module "dns_hub" {
 *****************************************/
 
 module "base_network_hub" {
-  source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 10.1"
-  count                       = var.enable_hub_and_spoke ? 1 : 0
-  random_project_id           = "true"
-  impersonate_service_account = var.terraform_service_account
-  default_service_account     = "deprivilege"
-  name                        = "${var.project_prefix}-c-base-net-hub"
-  org_id                      = var.org_id
-  billing_account             = var.billing_account
-  folder_id                   = google_folder.common.id
+  source                  = "terraform-google-modules/project-factory/google"
+  version                 = "~> 11.1"
+  count                   = var.enable_hub_and_spoke ? 1 : 0
+  random_project_id       = "true"
+  default_service_account = "deprivilege"
+  name                    = "${var.project_prefix}-c-base-net-hub"
+  org_id                  = var.org_id
+  billing_account         = var.billing_account
+  folder_id               = google_folder.common.id
 
   activate_apis = [
     "compute.googleapis.com",
@@ -242,16 +235,15 @@ module "base_network_hub" {
 *****************************************/
 
 module "restricted_network_hub" {
-  source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 10.1"
-  count                       = var.enable_hub_and_spoke ? 1 : 0
-  random_project_id           = "true"
-  impersonate_service_account = var.terraform_service_account
-  default_service_account     = "deprivilege"
-  name                        = "${var.project_prefix}-c-restricted-net-hub"
-  org_id                      = var.org_id
-  billing_account             = var.billing_account
-  folder_id                   = google_folder.common.id
+  source                  = "terraform-google-modules/project-factory/google"
+  version                 = "~> 11.1"
+  count                   = var.enable_hub_and_spoke ? 1 : 0
+  random_project_id       = "true"
+  default_service_account = "deprivilege"
+  name                    = "${var.project_prefix}-c-restricted-net-hub"
+  org_id                  = var.org_id
+  billing_account         = var.billing_account
+  folder_id               = google_folder.common.id
 
   activate_apis = [
     "compute.googleapis.com",

--- a/2-environments/envs/development/main.tf
+++ b/2-environments/envs/development/main.tf
@@ -23,7 +23,6 @@ module "env" {
   parent_id                  = var.parent_folder != "" ? "folders/${var.parent_folder}" : "organizations/${var.org_id}"
   org_id                     = var.org_id
   billing_account            = var.billing_account
-  terraform_service_account  = var.terraform_service_account
   monitoring_workspace_users = var.monitoring_workspace_users
   project_prefix             = var.project_prefix
   folder_prefix              = var.folder_prefix

--- a/2-environments/envs/non-production/main.tf
+++ b/2-environments/envs/non-production/main.tf
@@ -23,7 +23,6 @@ module "env" {
   parent_id                  = var.parent_folder != "" ? "folders/${var.parent_folder}" : "organizations/${var.org_id}"
   org_id                     = var.org_id
   billing_account            = var.billing_account
-  terraform_service_account  = var.terraform_service_account
   monitoring_workspace_users = var.monitoring_workspace_users
   project_prefix             = var.project_prefix
   folder_prefix              = var.folder_prefix

--- a/2-environments/envs/production/main.tf
+++ b/2-environments/envs/production/main.tf
@@ -23,7 +23,6 @@ module "env" {
   parent_id                  = var.parent_folder != "" ? "folders/${var.parent_folder}" : "organizations/${var.org_id}"
   org_id                     = var.org_id
   billing_account            = var.billing_account
-  terraform_service_account  = var.terraform_service_account
   monitoring_workspace_users = var.monitoring_workspace_users
   project_prefix             = var.project_prefix
   folder_prefix              = var.folder_prefix

--- a/2-environments/modules/env_baseline/README.md
+++ b/2-environments/modules/env_baseline/README.md
@@ -23,7 +23,6 @@
 | secret\_project\_alert\_pubsub\_topic | The name of the Cloud Pub/Sub topic where budget related messages will be published, in the form of `projects/{project_id}/topics/{topic_id}` for the secrets project. | `string` | `null` | no |
 | secret\_project\_alert\_spent\_percents | A list of percentages of the budget to alert on when threshold is exceeded for the secrets project. | `list(number)` | <pre>[<br>  0.5,<br>  0.75,<br>  0.9,<br>  0.95<br>]</pre> | no |
 | secret\_project\_budget\_amount | The amount to use as the budget for the secrets project. | `number` | `1000` | no |
-| terraform\_service\_account | Service account email of the account to impersonate to run Terraform. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/2-environments/modules/env_baseline/monitoring.tf
+++ b/2-environments/modules/env_baseline/monitoring.tf
@@ -20,9 +20,8 @@
 
 module "monitoring_project" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 10.1"
+  version                     = "~> 11.1"
   random_project_id           = "true"
-  impersonate_service_account = var.terraform_service_account
   name                        = "${var.project_prefix}-${var.environment_code}-monitoring"
   org_id                      = var.org_id
   billing_account             = var.billing_account

--- a/2-environments/modules/env_baseline/networking.tf
+++ b/2-environments/modules/env_baseline/networking.tf
@@ -20,9 +20,8 @@
 
 module "base_shared_vpc_host_project" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 10.1"
+  version                     = "~> 11.1"
   random_project_id           = "true"
-  impersonate_service_account = var.terraform_service_account
   name                        = format("%s-%s-shared-base", var.project_prefix, var.environment_code)
   org_id                      = var.org_id
   billing_account             = var.billing_account
@@ -53,9 +52,8 @@ module "base_shared_vpc_host_project" {
 
 module "restricted_shared_vpc_host_project" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 10.1"
+  version                     = "~> 11.1"
   random_project_id           = "true"
-  impersonate_service_account = var.terraform_service_account
   name                        = format("%s-%s-shared-restricted", var.project_prefix, var.environment_code)
   org_id                      = var.org_id
   billing_account             = var.billing_account

--- a/2-environments/modules/env_baseline/secrets.tf
+++ b/2-environments/modules/env_baseline/secrets.tf
@@ -21,9 +21,8 @@
 
 module "env_secrets" {
   source                      = "terraform-google-modules/project-factory/google"
-  version                     = "~> 10.1"
+  version                     = "~> 11.1"
   random_project_id           = "true"
-  impersonate_service_account = var.terraform_service_account
   default_service_account     = "deprivilege"
   name                        = "${var.project_prefix}-${var.environment_code}-secrets"
   org_id                      = var.org_id

--- a/2-environments/modules/env_baseline/variables.tf
+++ b/2-environments/modules/env_baseline/variables.tf
@@ -39,11 +39,6 @@ variable "billing_account" {
   type        = string
 }
 
-variable "terraform_service_account" {
-  description = "Service account email of the account to impersonate to run Terraform."
-  type        = string
-}
-
 variable "monitoring_workspace_users" {
   description = "Google Workspace or Cloud Identity group that have access to Monitoring Workspaces."
   type        = string

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -25,7 +25,7 @@ resource "google_folder" "test_folder" {
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 10.1"
+  version = "~> 11.1"
 
   name              = "ci-foundation"
   random_project_id = true


### PR DESCRIPTION
This is first PR in series to update `terraform-google-modules/project-factory/google` module from `10.1` to `11.1`.

There's a [breaking change](https://github.com/terraform-google-modules/terraform-google-project-factory/commit/e4c9b0362166ebb2ce6cab1a54d55fc3014f00f3) that prevents straightforward update. As per [Upgrading to Project Factory v11.0](https://github.com/terraform-google-modules/terraform-google-project-factory/blob/master/docs/upgrading_to_project_factory_v11.0.md) this should be no-op change.

This PR updates version in `0-bootstrap`, `1-org` and `2-environments`.

I'm not quite sure if we need to add `iamcredentials.googleapis.com` to the project API list in `0-bootstrap/main.tf` `seed_bootstrap` module definition to allow state to be stored under impersonated service account.