### PR TITLE
Add Create Unique Tag Key in terraform.example.tfvars

### DIFF
--- a/1-org/envs/shared/terraform.example.tfvars
+++ b/1-org/envs/shared/terraform.example.tfvars
@@ -32,3 +32,8 @@ remote_state_bucket = "REMOTE_STATE_BUCKET"
 //enable_hub_and_spoke = true
 
 //create_access_context_manager_access_policy = false
+
+// Optional - If you are deploying Foundation Example in a parent folder
+// consider using below create_unique_tag_key var because as Tag Keys are
+// unique organization-wide it will add a random suffix at each tag key
+//create_unique_tag_key = true


### PR DESCRIPTION
Added `create_unique_tag_key` in terraform.example.tfvars as a suggestion for users to consider this variable when deploying to a folder because tag keys are unique across the organization.