### PR TITLE
unset GOOGLE_IMPERSONATE_SERVICE_ACCOUNT after terraform manual execution

### DIFF
--- a/3-networks-dual-svpc/README.md
+++ b/3-networks-dual-svpc/README.md
@@ -258,6 +258,12 @@ If you are not able to use Dedicated or Partner Interconnect, you can also use a
    git push origin non-production
    ```
 
+1. Before executing the next steps, unset the `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` environment variable.
+
+   ```bash
+   unset GOOGLE_IMPERSONATE_SERVICE_ACCOUNT
+   ```
+
 1. You can now move to the instructions in the [4-projects](../4-projects/README.md) step.
 
 ### Deploying with Jenkins

--- a/3-networks-hub-and-spoke/README.md
+++ b/3-networks-hub-and-spoke/README.md
@@ -261,6 +261,12 @@ If you are not able to use Dedicated or Partner Interconnect, you can also use a
    git push origin non-production
    ```
 
+1. Before executing the next steps, unset the `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` environment variable.
+
+   ```bash
+   unset GOOGLE_IMPERSONATE_SERVICE_ACCOUNT
+   ```
+
 1. You can now move to the instructions in the [4-projects](../4-projects/README.md) step.
 
 ### Deploying with Jenkins

--- a/4-projects/README.md
+++ b/4-projects/README.md
@@ -202,6 +202,12 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
    git push origin non-production
    ```
 
+1. Before executing the next step, unset the `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` environment variable.
+
+   ```bash
+   unset GOOGLE_IMPERSONATE_SERVICE_ACCOUNT
+   ```
+
 1. You can now move to the instructions in the [5-app-infra](../5-app-infra/README.md) step.
 
 ### Deploying with Jenkins


### PR DESCRIPTION
Unset the GOOGLE_IMPERSONATE_SERVICE_ACCOUNT environment variable used to impersonate the terraform service account when manually  executing Terraform for steps:

- 3-networks-dual-svpc
- 3-networks-hub-and-spoke
-  4-projects