### PR TITLE
missing input vars on peering_project (4-projects)

### DIFF
--- a/4-projects/business_unit_1/development/example_peering_project.tf
+++ b/4-projects/business_unit_1/development/example_peering_project.tf
@@ -46,6 +46,9 @@ module "peering_project" {
   billing_account             = var.billing_account
   folder_id                   = data.google_active_folder.env.name
   environment                 = "development"
+  alert_spent_percents        = var.alert_spent_percents
+  alert_pubsub_topic          = var.alert_pubsub_topic
+  budget_amount               = var.budget_amount
   project_prefix              = var.project_prefix
 
   # Metadata

--- a/4-projects/business_unit_1/non-production/example_peering_project.tf
+++ b/4-projects/business_unit_1/non-production/example_peering_project.tf
@@ -46,6 +46,9 @@ module "peering_project" {
   billing_account             = var.billing_account
   folder_id                   = data.google_active_folder.env.name
   environment                 = "non-production"
+  alert_spent_percents        = var.alert_spent_percents
+  alert_pubsub_topic          = var.alert_pubsub_topic
+  budget_amount               = var.budget_amount
   project_prefix              = var.project_prefix
 
   # Metadata

--- a/4-projects/business_unit_1/production/example_peering_project.tf
+++ b/4-projects/business_unit_1/production/example_peering_project.tf
@@ -46,6 +46,9 @@ module "peering_project" {
   billing_account             = var.billing_account
   folder_id                   = data.google_active_folder.env.name
   environment                 = "production"
+  alert_spent_percents        = var.alert_spent_percents
+  alert_pubsub_topic          = var.alert_pubsub_topic
+  budget_amount               = var.budget_amount
   project_prefix              = var.project_prefix
 
   # Metadata

--- a/4-projects/business_unit_2/development/example_peering_project.tf
+++ b/4-projects/business_unit_2/development/example_peering_project.tf
@@ -46,6 +46,9 @@ module "peering_project" {
   billing_account             = var.billing_account
   folder_id                   = data.google_active_folder.env.name
   environment                 = "development"
+  alert_spent_percents        = var.alert_spent_percents
+  alert_pubsub_topic          = var.alert_pubsub_topic
+  budget_amount               = var.budget_amount
   project_prefix              = var.project_prefix
 
   # Metadata

--- a/4-projects/business_unit_2/non-production/example_peering_project.tf
+++ b/4-projects/business_unit_2/non-production/example_peering_project.tf
@@ -46,6 +46,9 @@ module "peering_project" {
   billing_account             = var.billing_account
   folder_id                   = data.google_active_folder.env.name
   environment                 = "non-production"
+  alert_spent_percents        = var.alert_spent_percents
+  alert_pubsub_topic          = var.alert_pubsub_topic
+  budget_amount               = var.budget_amount
   project_prefix              = var.project_prefix
 
   # Metadata

--- a/4-projects/business_unit_2/production/example_peering_project.tf
+++ b/4-projects/business_unit_2/production/example_peering_project.tf
@@ -46,6 +46,9 @@ module "peering_project" {
   billing_account             = var.billing_account
   folder_id                   = data.google_active_folder.env.name
   environment                 = "production"
+  alert_spent_percents        = var.alert_spent_percents
+  alert_pubsub_topic          = var.alert_pubsub_topic
+  budget_amount               = var.budget_amount
   project_prefix              = var.project_prefix
 
   # Metadata


### PR DESCRIPTION
Hi there, I noticed the peering project, defined on '4-projects', is not customizing the budget amount for its alerts due to missing some input parameters. Here goes the correction. Thanks!