### PR TITLE
fix infra-pipeline gcs location (4-projects)

### DIFF
--- a/4-projects/business_unit_1/shared/example_infra_pipeline.tf
+++ b/4-projects/business_unit_1/shared/example_infra_pipeline.tf
@@ -50,6 +50,7 @@ module "infra_pipelines" {
   project_prefix              = var.project_prefix
   billing_account             = var.billing_account
   default_region              = var.default_region
+  bucket_region               = var.location_gcs
   app_infra_repos             = ["bu1-example-app"]
 }
 

--- a/4-projects/business_unit_2/shared/example_infra_pipeline.tf
+++ b/4-projects/business_unit_2/shared/example_infra_pipeline.tf
@@ -49,6 +49,7 @@ module "infra_pipelines" {
   project_prefix              = var.project_prefix
   billing_account             = var.billing_account
   default_region              = var.default_region
+  bucket_region               = var.location_gcs
   app_infra_repos             = ["bu2-example-app"]
 }
 


### PR DESCRIPTION
Hi again, it seems the supporting buckets for the infra pipeline, defined on 4-projects, are always created on the default location. I've added the location_gcs variable as input parameter to allow customization. Thanks!