### PR TITLE
Add Assured workload folder for production environment

### DIFF
--- a/0-bootstrap/main.tf
+++ b/0-bootstrap/main.tf
@@ -80,6 +80,7 @@ module "seed_bootstrap" {
 
   sa_org_iam_permissions = [
     "roles/accesscontextmanager.policyAdmin",
+    "roles/assuredworkloads.admin",
     "roles/billing.user",
     "roles/compute.networkAdmin",
     "roles/compute.xpnAdmin",

--- a/0-bootstrap/main.tf
+++ b/0-bootstrap/main.tf
@@ -74,7 +74,8 @@ module "seed_bootstrap" {
     "pubsub.googleapis.com",
     "securitycenter.googleapis.com",
     "accesscontextmanager.googleapis.com",
-    "billingbudgets.googleapis.com"
+    "billingbudgets.googleapis.com",
+    "assuredworkloads.googleapis.com"
   ]
 
   sa_org_iam_permissions = [

--- a/2-environments/README.md
+++ b/2-environments/README.md
@@ -64,8 +64,10 @@ Please refer to [troubleshooting](../docs/TROUBLESHOOTING.md) if you run into is
 
 ## Usage
 
-**Note:** If you are using MacOS, replace `cp -RT` with `cp -R` in the relevant
+**Note 1:** If you are using MacOS, replace `cp -RT` with `cp -R` in the relevant
 commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
+
+**Note 2:** It is possible to create a folder for [Assured Workloads environments](https://cloud.google.com/assured-workloads/docs/create-folder) in the production environment. Follow the instructions for your build environment. If the folder is created, complete the Assured Workloads folder onboarding [form](https://cloud.google.com/assured-workloads/docs/create-folder#create_a_new_folder). The display name of the folder created is in the `assured_workload_folder_display_name` output of the production environment.
 
 ### Deploying with Cloud Build
 
@@ -98,6 +100,7 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
    chmod 755 ./tf-wrapper.sh
    ```
 1. Rename `terraform.example.tfvars` to `terraform.tfvars` and update the file with values from your environment and bootstrap (you can re-run `terraform output` in the 0-bootstrap directory to find these values). See any of the envs folder [README.md](./envs/production/README.md) files for additional information on the values in the `terraform.tfvars` file.
+1. To enable [Assured Workloads](https://cloud.google.com/assured-workloads) in the production folder, rename `./envs/production/assured_workload.auto.example.tfvars` to `./envs/production/assured_workload.auto.tfvars` and update the file with values from your environment. See the envs production folder [README.md](./envs/production/README.md) file for additional information on the values in the `terraform.tfvars` file.
 1. Commit changes.
    ```
    git add .
@@ -170,6 +173,7 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
    chmod 755 ./tf-wrapper.sh
    ```
 1. Rename `terraform.example.tfvars` to `terraform.tfvars` and update the file with values from your environment and bootstrap (you can re-run `terraform output` in the 0-bootstrap directory to find these values). See any of the envs folder [README.md](./envs/production/README.md) files for additional information on the values in the `terraform.tfvars` file.
+1. To enable [Assured Workloads](https://cloud.google.com/assured-workloads) in the production folder, rename `./envs/production/assured_workload.auto.example.tfvars` to `./envs/production/assured_workload.auto.tfvars` and update the file with values from your environment. See the envs production folder [README.md](./envs/production/README.md) file for additional information on the values in the `terraform.tfvars` file.
 1. Commit changes.
    ```
    git add .

--- a/2-environments/README.md
+++ b/2-environments/README.md
@@ -67,7 +67,9 @@ Please refer to [troubleshooting](../docs/TROUBLESHOOTING.md) if you run into is
 **Note 1:** If you are using MacOS, replace `cp -RT` with `cp -R` in the relevant
 commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
 
-**Note 2:** It is possible to create a folder for [Assured Workloads environments](https://cloud.google.com/assured-workloads/docs/create-folder) in the production environment. Follow the instructions for your build environment. If the folder is created, complete the Assured Workloads folder onboarding [form](https://cloud.google.com/assured-workloads/docs/create-folder#create_a_new_folder). The display name of the folder created is in the `assured_workload_folder_display_name` output of the production environment.
+**Note 2:** A folder for [Assured Workloads environments](https://cloud.google.com/assured-workloads/docs/create-folder) is created in the production environment. The ID of the folder created is in the `assured_workload_parent_folder_id` output of the production environment.
+To use Assured Workloads complete the Assured Workloads folder onboarding [form](https://cloud.google.com/assured-workloads/docs/create-folder#create_a_new_folder) and after receiving confirmation follow the instructions for your build environment to create a workload.
+**Assured Workload is a paid service.** see **Pricing** section in the [documentation](https://cloud.google.com/assured-workloads).
 
 ### Deploying with Cloud Build
 

--- a/2-environments/README.md
+++ b/2-environments/README.md
@@ -68,7 +68,9 @@ Please refer to [troubleshooting](../docs/TROUBLESHOOTING.md) if you run into is
 commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
 
 **Note 2:** A folder for [Assured Workloads environments](https://cloud.google.com/assured-workloads/docs/create-folder) is created in the production environment. The ID of the folder created is in the `assured_workload_parent_folder_id` output of the production environment.
-To use Assured Workloads complete the Assured Workloads folder onboarding [form](https://cloud.google.com/assured-workloads/docs/create-folder#create_a_new_folder) and after receiving confirmation follow the instructions for your build environment to create a workload.
+If you will not use Assured Workloads, you can ignore this folder.
+To use Assured Workloads, complete the Assured Workloads folder onboarding [form](https://cloud.google.com/assured-workloads/docs/create-folder#create_a_new_folder) using the folder created
+and **after** receiving a confirmation email, follow the instructions for your build environment to create an assured workload project.
 **Assured Workload is a paid service.** see **Pricing** section in the [documentation](https://cloud.google.com/assured-workloads).
 
 ### Deploying with Cloud Build
@@ -102,7 +104,7 @@ To use Assured Workloads complete the Assured Workloads folder onboarding [form]
    chmod 755 ./tf-wrapper.sh
    ```
 1. Rename `terraform.example.tfvars` to `terraform.tfvars` and update the file with values from your environment and bootstrap (you can re-run `terraform output` in the 0-bootstrap directory to find these values). See any of the envs folder [README.md](./envs/production/README.md) files for additional information on the values in the `terraform.tfvars` file.
-1. To enable [Assured Workloads](https://cloud.google.com/assured-workloads) in the production folder, rename `./envs/production/assured_workload.auto.example.tfvars` to `./envs/production/assured_workload.auto.tfvars` and update the file with values from your environment. See the envs production folder [README.md](./envs/production/README.md) file for additional information on the values in the `terraform.tfvars` file.
+1. To enable [Assured Workloads](https://cloud.google.com/assured-workloads) in the production folder, rename `./envs/production/assured_workload.auto.example.tfvars` to `./envs/production/assured_workload.auto.tfvars` and update the file with values from your environment. See the envs production folder [README.md](./envs/production/README.md) file for additional information on the values in the `terraform.tfvars` file. **Only enable Assured Workloads if you have successfully completed** the [onboarding process](https://cloud.google.com/assured-workloads/docs/create-folder#create_a_new_folder) for the folder created in a previous execution of the foundation. **Assured Workload is a paid service.** see **Pricing** section in the [documentation](https://cloud.google.com/assured-workloads).
 1. Commit changes.
    ```
    git add .

--- a/2-environments/envs/production/README.md
+++ b/2-environments/envs/production/README.md
@@ -17,7 +17,7 @@
 | Name | Description |
 |------|-------------|
 | assured\_workload\_id | Assured Workload ID. |
-| assured\_workload\_parent\_folder\_id | Assured Workload parent folder ID. |
+| assured\_workload\_parent\_folder\_id | Assured Workload parent folder ID. This folder ID must be used in the [onboarding form](https://cloud.google.com/assured-workloads/docs/create-folder#create_a_new_folder). |
 | base\_shared\_vpc\_project\_id | Project for base shared VPC. |
 | env\_folder | Environment folder created under parent. |
 | env\_secrets\_project\_id | Project for environment related secrets. |

--- a/2-environments/envs/production/README.md
+++ b/2-environments/envs/production/README.md
@@ -16,7 +16,8 @@
 
 | Name | Description |
 |------|-------------|
-| assured\_workload\_folder\_display\_name | Assured Workload folder display name. |
+| assured\_workload\_id | Assured Workload ID. |
+| assured\_workload\_parent\_folder\_id | Assured Workload parent folder ID. |
 | base\_shared\_vpc\_project\_id | Project for base shared VPC. |
 | env\_folder | Environment folder created under parent. |
 | env\_secrets\_project\_id | Project for environment related secrets. |

--- a/2-environments/envs/production/README.md
+++ b/2-environments/envs/production/README.md
@@ -3,6 +3,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| assured\_workload\_configuration | Assured Workload configuration. See https://cloud.google.com/assured-workloads . | <pre>object({<br>    enabled           = bool<br>    location          = string<br>    compliance_regime = string<br>  })</pre> | <pre>{<br>  "compliance_regime": "FEDRAMP_MODERATE",<br>  "enabled": false,<br>  "location": "us-central1"<br>}</pre> | no |
 | billing\_account | The ID of the billing account to associate this project with | `string` | n/a | yes |
 | folder\_prefix | Name prefix to use for folders created. Should be the same in all steps. | `string` | `"fldr"` | no |
 | monitoring\_workspace\_users | Google Workspace or Cloud Identity group that have access to Monitoring Workspaces. | `string` | n/a | yes |

--- a/2-environments/envs/production/README.md
+++ b/2-environments/envs/production/README.md
@@ -16,6 +16,7 @@
 
 | Name | Description |
 |------|-------------|
+| assured\_workload\_folder\_display\_name | Assured Workload folder display name. |
 | base\_shared\_vpc\_project\_id | Project for base shared VPC. |
 | env\_folder | Environment folder created under parent. |
 | env\_secrets\_project\_id | Project for environment related secrets. |

--- a/2-environments/envs/production/assured_workload.auto.example.tfvars
+++ b/2-environments/envs/production/assured_workload.auto.example.tfvars
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+  assured_workload_configuration = {
+    enabled           = true
+    location          = "us-central1"
+    compliance_regime = "FEDRAMP_MODERATE"
+  }

--- a/2-environments/envs/production/assured_workload.auto.example.tfvars
+++ b/2-environments/envs/production/assured_workload.auto.example.tfvars
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-  assured_workload_configuration = {
-    enabled           = true
-    location          = "us-central1"
-    compliance_regime = "FEDRAMP_MODERATE"
-  }
+assured_workload_configuration = {
+  enabled           = true
+  location          = "us-central1"
+  compliance_regime = "FEDRAMP_MODERATE"
+}

--- a/2-environments/envs/production/assured_workload.tf
+++ b/2-environments/envs/production/assured_workload.tf
@@ -14,13 +14,6 @@
  * limitations under the License.
  */
 
-resource "google_folder" "assured_workload" {
-  count = var.assured_workload_configuration != null && var.assured_workload_configuration.enabled ? 1 : 0
-
-  display_name = "${var.folder_prefix}-assured-workload"
-  parent       = module.env.env_folder
-}
-
 resource "google_assured_workloads_workload" "production" {
   provider = google-beta
 
@@ -28,8 +21,8 @@ resource "google_assured_workloads_workload" "production" {
 
   billing_account              = "billingAccounts/${var.billing_account}"
   compliance_regime            = var.assured_workload_configuration.compliance_regime
-  display_name                 = "Assured Workload Production"
+  display_name                 = "${var.folder_prefix}-assured-workload"
   location                     = var.assured_workload_configuration.location
   organization                 = var.org_id
-  provisioned_resources_parent = google_folder.assured_workload[0].name
+  provisioned_resources_parent = module.env.env_folder
 }

--- a/2-environments/envs/production/assured_workload.tf
+++ b/2-environments/envs/production/assured_workload.tf
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-resource "google_folder" "assured_workloads" {
+resource "google_folder" "assured_workload" {
   count = var.assured_workload_configuration != null && var.assured_workload_configuration.enabled ? 1 : 0
 
-  display_name = "${var.folder_prefix}-production-assured-workload"
+  display_name = "${var.folder_prefix}-assured-workload"
   parent       = module.env.env_folder
 }
 
@@ -31,5 +31,5 @@ resource "google_assured_workloads_workload" "production" {
   display_name                 = "Assured Workload Production"
   location                     = var.assured_workload_configuration.location
   organization                 = var.org_id
-  provisioned_resources_parent = google_folder.assured_workloads[0].name
+  provisioned_resources_parent = google_folder.assured_workload[0].name
 }

--- a/2-environments/envs/production/assured_workload.tf
+++ b/2-environments/envs/production/assured_workload.tf
@@ -17,7 +17,7 @@
 locals {
   assured_workloads_folder = "${var.folder_prefix}-assured-workloads"
   enable_assured_workload  = lookup(var.assured_workload_configuration, "enabled", false)
-  assured_workload_project = "${var.project_prefix}-p-aw-regional-${random_id.suffix.hex}"
+  assured_workload_project = "${var.project_prefix}-aw-p-regional-${random_id.suffix.hex}"
 }
 
 resource "random_id" "suffix" {
@@ -34,7 +34,7 @@ resource "google_assured_workloads_workload" "workload" {
 
   billing_account              = "billingAccounts/${var.billing_account}"
   compliance_regime            = var.assured_workload_configuration.compliance_regime
-  display_name                 = "${var.folder_prefix}-workload"
+  display_name                 = "regional assured workload"
   location                     = var.assured_workload_configuration.location
   organization                 = var.org_id
   provisioned_resources_parent = google_folder.assured_workloads.name

--- a/2-environments/envs/production/assured_workload.tf
+++ b/2-environments/envs/production/assured_workload.tf
@@ -17,7 +17,11 @@
 locals {
   assured_workloads_folder = "${var.folder_prefix}-assured-workloads"
   enable_assured_workload  = lookup(var.assured_workload_configuration, "enabled", false)
-  assured_workload_project = "${var.project_prefix}-p-aw-regional"
+  assured_workload_project = "${var.project_prefix}-p-aw-regional-${random_id.suffix.hex}"
+}
+
+resource "random_id" "suffix" {
+  byte_length = 4
 }
 
 resource "google_folder" "assured_workloads" {

--- a/2-environments/envs/production/assured_workload.tf
+++ b/2-environments/envs/production/assured_workload.tf
@@ -17,7 +17,6 @@
 locals {
   assured_workloads_folder = "${var.folder_prefix}-assured-workloads"
   enable_assured_workload  = lookup(var.assured_workload_configuration, "enabled", false)
-  assured_workload_project = "${var.project_prefix}-aw-p-regional-${random_id.suffix.hex}"
 }
 
 resource "random_id" "suffix" {
@@ -40,7 +39,6 @@ resource "google_assured_workloads_workload" "workload" {
   provisioned_resources_parent = google_folder.assured_workloads.name
 
   resource_settings {
-    resource_id   = local.assured_workload_project
-    resource_type = "CONSUMER_PROJECT"
+    resource_type = "CONSUMER_FOLDER"
   }
 }

--- a/2-environments/envs/production/assured_workload.tf
+++ b/2-environments/envs/production/assured_workload.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_folder" "assured_workloads" {
+  count = var.assured_workload_configuration != null && var.assured_workload_configuration.enabled ? 1 : 0
+
+  display_name = "${var.folder_prefix}-production-assured-workload"
+  parent       = module.env.env_folder
+}
+
+resource "google_assured_workloads_workload" "production" {
+  provider = google-beta
+
+  count = var.assured_workload_configuration != null && var.assured_workload_configuration.enabled ? 1 : 0
+
+  billing_account              = "billingAccounts/${var.billing_account}"
+  compliance_regime            = var.assured_workload_configuration.compliance_regime
+  display_name                 = "Assured Workload Production"
+  location                     = var.assured_workload_configuration.location
+  organization                 = var.org_id
+  provisioned_resources_parent = google_folder.assured_workloads[0].name
+}

--- a/2-environments/envs/production/assured_workload.tf
+++ b/2-environments/envs/production/assured_workload.tf
@@ -14,14 +14,19 @@
  * limitations under the License.
  */
 
+locals {
+  assured_workload_display_name = "${var.folder_prefix}-assured-workload"
+  enable_assured_workload       = var.assured_workload_configuration != null && var.assured_workload_configuration.enabled
+}
+
 resource "google_assured_workloads_workload" "production" {
   provider = google-beta
 
-  count = var.assured_workload_configuration != null && var.assured_workload_configuration.enabled ? 1 : 0
+  count = local.enable_assured_workload ? 1 : 0
 
   billing_account              = "billingAccounts/${var.billing_account}"
   compliance_regime            = var.assured_workload_configuration.compliance_regime
-  display_name                 = "${var.folder_prefix}-assured-workload"
+  display_name                 = local.assured_workload_display_name
   location                     = var.assured_workload_configuration.location
   organization                 = var.org_id
   provisioned_resources_parent = module.env.env_folder

--- a/2-environments/envs/production/outputs.tf
+++ b/2-environments/envs/production/outputs.tf
@@ -38,3 +38,8 @@ output "env_secrets_project_id" {
   description = "Project for environment related secrets."
   value       = module.env.env_secrets_project_id
 }
+
+output "assured_workload_folder_display_name" {
+  description = "Assured Workload folder display name."
+  value       = local.enable_assured_workload ? local.assured_workload_display_name : ""
+}

--- a/2-environments/envs/production/outputs.tf
+++ b/2-environments/envs/production/outputs.tf
@@ -40,7 +40,7 @@ output "env_secrets_project_id" {
 }
 
 output "assured_workload_parent_folder_id" {
-  description = "Assured Workload parent folder ID."
+  description = "Assured Workload parent folder ID. This folder ID must be used in the [onboarding form](https://cloud.google.com/assured-workloads/docs/create-folder#create_a_new_folder)."
   value       = google_folder.assured_workloads.name
 }
 

--- a/2-environments/envs/production/outputs.tf
+++ b/2-environments/envs/production/outputs.tf
@@ -46,5 +46,5 @@ output "assured_workload_parent_folder_id" {
 
 output "assured_workload_id" {
   description = "Assured Workload ID."
-  value       = local.enable_assured_workload ? google_assured_workloads_workload[0].workload.id : ""
+  value       = local.enable_assured_workload ? google_assured_workloads_workload.workload[0].id : ""
 }

--- a/2-environments/envs/production/outputs.tf
+++ b/2-environments/envs/production/outputs.tf
@@ -39,7 +39,12 @@ output "env_secrets_project_id" {
   value       = module.env.env_secrets_project_id
 }
 
-output "assured_workload_folder_display_name" {
-  description = "Assured Workload folder display name."
-  value       = local.enable_assured_workload ? local.assured_workload_display_name : ""
+output "assured_workload_parent_folder_id" {
+  description = "Assured Workload parent folder ID."
+  value       = google_folder.assured_workloads.name
+}
+
+output "assured_workload_id" {
+  description = "Assured Workload ID."
+  value       = local.enable_assured_workload ? google_assured_workloads_workload[0].workload.id : ""
 }

--- a/2-environments/envs/production/variables.tf
+++ b/2-environments/envs/production/variables.tf
@@ -51,3 +51,18 @@ variable "folder_prefix" {
   type        = string
   default     = "fldr"
 }
+
+
+variable "assured_workload_configuration" {
+  description = "Assured Workload configuration. See https://cloud.google.com/assured-workloads ."
+  type = object({
+    enabled           = bool
+    location          = string
+    compliance_regime = string
+  })
+  default = {
+    enabled           = false
+    location          = "us-central1"
+    compliance_regime = "FEDRAMP_MODERATE"
+  }
+}

--- a/test/fixtures/envs/main.tf
+++ b/test/fixtures/envs/main.tf
@@ -44,7 +44,7 @@ module "production" {
   project_prefix             = var.project_prefix
 
   assured_workload_configuration = {
-    enabled           = true
+    enabled           = false
     location          = "us-central1"
     compliance_regime = "FEDRAMP_MODERATE"
   }

--- a/test/fixtures/envs/main.tf
+++ b/test/fixtures/envs/main.tf
@@ -42,4 +42,10 @@ module "production" {
   parent_folder              = var.parent_folder
   terraform_service_account  = var.terraform_service_account
   project_prefix             = var.project_prefix
+
+  assured_workload_configuration = {
+    enabled           = true
+    location          = "us-central1"
+    compliance_regime = "FEDRAMP_MODERATE"
+  }
 }

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -31,6 +31,7 @@ locals {
     "roles/compute.xpnAdmin",
     "roles/compute.orgSecurityPolicyAdmin",
     "roles/compute.orgSecurityResourceAdmin",
+    "roles/assuredworkloads.admin",
   ]
 }
 

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -47,5 +47,6 @@ module "project" {
     "securitycenter.googleapis.com",
     "servicenetworking.googleapis.com",
     "billingbudgets.googleapis.com",
+    "assuredworkloads.googleapis.com",
   ]
 }


### PR DESCRIPTION
This PR  creates a folder,`fdr-production-assured-workload`, under the `fdr-production` folder  and configure  Assured Workload for this new folder