### PR TITLE
fix: conventional-commit-lint.yaml file must have the default header

### DIFF
--- a/.github/conventional-commit-lint.yaml
+++ b/.github/conventional-commit-lint.yaml
@@ -1,2 +1,16 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 enabled: true
 always_check_pr_title: true


### PR DESCRIPTION
The conventional-commit-lint.yaml file is missing the default header

```
Checking file headers
./.github/conventional-commit-lint.yaml
```
