### PR TITLE
Remove undeclared variables from the terraform.example.tfvars files from step 1-org

### DIFF
--- a/1-org/envs/shared/terraform.example.tfvars
+++ b/1-org/envs/shared/terraform.example.tfvars
@@ -19,10 +19,6 @@ domains_to_allow = ["example.com"]
 
 essential_contacts_domains_to_allow = ["@example.com"]
 
-group_org_admins = "gcp-organization-admins@example.com"
-
-group_billing_admins = "gcp-billing-admins@example.com"
-
 billing_data_users = "gcp-billing-data-users@example.com"
 
 audit_data_users = "gcp-security-admins@example.com"


### PR DESCRIPTION
Remove undeclared variables:

- `group_org_admins`
- `group_billing_admins`

 from step 1-org `terraform.example.tfvars` files

These values are read from the remote state of step 0-bootstrap