### PR TITLE
Create a workspace for 0-bootstrap

### DIFF
--- a/0-bootstrap/README.md
+++ b/0-bootstrap/README.md
@@ -203,19 +203,49 @@ your current Jenkins manager (controller) environment.
    ```
 
 1. (Optional) Run `terraform plan` to verify that state is configured correctly. You should see no changes from the previous state.
-1. Save `0-bootstrap` Terraform configuration to `gcp-bootstrap` source repository:
+1. Clone the policy repo and copy contents of policy-library to new repo. Clone the repo at the same level of the `terraform-example-foundation` folder, the next instructions assume that layout.
 
    ```bash
    cd ../..
 
+   gcloud source repos clone gcp-policies --project=${cloudbuild_project_id}
+
+   cd gcp-policies
+   git checkout -b main
+   cp -RT ../terraform-example-foundation/policy-library/ .
+   ```
+
+1. Commit changes and push your main branch to the policy repo.
+
+   ```bash
+   git add .
+   git commit -m 'Initialize policy library'
+   git push --set-upstream origin main
+   ```
+
+1. Navigate out of the repo.
+
+   ```bash
+   cd ..
+   ```
+
+1. Save `0-bootstrap` Terraform configuration to `gcp-bootstrap` source repository:
+
+   ```bash
    gcloud source repos clone gcp-bootstrap --project=${cloudbuild_project_id}
+
    cd gcp-bootstrap
-   git checkout -b production
-   cp -RT ../terraform-example-foundation/0-bootstrap/ .
+   git checkout -b plan
+   mkdir -p envs/shared
+
+   cp -RT ../terraform-example-foundation/0-bootstrap/ ./envs/shared
+   cp ../terraform-example-foundation/build/cloudbuild-tf-* .
+   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   chmod 755 ./tf-wrapper.sh
 
    git add .
    git commit -m 'Initialize bootstrap'
