### PR TITLE
fix: data_access_logs_enabled now enables read and write audit logs, defaults to false for cost savings

### DIFF
--- a/1-org/envs/shared/README.md
+++ b/1-org/envs/shared/README.md
@@ -12,7 +12,7 @@
 | billing\_account | The ID of the billing account to associate this project with | `string` | n/a | yes |
 | billing\_data\_users | Google Workspace or Cloud Identity group that have access to billing data set. | `string` | n/a | yes |
 | create\_access\_context\_manager\_access\_policy | Whether to create access context manager access policy | `bool` | `true` | no |
-| data\_access\_logs\_enabled | Enable Data Access logs of types DATA\_READ, DATA\_WRITE and ADMIN\_READ for all GCP services. Enabling Data Access logs might result in your organization being charged for the additional logs usage. See https://cloud.google.com/logging/docs/audit#data-access | `bool` | `true` | no |
+| data\_access\_logs\_enabled | Enable Data Access logs of types DATA\_READ, DATA\_WRITE for all GCP services. Enabling Data Access logs might result in your organization being charged for the additional logs usage. See https://cloud.google.com/logging/docs/audit#data-access The ADMIN\_READ logs are enabled by default. | `bool` | `true` | no |
 | default\_region | Default region for BigQuery resources. | `string` | n/a | yes |
 | dns\_hub\_project\_alert\_pubsub\_topic | The name of the Cloud Pub/Sub topic where budget related messages will be published, in the form of `projects/{project_id}/topics/{topic_id}` for the DNS hub project. | `string` | `null` | no |
 | dns\_hub\_project\_alert\_spent\_percents | A list of percentages of the budget to alert on when threshold is exceeded for the DNS hub project. | `list(number)` | <pre>[<br>  0.5,<br>  0.75,<br>  0.9,<br>  0.95<br>]</pre> | no |

--- a/1-org/envs/shared/README.md
+++ b/1-org/envs/shared/README.md
@@ -12,7 +12,7 @@
 | billing\_account | The ID of the billing account to associate this project with | `string` | n/a | yes |
 | billing\_data\_users | Google Workspace or Cloud Identity group that have access to billing data set. | `string` | n/a | yes |
 | create\_access\_context\_manager\_access\_policy | Whether to create access context manager access policy | `bool` | `true` | no |
-| data\_access\_logs\_enabled | Enable Data Access logs of types DATA\_READ, DATA\_WRITE for all GCP services. Enabling Data Access logs might result in your organization being charged for the additional logs usage. See https://cloud.google.com/logging/docs/audit#data-access The ADMIN\_READ logs are enabled by default. | `bool` | `true` | no |
+| data\_access\_logs\_enabled | Enable Data Access logs of types DATA\_READ, DATA\_WRITE for all GCP services. Enabling Data Access logs might result in your organization being charged for the additional logs usage. See https://cloud.google.com/logging/docs/audit#data-access The ADMIN\_READ logs are enabled by default. | `bool` | `false` | no |
 | default\_region | Default region for BigQuery resources. | `string` | n/a | yes |
 | dns\_hub\_project\_alert\_pubsub\_topic | The name of the Cloud Pub/Sub topic where budget related messages will be published, in the form of `projects/{project_id}/topics/{topic_id}` for the DNS hub project. | `string` | `null` | no |
 | dns\_hub\_project\_alert\_spent\_percents | A list of percentages of the budget to alert on when threshold is exceeded for the DNS hub project. | `list(number)` | <pre>[<br>  0.5,<br>  0.75,<br>  0.9,<br>  0.95<br>]</pre> | no |

