### PR TITLE
fix: exclude version `4.31.0` from the possible versions for infra pipeline module

### DIFF
--- a/0-bootstrap/versions.tf
+++ b/0-bootstrap/versions.tf
@@ -18,8 +18,9 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
+      // version 4.31.0 removed because of issue https://github.com/hashicorp/terraform-provider-google/issues/12226
       source  = "hashicorp/google"
-      version = ">= 3.50"
+      version = ">= 3.50, != 4.31.0"
     }
   }
 

--- a/4-projects/modules/infra_pipelines/versions.tf
+++ b/4-projects/modules/infra_pipelines/versions.tf
@@ -18,13 +18,13 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
       // remove "<= 4.30.0" after new provider release with https://github.com/hashicorp/terraform-provider-google/pull/12248
+      source  = "hashicorp/google"
       version = ">= 3.50, <= 4.30.0"
     }
     google-beta = {
-      source  = "hashicorp/google-beta"
       // remove "<= 4.30.0" after new provider release with https://github.com/hashicorp/terraform-provider-google-beta/pull/4566
+      source  = "hashicorp/google-beta"
       version = ">= 3.50, <= 4.30.0"
     }
     null = {

--- a/4-projects/modules/infra_pipelines/versions.tf
+++ b/4-projects/modules/infra_pipelines/versions.tf
@@ -18,14 +18,14 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      // remove "<= 4.30.0" after new provider release with https://github.com/hashicorp/terraform-provider-google/pull/12248
+      // version 4.31.0 removed because of issue https://github.com/hashicorp/terraform-provider-google/issues/12226
       source  = "hashicorp/google"
-      version = ">= 3.50, <= 4.30.0"
+      version = ">= 3.50, != 4.31.0"
     }
     google-beta = {
-      // remove "<= 4.30.0" after new provider release with https://github.com/hashicorp/terraform-provider-google-beta/pull/4566
+      // version 4.31.0 removed because of issue https://github.com/hashicorp/terraform-provider-google/issues/12226
       source  = "hashicorp/google-beta"
-      version = ">= 3.50, <= 4.30.0"
+      version = ">= 3.50, != 4.31.0"
     }
     null = {
       source = "hashicorp/null"

--- a/4-projects/modules/infra_pipelines/versions.tf
+++ b/4-projects/modules/infra_pipelines/versions.tf
@@ -19,11 +19,13 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.50"
+      // remove "<= 4.30.0" after new provider release with https://github.com/hashicorp/terraform-provider-google/pull/12248
+      version = ">= 3.50, <= 4.30.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.50"
+      // remove "<= 4.30.0" after new provider release with https://github.com/hashicorp/terraform-provider-google-beta/pull/4566
+      version = ">= 3.50, <= 4.30.0"
     }
     null = {
       source = "hashicorp/null"


### PR DESCRIPTION
Fixes #770 