-   git push --set-upstream origin production
+   git push --set-upstream origin plan
    ```
 
 1. You can now move to the instructions in the [1-org](../1-org/README.md) step.
@@ -256,6 +286,7 @@ Each step has instructions for this change.
 
 | Name | Description |
 |------|-------------|
+| bootstrap\_step\_terraform\_service\_account\_email | Bootstrap Step Terraform Account |
 | cloud\_builder\_artifact\_repo | GAR Repo created to store TF Cloud Builder images. |
 | cloudbuild\_project\_id | Project where CloudBuild configuration and terraform container image will reside. |
 | common\_config | Common configuration data to be used in other steps. |

--- a/0-bootstrap/jenkins.tf.example
+++ b/0-bootstrap/jenkins.tf.example
@@ -16,6 +16,8 @@
 
 locals {
   sa_names = { for k, v in google_service_account.terraform-env-sa : k => v.id }
+
+  cicd_project_id = module.jenkins_bootstrap.cicd_project_id
 }
 
 module "jenkins_bootstrap" {

--- a/0-bootstrap/main.tf
+++ b/0-bootstrap/main.tf
@@ -22,6 +22,7 @@ locals {
   // in the list "org_project_creators" will have the Project Creator role,
   // so the granular service accounts for each step need to be added to the list.
   step_terraform_sa = [
+    "serviceAccount:${google_service_account.terraform-env-sa["bootstrap"].email}",
     "serviceAccount:${google_service_account.terraform-env-sa["org"].email}",
     "serviceAccount:${google_service_account.terraform-env-sa["env"].email}",
     "serviceAccount:${google_service_account.terraform-env-sa["net"].email}",

--- a/0-bootstrap/outputs.tf
+++ b/0-bootstrap/outputs.tf
@@ -19,6 +19,11 @@ output "seed_project_id" {
   value       = module.seed_bootstrap.seed_project_id
 }
 
+output "bootstrap_step_terraform_service_account_email" {
+  description = "Bootstrap Step Terraform Account"
+  value       = google_service_account.terraform-env-sa["bootstrap"].email
+}
+
 output "projects_step_terraform_service_account_email" {
   description = "Projects Step Terraform Account"
   value       = google_service_account.terraform-env-sa["proj"].email
@@ -94,7 +99,7 @@ output "gcs_bucket_cloudbuild_artifacts" {
 
 output "projects_gcs_bucket_tfstate" {
   description = "Bucket used for storing terraform state for stage 4-projects foundations pipelines in seed project."
-  value       = local.projects_gcs_bucket_tfstate
+  value       = module.gcp_projects_state_bucket.bucket.name
 }
 
 output "cloud_builder_artifact_repo" {

--- a/0-bootstrap/sa.tf
+++ b/0-bootstrap/sa.tf
@@ -20,10 +20,11 @@ locals {
   parent_id   = var.parent_folder == "" ? var.org_id : var.parent_folder
 
   granular_sa = {
-    "org"  = "Foundation Organization SA. Managed by Terraform.",
-    "env"  = "Foundation Environment SA. Managed by Terraform.",
-    "net"  = "Foundation Network SA. Managed by Terraform.",
-    "proj" = "Foundation Projects SA. Managed by Terraform.",
+    "bootstrap" = "Foundation Bootstrap SA. Managed by Terraform.",
+    "org"       = "Foundation Organization SA. Managed by Terraform.",
+    "env"       = "Foundation Environment SA. Managed by Terraform.",
+    "net"       = "Foundation Network SA. Managed by Terraform.",
+    "proj"      = "Foundation Projects SA. Managed by Terraform.",
   }
 
   common_roles = [
@@ -31,6 +32,11 @@ locals {
   ]
 
   granular_sa_org_level_roles = {
+    "bootstrap" = distinct(concat([
+      "roles/resourcemanager.organizationAdmin",
+      "roles/accesscontextmanager.policyAdmin",
+      "roles/serviceusage.serviceUsageConsumer",
+    ], local.common_roles)),
     "org" = distinct(concat([
       "roles/orgpolicy.policyAdmin",
       "roles/logging.configWriter",
@@ -57,6 +63,9 @@ locals {
   }
 
   granular_sa_parent_level_roles = {
+    "bootstrap" = [
+      "roles/resourcemanager.folderAdmin",
+    ],
     "org" = [
       "roles/resourcemanager.folderAdmin",
     ],
@@ -81,6 +90,11 @@ locals {
   }
 
   granular_sa_seed_project = {
+    "bootstrap" = [
+      "roles/storage.admin",
+      "roles/iam.serviceAccountAdmin",
+      "roles/resourcemanager.projectDeleter",
+    ],
     "org" = [
       "roles/storage.objectAdmin",
     ],

--- a/0-bootstrap/sa.tf
+++ b/0-bootstrap/sa.tf
@@ -89,6 +89,7 @@ locals {
     ],
   }
 
+  // Roles required to manage resources in the Seed project
   granular_sa_seed_project = {
     "bootstrap" = [
       "roles/storage.admin",
@@ -106,6 +107,22 @@ locals {
     ],
     "proj" = [
       "roles/storage.objectAdmin",
+    ],
+  }
+
+  // Roles required to manage resources in the CI/CD project
+  granular_sa_cicd_project = {
+    "bootstrap" = [
+      "roles/storage.admin",
+      "roles/compute.networkAdmin",
+      "roles/cloudbuild.builds.editor",
+      "roles/cloudbuild.workerPoolOwner",
+      "roles/artifactregistry.admin",
+      "roles/source.admin",
+      "roles/iam.serviceAccountAdmin",
+      "roles/workflows.admin",
+      "roles/cloudscheduler.admin",
+      "roles/resourcemanager.projectDeleter",
     ],
   }
 }
@@ -138,13 +155,23 @@ module "parent_iam_member" {
   roles       = each.value
 }
 
-module "project_iam_member" {
+module "seed_project_iam_member" {
   source   = "./modules/parent-iam-member"
   for_each = local.granular_sa_seed_project
 
   member      = "serviceAccount:${google_service_account.terraform-env-sa[each.key].email}"
   parent_type = "project"
   parent_id   = module.seed_bootstrap.seed_project_id
+  roles       = each.value
+}
+
+module "cicd_project_iam_member" {
+  source   = "./modules/parent-iam-member"
+  for_each = local.granular_sa_cicd_project
+
+  member      = "serviceAccount:${google_service_account.terraform-env-sa[each.key].email}"
+  parent_type = "project"
+  parent_id   = local.cicd_project_id
   roles       = each.value
 }
 

--- a/1-org/README.md
+++ b/1-org/README.md
@@ -105,51 +105,21 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
 
 ### Deploying with Cloud Build
 
-1. Clone the policy repo based on the Terraform output from the previous section.
+1. Clone the `gcp-org` repo based on the Terraform output from the previous step.
 Clone the repo at the same level of the `terraform-example-foundation` folder, the next instructions assume that layout.
 Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to see the project again.
 
    ```bash
    export CLOUD_BUILD_PROJECT_ID=$(terraform -chdir="terraform-example-foundation/0-bootstrap/" output -raw cloudbuild_project_id)
    echo ${CLOUD_BUILD_PROJECT_ID}