--- a/1-org/envs/shared/iam.tf
+++ b/1-org/envs/shared/iam.tf
@@ -23,12 +23,19 @@ resource "google_organization_iam_audit_config" "org_config" {
   org_id  = var.org_id
   service = "allServices"
 
-  audit_log_config {
-    log_type = "DATA_READ"
-  }
-  audit_log_config {
-    log_type = "DATA_WRITE"
-  }
+  ###################################################################################################
+  ### Audit logs can generate costs, to know more about it,
+  ### check the official documentation: https://cloud.google.com/stackdriver/pricing#logging-costs
+  ### To know more about audit logs, you can find more infos
+  ### here https://cloud.google.com/logging/docs/audit/configure-data-access
+  ### To enable all audit logs, uncomment the code below.
+  ####################################################################################################
+  # audit_log_config {
+  #   log_type = "DATA_READ"
+  # }
+  # audit_log_config {
+  #   log_type = "DATA_WRITE"
+  # }
   audit_log_config {
     log_type = "ADMIN_READ"
   }
@@ -39,12 +46,19 @@ resource "google_folder_iam_audit_config" "folder_config" {
   folder  = "folders/${var.parent_folder}"
   service = "allServices"
 
-  audit_log_config {
-    log_type = "DATA_READ"
-  }
-  audit_log_config {
-    log_type = "DATA_WRITE"
-  }
+  ###################################################################################################
+  ### Audit logs can generate costs, to know more about it,
+  ### check the official documentation: https://cloud.google.com/stackdriver/pricing#logging-costs
+  ### To know more about audit logs, you can find more infos
+  ### here https://cloud.google.com/logging/docs/audit/configure-data-access
+  ### To enable all audit logs, uncomment the code below.
+  ####################################################################################################
+  # audit_log_config {
+  #   log_type = "DATA_READ"
+  # }
+  # audit_log_config {
+  #   log_type = "DATA_WRITE"
+  # }
   audit_log_config {
     log_type = "ADMIN_READ"
   }

--- a/1-org/envs/shared/iam.tf
+++ b/1-org/envs/shared/iam.tf
@@ -18,8 +18,12 @@
   Audit Logs - IAM
 *****************************************/
 
+locals {
+  enabling_data_logs = var.data_access_logs_enabled ? ["DATA_WRITE", "DATA_READ"] : []
+}
+
 resource "google_organization_iam_audit_config" "org_config" {
-  count   = var.data_access_logs_enabled && var.parent_folder == "" ? 1 : 0
+  count   = var.parent_folder == "" ? 1 : 0
   org_id  = var.org_id
   service = "allServices"
 
@@ -28,21 +32,21 @@ resource "google_organization_iam_audit_config" "org_config" {
   ### check the official documentation: https://cloud.google.com/stackdriver/pricing#logging-costs
   ### To know more about audit logs, you can find more infos
   ### here https://cloud.google.com/logging/docs/audit/configure-data-access
-  ### To enable all audit logs, uncomment the code below.
+  ### To enable DATA_READ and DATA_WRITE audit logs, set `data_access_logs_enabled` to true
   ####################################################################################################
-  # audit_log_config {
-  #   log_type = "DATA_READ"
-  # }
-  # audit_log_config {
-  #   log_type = "DATA_WRITE"
-  # }
+  dynamic "audit_log_config" {
+    for_each = local.enabling_data_logs
+    content {
+      log_type = each.value
+    }
+  }
   audit_log_config {
     log_type = "ADMIN_READ"
   }
 }
 
 resource "google_folder_iam_audit_config" "folder_config" {
-  count   = var.data_access_logs_enabled && var.parent_folder != "" ? 1 : 0
+  count   = var.parent_folder != "" ? 1 : 0
   folder  = "folders/${var.parent_folder}"
   service = "allServices"
 
@@ -51,14 +55,14 @@ resource "google_folder_iam_audit_config" "folder_config" {
   ### check the official documentation: https://cloud.google.com/stackdriver/pricing#logging-costs
   ### To know more about audit logs, you can find more infos
   ### here https://cloud.google.com/logging/docs/audit/configure-data-access
-  ### To enable all audit logs, uncomment the code below.
+  ### To enable DATA_READ and DATA_WRITE audit logs, set `data_access_logs_enabled` to true
   ####################################################################################################
-  # audit_log_config {
-  #   log_type = "DATA_READ"
-  # }
-  # audit_log_config {
-  #   log_type = "DATA_WRITE"
-  # }
+  dynamic "audit_log_config" {
+    for_each = local.enabling_data_logs
+    content {
+      log_type = each.value
+    }
+  }
   audit_log_config {
     log_type = "ADMIN_READ"
   }

--- a/1-org/envs/shared/iam.tf
+++ b/1-org/envs/shared/iam.tf
@@ -38,7 +38,7 @@ resource "google_organization_iam_audit_config" "org_config" {
   dynamic "audit_log_config" {
     for_each = setunion(local.enabling_data_logs, ["ADMIN_READ"])
     content {
-      log_type = each.value
+      log_type = each.key
     }
   }
 }
@@ -59,7 +59,7 @@ resource "google_folder_iam_audit_config" "folder_config" {
   dynamic "audit_log_config" {
     for_each = setunion(local.enabling_data_logs, ["ADMIN_READ"])
     content {
-      log_type = each.value
+      log_type = each.key
     }
   }
 }

--- a/1-org/envs/shared/iam.tf
+++ b/1-org/envs/shared/iam.tf
@@ -33,15 +33,13 @@ resource "google_organization_iam_audit_config" "org_config" {
   ### To know more about audit logs, you can find more infos
   ### here https://cloud.google.com/logging/docs/audit/configure-data-access
   ### To enable DATA_READ and DATA_WRITE audit logs, set `data_access_logs_enabled` to true
+  ### ADMIN_READ logs are enabled by default.
   ####################################################################################################
   dynamic "audit_log_config" {
-    for_each = local.enabling_data_logs
+    for_each = setunion(local.enabling_data_logs, ["ADMIN_READ"])
     content {
       log_type = each.value
     }
-  }
-  audit_log_config {
-    log_type = "ADMIN_READ"
   }
 }
 
@@ -56,15 +54,13 @@ resource "google_folder_iam_audit_config" "folder_config" {
   ### To know more about audit logs, you can find more infos
   ### here https://cloud.google.com/logging/docs/audit/configure-data-access
   ### To enable DATA_READ and DATA_WRITE audit logs, set `data_access_logs_enabled` to true
+  ### ADMIN_READ logs are enabled by default.
   ####################################################################################################
   dynamic "audit_log_config" {
-    for_each = local.enabling_data_logs
+    for_each = setunion(local.enabling_data_logs, ["ADMIN_READ"])
     content {
       log_type = each.value
     }
-  }
-  audit_log_config {
-    log_type = "ADMIN_READ"
   }
 }
 

--- a/1-org/envs/shared/iam.tf
+++ b/1-org/envs/shared/iam.tf
@@ -38,7 +38,7 @@ resource "google_organization_iam_audit_config" "org_config" {
   dynamic "audit_log_config" {
     for_each = setunion(local.enabling_data_logs, ["ADMIN_READ"])
     content {
-      log_type = each.key
+      log_type = audit_log_config.key
     }
   }
 }
@@ -59,7 +59,7 @@ resource "google_folder_iam_audit_config" "folder_config" {
   dynamic "audit_log_config" {
     for_each = setunion(local.enabling_data_logs, ["ADMIN_READ"])
     content {
-      log_type = each.key
+      log_type = audit_log_config.key
     }
   }
 }

--- a/1-org/envs/shared/variables.tf
+++ b/1-org/envs/shared/variables.tf
@@ -99,7 +99,7 @@ variable "create_access_context_manager_access_policy" {
 variable "data_access_logs_enabled" {
   description = "Enable Data Access logs of types DATA_READ, DATA_WRITE for all GCP services. Enabling Data Access logs might result in your organization being charged for the additional logs usage. See https://cloud.google.com/logging/docs/audit#data-access The ADMIN_READ logs are enabled by default."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "log_export_storage_location" {

--- a/1-org/envs/shared/variables.tf
+++ b/1-org/envs/shared/variables.tf
@@ -97,7 +97,7 @@ variable "create_access_context_manager_access_policy" {
 }
 
 variable "data_access_logs_enabled" {
-  description = "Enable Data Access logs of types DATA_READ, DATA_WRITE and ADMIN_READ for all GCP services. Enabling Data Access logs might result in your organization being charged for the additional logs usage. See https://cloud.google.com/logging/docs/audit#data-access"
+  description = "Enable Data Access logs of types DATA_READ, DATA_WRITE for all GCP services. Enabling Data Access logs might result in your organization being charged for the additional logs usage. See https://cloud.google.com/logging/docs/audit#data-access The ADMIN_READ logs are enabled by default."
   type        = bool
   default     = true
 }


### PR DESCRIPTION
Hey folks, 

This pull request comment the code where enable all the audit logs, due to the costs can be generated.

I also added a disclaimer of charges and to remove the comment of the code to enable all of the audit logs.