### PR TITLE
update request timeout to 5 minutes in network step

### DIFF
--- a/3-networks-dual-svpc/envs/development/providers.tf
+++ b/3-networks-dual-svpc/envs/development/providers.tf
@@ -18,9 +18,9 @@
   Provider request timeout configuration
  *****************************************/
 provider "google" {
-  request_timeout = "2m"
+  request_timeout = "5m"
 }
 
 provider "google-beta" {
-  request_timeout = "2m"
+  request_timeout = "5m"
 }

--- a/3-networks-dual-svpc/envs/non-production/providers.tf
+++ b/3-networks-dual-svpc/envs/non-production/providers.tf
@@ -18,9 +18,9 @@
   Provider request timeout configuration
  *****************************************/
 provider "google" {
-  request_timeout = "2m"
+  request_timeout = "5m"
 }
 
 provider "google-beta" {
-  request_timeout = "2m"
+  request_timeout = "5m"
 }

--- a/3-networks-dual-svpc/envs/production/providers.tf
+++ b/3-networks-dual-svpc/envs/production/providers.tf
@@ -18,9 +18,9 @@
   Provider request timeout configuration
  *****************************************/
 provider "google" {
-  request_timeout = "2m"
+  request_timeout = "5m"
 }
 
 provider "google-beta" {
-  request_timeout = "2m"
+  request_timeout = "5m"
 }

--- a/3-networks-dual-svpc/envs/shared/providers.tf
+++ b/3-networks-dual-svpc/envs/shared/providers.tf
@@ -18,9 +18,9 @@
   Provider request timeout configuration
  *****************************************/
 provider "google" {
-  request_timeout = "2m"
+  request_timeout = "5m"
 }
 
 provider "google-beta" {
-  request_timeout = "2m"
+  request_timeout = "5m"
 }

--- a/3-networks-hub-and-spoke/envs/development/providers.tf
+++ b/3-networks-hub-and-spoke/envs/development/providers.tf
@@ -18,9 +18,9 @@
   Provider request timeout configuration
  *****************************************/
 provider "google" {
-  request_timeout = "2m"
+  request_timeout = "5m"
 }
 
 provider "google-beta" {
-  request_timeout = "2m"
+  request_timeout = "5m"
 }

--- a/3-networks-hub-and-spoke/envs/non-production/providers.tf
+++ b/3-networks-hub-and-spoke/envs/non-production/providers.tf
@@ -18,9 +18,9 @@
   Provider request timeout configuration
  *****************************************/
 provider "google" {
-  request_timeout = "2m"
+  request_timeout = "5m"
 }
 
 provider "google-beta" {
-  request_timeout = "2m"
+  request_timeout = "5m"
 }

--- a/3-networks-hub-and-spoke/envs/production/providers.tf
+++ b/3-networks-hub-and-spoke/envs/production/providers.tf
@@ -18,9 +18,9 @@
   Provider request timeout configuration
  *****************************************/
 provider "google" {
-  request_timeout = "2m"
+  request_timeout = "5m"
 }
 
 provider "google-beta" {
-  request_timeout = "2m"
+  request_timeout = "5m"
 }

--- a/3-networks-hub-and-spoke/envs/shared/providers.tf
+++ b/3-networks-hub-and-spoke/envs/shared/providers.tf
@@ -18,9 +18,9 @@
   Provider request timeout configuration
  *****************************************/
 provider "google" {
-  request_timeout = "2m"
+  request_timeout = "5m"
 }
 
 provider "google-beta" {
-  request_timeout = "2m"
+  request_timeout = "5m"
 }


### PR DESCRIPTION
update request timeout form 2 minutes to 5 minutes in network step to prevent timeout during the creation of DNS resources.