### PR TITLE
fix: always grant view permissions at org to CB SA for TFV

### DIFF
--- a/0-bootstrap/main.tf
+++ b/0-bootstrap/main.tf
@@ -177,15 +177,7 @@ data "google_project" "cloudbuild" {
 }
 
 resource "google_organization_iam_member" "org_cb_sa_iam_viewer" {
-  count  = var.parent_folder == "" ? 1 : 0
   org_id = var.org_id
-  role   = "roles/iam.securityReviewer"
-  member = "serviceAccount:${data.google_project.cloudbuild.number}@cloudbuild.gserviceaccount.com"
-}
-
-resource "google_folder_iam_member" "org_cb_sa_iam_viewer" {
-  count  = var.parent_folder != "" ? 1 : 0
-  folder = var.parent_folder
   role   = "roles/iam.securityReviewer"
   member = "serviceAccount:${data.google_project.cloudbuild.number}@cloudbuild.gserviceaccount.com"
 }


### PR DESCRIPTION
fixes #644 
This seems to be due to resources like  https://github.com/terraform-google-modules/terraform-google-bootstrap/blob/2f4089fbb8330337b703a5b3037f7b476962911a/main.tf#L177 which are always deployed at org 