### PR TITLE
corrected relative file path in policy library cp command

### DIFF
--- a/1-org/README.md
+++ b/1-org/README.md
@@ -112,7 +112,7 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to see 
    ```
 1. Copy contents of policy-library to new repo.
    ```
-   cp -RT ../terraform-example-foundation/policy-library/ .
+   cp -RT ../policy-library/ .
    ```
 
 1. Commit changes.


### PR DESCRIPTION
Once changed into the gcp-policies folder, the previous folder is already terraform-example-foundation making the `cp -RT ../terraform-example-foundation/policy-library/ .` command incorrect.