### PR TITLE
enable firewall logging for health check firewall rule

### DIFF
--- a/3-networks-hub-and-spoke/modules/transitivity/main.tf
+++ b/3-networks-hub-and-spoke/modules/transitivity/main.tf
@@ -87,6 +87,7 @@ module "ilbs" {
   global_access           = true
   network                 = var.vpc_name
   subnetwork              = var.gw_subnets[each.key]
+  firewall_enable_logging = true
   source_ip_ranges        = flatten(values(var.regional_aggregates))
   target_service_accounts = [module.service_account.email]
   source_tags             = null


### PR DESCRIPTION
Enable firewall logging for health check firewall rule in the transitivity configuration for the hub and spoke network mode