### PR TITLE
chore: fix script typos on readmes

### DIFF
--- a/4-projects/README.md
+++ b/4-projects/README.md
@@ -240,7 +240,7 @@ See `0-bootstrap` [README-Jenkins.md](../0-bootstrap/README-Jenkins.md#deploying
 
    ```bash
    export remote_state_bucket=$(terraform -chdir="../0-bootstrap/" output -raw gcs_bucket_tfstate)
-   echo "remote_state_bucket = ${REMOTE_STATE_BUCKET}"
+   echo "remote_state_bucket = ${remote_state_bucket}"
 
    sed -i "s/REMOTE_STATE_BUCKET/${remote_state_bucket}/" ./common.auto.tfvars
    ```

--- a/5-app-infra/README.md
+++ b/5-app-infra/README.md
@@ -226,7 +226,7 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
    terraform_sa=$(terraform -chdir="../4-projects/business_unit_1/shared/" output -json terraform_service_accounts | jq '."bu1-example-app"' --raw-output)
    echo ${terraform_sa}
 
-   gcloud iam service-accounts add-iam-policy-binding ${terraform_sa} --project ${project_id}} --member="${member}" --role="roles/iam.serviceAccountTokenCreator"
+   gcloud iam service-accounts add-iam-policy-binding ${terraform_sa} --project ${project_id} --member="${member}" --role="roles/iam.serviceAccountTokenCreator"
    ```
 
 1. Update `backend.tf` with your bucket from the infra pipeline output.


### PR DESCRIPTION
4-projects/README.md
  remote_state_bucket variable should be lowercase.

5-app-infra/README.md
  Remove additional closing curly bracket typo