### PR TITLE
feat: add a chmod command to guarantee_execution_permission in the entrypoint.bash file

### DIFF
--- a/4-projects/modules/infra_pipelines/cloudbuild_builder/Dockerfile
+++ b/4-projects/modules/infra_pipelines/cloudbuild_builder/Dockerfile
@@ -41,4 +41,5 @@ RUN apt-get update && \
 
 ENV PATH=/builder/terraform/:$PATH
 COPY entrypoint.bash /builder/entrypoint.bash
+RUN chmod +x /builder/entrypoint.bash
 ENTRYPOINT ["/builder/entrypoint.bash"]


### PR DESCRIPTION
Add in the docker file a command to guarantee that the execute permission in the entrypoint.bash file is given even in a windows platform.