### PR TITLE
Possible update to private CIDR range required

### DIFF
--- a/3-networks/modules/base_shared_vpc/main.tf
+++ b/3-networks/modules/base_shared_vpc/main.tf
@@ -18,7 +18,7 @@ locals {
   mode                    = var.mode == null ? "" : var.mode == "hub" ? "-hub" : "-spoke"
   vpc_name                = "${var.environment_code}-shared-base${local.mode}"
   network_name            = "vpc-${local.vpc_name}"
-  private_googleapis_cidr = "199.36.153.8/30"
+  private_googleapis_cidr = "199.36.153.4/30"
 }
 
 /******************************************


### PR DESCRIPTION
[Google documentation](https://cloud.google.com/vpc-service-controls/docs/set-up-private-connectivity) states that the IP range for private API connectivity is `199.36.153.4/30`, which leads me to believe that this value (x.8/30) could be wrong. I've [opened an issue](https://github.com/terraform-google-modules/terraform-example-foundation/issues/578) to query this, but I'm also pushing this change if it's needed.