### PR TITLE
fix sed regex for backend bucket name substitution

### DIFF
--- a/build/cloudbuild-tf-apply.yaml
+++ b/build/cloudbuild-tf-apply.yaml
@@ -29,7 +29,8 @@ steps:
       gcloud config set auth/impersonate_service_account $tf_sa_email
     fi
     echo "Adding bucket information to backends"
-    for i in `find -name 'backend.tf'`; do sed -i 's/UPDATE_ME/${_STATE_BUCKET_NAME}/' $i; done
+    for i in `find -name 'backend.tf'`; do sed -r -i 's/UPDATE_ME|UPDATE_PROJECTS_BACKEND|UPDATE_APP_INFRA_BUCKET/${_STATE_BUCKET_NAME}/' $i; done
+
 
 # [START tf-init]
 - id: 'tf init'

--- a/build/cloudbuild-tf-plan.yaml
+++ b/build/cloudbuild-tf-plan.yaml
@@ -29,7 +29,8 @@ steps:
       gcloud config set auth/impersonate_service_account $tf_sa_email
     fi
     echo "Adding bucket information to backends"
-    for i in `find -name 'backend.tf'`; do sed -i 's/UPDATE_ME/${_STATE_BUCKET_NAME}/' $i; done
+    for i in `find -name 'backend.tf'`; do sed -r -i 's/UPDATE_ME|UPDATE_PROJECTS_BACKEND|UPDATE_APP_INFRA_BUCKET/${_STATE_BUCKET_NAME}/' $i; done
+
 
 # [START tf-plan_validate_all]
 - id: 'tf plan validate all'


### PR DESCRIPTION
There are now different tokens to be used to do the replacement of the backend bucket name in each step.

Steps 1, 2 and 3 use `UPDATE_ME`
Step 4 uses `UPDATE_PROJECTS_BACKEND`
Step 5 uses `UPDATE_APP_INFRA_BUCKET`

They need to be different  because we are replacing all the backends for steps 1, 2 ,3 and 4 at the end of step 0-bootstrap. for this reason, we now need different token for different values to avoid wrong replacement of the tokens

This PR fixes the regex used in the cloud build files for the regex to be able to work in all the three cases.