### PR TITLE
Retry on transient errors

### DIFF
--- a/test/integration/bootstrap/bootstrap_test.go
+++ b/test/integration/bootstrap/bootstrap_test.go
@@ -57,6 +57,7 @@ func TestBootstrap(t *testing.T) {
 	bootstrap := tft.NewTFBlueprintTest(t,
 		tft.WithTFDir("../../../0-bootstrap"),
 		tft.WithVars(vars),
+		tft.WithRetryableTerraformErrors(testutils.RetryableTransientErrors, 1, 2*time.Minute),
 		tft.WithPolicyLibraryPath("/workspace/policy-library", temp.GetTFSetupStringOutput("project_id")),
 	)
 

--- a/test/integration/envs/envs_test.go
+++ b/test/integration/envs/envs_test.go
@@ -17,6 +17,7 @@ package envs
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
@@ -56,6 +57,7 @@ func TestEnvs(t *testing.T) {
 		t.Run(envName, func(t *testing.T) {
 			envs := tft.NewTFBlueprintTest(t,
 				tft.WithTFDir(fmt.Sprintf("../../../2-environments/envs/%s", envName)),
+				tft.WithRetryableTerraformErrors(testutils.RetryableTransientErrors, 1, 2*time.Minute),
 				tft.WithPolicyLibraryPath("/workspace/policy-library", bootstrap.GetTFSetupStringOutput("project_id")),
 				tft.WithVars(vars),
 				tft.WithBackendConfig(backendConfig),

--- a/test/integration/networks/networks_test.go
+++ b/test/integration/networks/networks_test.go
@@ -17,11 +17,14 @@ package networks
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/utils"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/terraform-google-modules/terraform-example-foundation/test/integration/testutils"
 )
 
 func getPolicyID(t *testing.T, orgID string) string {
@@ -190,6 +193,7 @@ func TestNetworks(t *testing.T) {
 			networks := tft.NewTFBlueprintTest(t,
 				tft.WithTFDir(fmt.Sprintf(tfdDir, envName)),
 				tft.WithVars(vars),
+				tft.WithRetryableTerraformErrors(testutils.RetryableTransientErrors, 1, 2*time.Minute),
 				tft.WithPolicyLibraryPath("/workspace/policy-library", bootstrap.GetTFSetupStringOutput("project_id")),
 				tft.WithBackendConfig(backendConfig),
 			)

--- a/test/integration/org/org_test.go
+++ b/test/integration/org/org_test.go
@@ -54,6 +54,7 @@ func TestOrg(t *testing.T) {
 	org := tft.NewTFBlueprintTest(t,
 		tft.WithTFDir("../../../1-org/envs/shared"),
 		tft.WithVars(vars),
+		tft.WithRetryableTerraformErrors(testutils.RetryableTransientErrors, 1, 2*time.Minute),
 		tft.WithPolicyLibraryPath("/workspace/policy-library", bootstrap.GetTFSetupStringOutput("project_id")),
 		tft.WithBackendConfig(backendConfig),
 	)

--- a/test/integration/projects-shared/projects_shared_test.go
+++ b/test/integration/projects-shared/projects_shared_test.go
@@ -17,6 +17,7 @@ package projectsshared
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
@@ -70,6 +71,7 @@ func TestProjectsShared(t *testing.T) {
 				tft.WithTFDir(tts.tfDir),
 				tft.WithVars(sharedVars),
 				tft.WithBackendConfig(backendConfig),
+				tft.WithRetryableTerraformErrors(testutils.RetryableTransientErrors, 1, 2*time.Minute),
 				tft.WithPolicyLibraryPath("/workspace/policy-library", bootstrap.GetTFSetupStringOutput("project_id")),
 			)
 

--- a/test/integration/projects/projects_test.go
+++ b/test/integration/projects/projects_test.go
@@ -17,6 +17,7 @@ package projects
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
@@ -141,6 +142,7 @@ func TestProjects(t *testing.T) {
 				tft.WithTFDir(fmt.Sprintf(tt.baseDir, env)),
 				tft.WithVars(vars),
 				tft.WithBackendConfig(backendConfig),
+				tft.WithRetryableTerraformErrors(testutils.RetryableTransientErrors, 1, 2*time.Minute),
 				tft.WithPolicyLibraryPath("/workspace/policy-library", bootstrap.GetTFSetupStringOutput("project_id")),
 			)
 

--- a/test/integration/testutils/retry.go
+++ b/test/integration/testutils/retry.go
@@ -1,0 +1,29 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+var (
+	RetryableTransientErrors = map[string]string{
+
+		// API Rate limit exceeded errors can be retried.
+		".*rateLimitExceeded.*": "Rate limit exceeded.",
+
+		// Project deletion is eventually consistent. Even if google_project resources inside the folder are deleted there may be a deletion error.
+		".*FOLDER_TO_DELETE_NON_EMPTY_VIOLATION.*": "Failed to delete non empty folder.",
+
+		// Granting IAM Roles is eventually consistent.
+		".*Error 403.*Permission.*denied.*": "Permission denied on resource.",
+	}
+)

--- a/test/integration/testutils/retry.go
+++ b/test/integration/testutils/retry.go
@@ -24,6 +24,6 @@ var (
 		".*FOLDER_TO_DELETE_NON_EMPTY_VIOLATION.*": "Failed to delete non empty folder.",
 
 		// Granting IAM Roles is eventually consistent.
-		".*Error 403.*Permission.*denied.*": "Permission denied on resource.",
+		".*Error 403.*Permission.*denied on resource.*": "Permission denied on resource.",
 	}
 )


### PR DESCRIPTION
Retry once on possible transient errors:

- Rate limit exceeded
- Failed to delete non empty folder
- Permission denied on resource