### PR TITLE
create billing dataset in multi-regional by default

### DIFF
--- a/1-org/envs/shared/README.md
+++ b/1-org/envs/shared/README.md
@@ -11,6 +11,7 @@
 | base\_net\_hub\_project\_alert\_spent\_percents | A list of percentages of the budget to alert on when threshold is exceeded for the base net hub project. | `list(number)` | <pre>[<br>  0.5,<br>  0.75,<br>  0.9,<br>  0.95<br>]</pre> | no |
 | base\_net\_hub\_project\_budget\_amount | The amount to use as the budget for the base net hub project. | `number` | `1000` | no |
 | billing\_data\_users | Google Workspace or Cloud Identity group that have access to billing data set. | `string` | n/a | yes |
+| billing\_export\_dataset\_location | The location of the dataset for billing data export. | `string` | `"US"` | no |
 | create\_access\_context\_manager\_access\_policy | Whether to create access context manager access policy. | `bool` | `true` | no |
 | data\_access\_logs\_enabled | Enable Data Access logs of types DATA\_READ, DATA\_WRITE for all GCP services. Enabling Data Access logs might result in your organization being charged for the additional logs usage. See https://cloud.google.com/logging/docs/audit#data-access The ADMIN\_READ logs are enabled by default. | `bool` | `false` | no |
 | dns\_hub\_project\_alert\_pubsub\_topic | The name of the Cloud Pub/Sub topic where budget related messages will be published, in the form of `projects/{project_id}/topics/{topic_id}` for the DNS hub project. | `string` | `null` | no |

--- a/1-org/envs/shared/log_sinks.tf
+++ b/1-org/envs/shared/log_sinks.tf
@@ -97,5 +97,5 @@ resource "google_bigquery_dataset" "billing_dataset" {
   dataset_id    = "billing_data"
   project       = module.org_billing_logs.project_id
   friendly_name = "GCP Billing Data"
-  location      = local.default_region
+  location      = var.billing_export_dataset_location
 }

--- a/1-org/envs/shared/variables.tf
+++ b/1-org/envs/shared/variables.tf
@@ -88,6 +88,12 @@ variable "log_export_storage_location" {
   default     = "US"
 }
 
+variable "billing_export_dataset_location" {
+  description = "The location of the dataset for billing data export."
+  type        = string
+  default     = "US"
+}
+
 variable "log_export_storage_force_destroy" {
   description = "(Optional) If set to true, delete all contents when destroying the resource; otherwise, destroying the resource will fail if contents are present."
   type        = bool


### PR DESCRIPTION
Creates billing dataset in the multi-regional mode as it's a [requirement](https://cloud.google.com/billing/docs/how-to/export-data-bigquery#:~:text=When%20exporting%20detailed%20usage%20cost%20data%2C%20you,to%20the%20appropriate%20tables%20within%20that%20dataset.) to be able to export billing data.

Users realize the multi-regional dataset limitation post running into an error, and this addressed the need for recreating the dataset.