### PR TITLE
Fix directory names on steps on READMEs

### DIFF
--- a/1-org/README.md
+++ b/1-org/README.md
@@ -146,7 +146,7 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to see 
    The message `warning: You appear to have cloned an empty repository.` is
    normal and can be ignored.
 1. Navigate into the repo and change to a non-production branch. All subsequent
-   steps assume you are running them from the gcp-environments directory. If
+   steps assume you are running them from the gcp-org directory. If
    you run them from another directory, adjust your copy paths accordingly.
    ```
    cd gcp-org
@@ -209,7 +209,7 @@ to run the command as the Terraform service account.
    git clone <YOUR_NEW_REPO-1-org>
    ```
 1. Navigate into the repo and change to a non-production branch. All subsequent
-   steps assume you are running them from the gcp-environments directory. If
+   steps assume you are running them from the <YOUR_NEW_REPO-1-org> directory. If
    you run them from another directory, adjust your copy paths accordingly.
    ```
    cd YOUR_NEW_REPO_CLONE-1-org

--- a/3-networks-dual-svpc/README.md
+++ b/3-networks-dual-svpc/README.md
@@ -204,7 +204,7 @@ If you are not able to use Dedicated or Partner Interconnect, you can also use a
    git clone <YOUR_NEW_REPO-3-networks>
    ```
 1. Navigate into the repo and change to a non-production branch. All subsequent
-   steps assume you are running them from the gcp-environments directory. If
+   steps assume you are running them from the <YOUR_NEW_REPO-3-networks> directory. If
    you run them from another directory, adjust your copy paths accordingly.
    ```
    cd YOUR_NEW_REPO_CLONE-3-networks

--- a/3-networks-hub-and-spoke/README.md
+++ b/3-networks-hub-and-spoke/README.md
@@ -206,7 +206,7 @@ If you are not able to use Dedicated or Partner Interconnect, you can also use a
    git clone <YOUR_NEW_REPO-3-networks>
    ```
 1. Navigate into the repo and change to a non-production branch. All subsequent
-   steps assume you are running them from the gcp-environments directory. If
+   steps assume you are running them from the <YOUR_NEW_REPO-3-networks> directory. If
    you run them from another directory, adjust your copy paths accordingly.
    ```
    cd YOUR_NEW_REPO_CLONE-3-networks

--- a/4-projects/README.md
+++ b/4-projects/README.md
@@ -166,7 +166,7 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
    git clone <YOUR_NEW_REPO-4-projects>
    ```
 1. Navigate into the repo and change to a non-production branch. All subsequent
-   steps assume you are running them from the gcp-environments directory. If
+   steps assume you are running them from the <YOUR_NEW_REPO-4-projects> directory. If
    you run them from another directory, adjust your copy paths accordingly.
    ```
    cd YOUR_NEW_REPO_CLONE-4-projects

--- a/5-app-infra/README.md
+++ b/5-app-infra/README.md
@@ -93,7 +93,7 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
    gcloud source repos clone gcp-policies --project=YOUR_INFRA_PIPELINE_PROJECT_ID
    ```
 1. Navigate into the repo. All subsequent steps assume you are running them
-   from the gcp-environments directory. If you run them from another directory,
+   from the gcp-policies directory. If you run them from another directory,
    adjust your copy paths accordingly.
    ```
    cd gcp-policies
@@ -121,7 +121,7 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
    gcloud source repos clone bu1-example-app --project=YOUR_INFRA_PIPELINE_PROJECT_ID
    ```
 1. Navigate into the repo. All subsequent steps assume you are running them
-   from the gcp-environments directory. If you run them from another directory,
+   from the bu1-example-app directory. If you run them from another directory,
    adjust your copy paths accordingly.
    ```
    cd bu1-example-app


### PR DESCRIPTION
Fix directory names on steps that was mentioning `gcp-environments`.