### PR TITLE
Fix propagation issues during integrated tests when deleting env folders

### DIFF
--- a/2-environments/modules/env_baseline/folders.tf
+++ b/2-environments/modules/env_baseline/folders.tf
@@ -23,10 +23,10 @@ resource "google_folder" "env" {
   parent       = local.parent
 }
 
-resource "time_sleep" "wait_30_seconds" {
+resource "time_sleep" "wait_60_seconds" {
   depends_on = [google_folder.env]
 
-  destroy_duration = "30s"
+  destroy_duration = "60s"
 }
 
 # The following code binds a tag to a resource.
@@ -35,4 +35,6 @@ resource "time_sleep" "wait_30_seconds" {
 resource "google_tags_tag_binding" "folder_env" {
   parent    = "//cloudresourcemanager.googleapis.com/${google_folder.env.id}"
   tag_value = local.tags["environment_${var.env}"]
+
+  depends_on = [time_sleep.wait_60_seconds]
 }

--- a/2-environments/modules/env_baseline/monitoring.tf
+++ b/2-environments/modules/env_baseline/monitoring.tf
@@ -27,7 +27,7 @@ module "monitoring_project" {
   billing_account             = local.billing_account
   folder_id                   = google_folder.env.id
   disable_services_on_destroy = false
-  depends_on                  = [time_sleep.wait_30_seconds]
+  depends_on                  = [time_sleep.wait_60_seconds]
   activate_apis = [
     "logging.googleapis.com",
     "monitoring.googleapis.com",

--- a/2-environments/modules/env_baseline/networking.tf
+++ b/2-environments/modules/env_baseline/networking.tf
@@ -27,7 +27,7 @@ module "base_shared_vpc_host_project" {
   billing_account             = local.billing_account
   folder_id                   = google_folder.env.id
   disable_services_on_destroy = false
-  depends_on                  = [time_sleep.wait_30_seconds]
+  depends_on                  = [time_sleep.wait_60_seconds]
   activate_apis = [
     "compute.googleapis.com",
     "dns.googleapis.com",
@@ -60,7 +60,7 @@ module "restricted_shared_vpc_host_project" {
   billing_account             = local.billing_account
   folder_id                   = google_folder.env.id
   disable_services_on_destroy = false
-  depends_on                  = [time_sleep.wait_30_seconds]
+  depends_on                  = [time_sleep.wait_60_seconds]
   activate_apis = [
     "compute.googleapis.com",
     "dns.googleapis.com",

--- a/2-environments/modules/env_baseline/secrets.tf
+++ b/2-environments/modules/env_baseline/secrets.tf
@@ -29,6 +29,7 @@ module "env_secrets" {
   billing_account             = local.billing_account
   folder_id                   = google_folder.env.id
   disable_services_on_destroy = false
+  depends_on                  = [time_sleep.wait_60_seconds]
   activate_apis               = ["logging.googleapis.com", "secretmanager.googleapis.com"]
 
   labels = {


### PR DESCRIPTION
- Increased time_sleep to delete env folder to 60 seconds
- Added tags and secrets to wait for the time_sleep