### PR TITLE
Change gcloud min version to 393.0.0 to fix terraform vet error

### DIFF
--- a/0-bootstrap/README.md
+++ b/0-bootstrap/README.md
@@ -63,7 +63,7 @@ The purpose of this step is to bootstrap a Google Cloud organization, creating a
 To run the commands described in this document, you need to have the following
 installed:
 
-- The [Google Cloud SDK](https://cloud.google.com/sdk/install) version 391.0.0 or later
+- The [Google Cloud SDK](https://cloud.google.com/sdk/install) version 393.0.0 or later
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) version 2.28.0 or later
 - [Terraform](https://www.terraform.io/downloads.html) version 1.0.0
 

--- a/scripts/validate-requirements.sh
+++ b/scripts/validate-requirements.sh
@@ -20,7 +20,9 @@
 # -------------------------- Variables --------------------------
 # Expected versions of the installers
 TF_VERSION="1.0.0"
-GCLOUD_SDK_VERSION="391.0.0"
+# Version 393.0.0 due to terraform-tools 0.5.0 version that fixes the issue
+# mentioned in this PR https://github.com/terraform-google-modules/terraform-example-foundation/pull/729#discussion_r919427668
+GCLOUD_SDK_VERSION="393.0.0"
 GIT_VERSION="2.28.0"
 
 # Expected roles


### PR DESCRIPTION
Change gcloud min version to 393.0.0 fix terraform vet error.
Version 393.0.0 is recommended due to terraform-tools 0.5.0 version that fixes the issue mentioned in this [PR 729](https://github.com/terraform-google-modules/terraform-example-foundation/pull/729#discussion_r919427668).