-   gcloud source repos clone gcp-policies --project=${CLOUD_BUILD_PROJECT_ID}
-   ```
 
-1. Navigate into the repo and copy contents of policy-library to new repo.
-   All subsequent steps assume you are running them
-   from the gcp-policies directory. If you run them from another directory,
-   adjust your copy paths accordingly.
-
-   ```bash
-   cd gcp-policies
-   git checkout -b main
-   cp -RT ../terraform-example-foundation/policy-library/ .
-   ```
-
-1. Commit changes and push your main branch to the new repo.
-
-   ```bash
-   git add .
-   git commit -m 'Your message'
-   git push --set-upstream origin main
-   ```
-
-1. Navigate out of the repo.
-
-   ```bash
-   cd ..
-   ```
-
-1. Clone the repo.
-
-   ```bash
    gcloud source repos clone gcp-org --project=${CLOUD_BUILD_PROJECT_ID}
    ```
 
    - The message `warning: You appear to have cloned an empty repository.` is
    normal and can be ignored.
 1. Navigate into the repo, change to a non-production branch and copy contents of foundation to new repo.
-   All subsequent steps assume you are running them from the gcp-org directory.
+   All subsequent steps assume you are running them from the `gcp-org` directory.
    If you run them from another directory, adjust your copy paths accordingly.
 
    ```bash

--- a/test/integration/bootstrap/bootstrap_test.go
+++ b/test/integration/bootstrap/bootstrap_test.go
@@ -72,6 +72,7 @@ func TestBootstrap(t *testing.T) {
 	}
 
 	triggerRepos := []string{
+		"gcp-bootstrap",
 		"gcp-org",
 		"gcp-environments",
 		"gcp-networks",
@@ -153,6 +154,7 @@ func TestBootstrap(t *testing.T) {
 			assert.True(prj.Exists(), "project %s should exist", cbProjectID)
 
 			for _, env := range []string{
+				"bootstrap",
 				"org",
 				"env",
 				"net",
@@ -231,6 +233,15 @@ func TestBootstrap(t *testing.T) {
 						"roles/securitycenter.notificationConfigEditor",
 						"roles/resourcemanager.organizationViewer",
 						"roles/accesscontextmanager.policyAdmin",
+						"roles/browser",
+					},
+				},
+				{
+					output: "bootstrap_step_terraform_service_account_email",
+					orgRoles: []string{
+						"roles/resourcemanager.organizationAdmin",
+						"roles/accesscontextmanager.policyAdmin",
+						"roles/serviceusage.serviceUsageConsumer",
 						"roles/browser",
 					},
 				},


### PR DESCRIPTION
Fixes #865 
Create a workspace for the 0-bootstrap step with:

- custom service account
  - roles granted at org level, parent level, and at project level 
- plan trigger
- apply trigger
- gcp-policies repo instructions moved to 0-bootstrap README

Additional change: creation of a state bucket for step 4-projects in the Seed project