### PR TITLE
fix: add onprem_dc variable and add missing routers in hub and spoke base and restricted modules

### DIFF
--- a/3-networks-dual-svpc/envs/shared/dns-hub.tf
+++ b/3-networks-dual-svpc/envs/shared/dns-hub.tf
@@ -96,7 +96,7 @@ module "dns_hub_region1_router1" {
   network = module.dns_hub_vpc.network_name
   region  = local.default_region1
   bgp = {
-    asn                  = var.bgp_asn_dns
+    asn                  = local.dns_bgp_asn_number
     advertised_ip_ranges = [{ range = "35.199.192.0/19" }]
   }
 }
@@ -109,7 +109,7 @@ module "dns_hub_region1_router2" {
   network = module.dns_hub_vpc.network_name
   region  = local.default_region1
   bgp = {
-    asn                  = var.bgp_asn_dns
+    asn                  = local.dns_bgp_asn_number
     advertised_ip_ranges = [{ range = "35.199.192.0/19" }]
   }
 }
@@ -122,7 +122,7 @@ module "dns_hub_region2_router1" {
   network = module.dns_hub_vpc.network_name
   region  = local.default_region2
   bgp = {
-    asn                  = var.bgp_asn_dns
+    asn                  = local.dns_bgp_asn_number
     advertised_ip_ranges = [{ range = "35.199.192.0/19" }]
   }
 }
@@ -135,7 +135,7 @@ module "dns_hub_region2_router2" {
   network = module.dns_hub_vpc.network_name
   region  = local.default_region2
   bgp = {
-    asn                  = var.bgp_asn_dns
+    asn                  = local.dns_bgp_asn_number
     advertised_ip_ranges = [{ range = "35.199.192.0/19" }]
   }
 }

--- a/3-networks-dual-svpc/envs/shared/interconnect.tf.example
+++ b/3-networks-dual-svpc/envs/shared/interconnect.tf.example
@@ -26,11 +26,13 @@ module "dns_hub_interconnect" {
   region1_interconnect1_vlan_tag8021q     = "3931"
   region1_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
   region1_interconnect1_location          = "las-zone1-770"
+  region1_interconnect1_onprem_dc         = "onprem-dc-1"
   region1_router2_name                    = module.dns_hub_region1_router2.router.name
   region1_interconnect2_candidate_subnets = ["169.254.0.8/29"]
   region1_interconnect2_vlan_tag8021q     = "3932"
   region1_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
   region1_interconnect2_location          = "las-zone1-770"
+  region1_interconnect2_onprem_dc         = "onprem-dc-2"
 
   region2                                 = local.default_region2
   region2_router1_name                    = module.dns_hub_region2_router1.router.name
@@ -38,11 +40,13 @@ module "dns_hub_interconnect" {
   region2_interconnect1_vlan_tag8021q     = "3933"
   region2_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
   region2_interconnect1_location          = "lax-zone2-19"
+  region2_interconnect1_onprem_dc         = "onprem-dc-3"
   region2_router2_name                    = module.dns_hub_region2_router2.router.name
   region2_interconnect2_candidate_subnets = ["169.254.0.24/29"]
   region2_interconnect2_vlan_tag8021q     = "3934"
   region2_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
   region2_interconnect2_location          = "lax-zone1-403"
+  region2_interconnect2_onprem_dc         = "onprem-dc-4"
 
   peer_asn  = "64515"
   peer_name = "interconnect-peer"

--- a/3-networks-dual-svpc/envs/shared/interconnect.tf.example
+++ b/3-networks-dual-svpc/envs/shared/interconnect.tf.example
@@ -26,13 +26,13 @@ module "dns_hub_interconnect" {
   region1_interconnect1_vlan_tag8021q     = "3931"
   region1_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
   region1_interconnect1_location          = "las-zone1-770"
-  region1_interconnect1_onprem_dc         = "onprem-dc-1"
+  region1_interconnect1_onprem_dc         = "onprem-dc1"
   region1_router2_name                    = module.dns_hub_region1_router2.router.name
   region1_interconnect2_candidate_subnets = ["169.254.0.8/29"]
   region1_interconnect2_vlan_tag8021q     = "3932"
   region1_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
   region1_interconnect2_location          = "las-zone1-770"
-  region1_interconnect2_onprem_dc         = "onprem-dc-2"
+  region1_interconnect2_onprem_dc         = "onprem-dc2"
 
   region2                                 = local.default_region2
   region2_router1_name                    = module.dns_hub_region2_router1.router.name
@@ -40,13 +40,13 @@ module "dns_hub_interconnect" {
   region2_interconnect1_vlan_tag8021q     = "3933"
   region2_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
   region2_interconnect1_location          = "lax-zone2-19"
-  region2_interconnect1_onprem_dc         = "onprem-dc-3"
+  region2_interconnect1_onprem_dc         = "onprem-dc3"
   region2_router2_name                    = module.dns_hub_region2_router2.router.name
   region2_interconnect2_candidate_subnets = ["169.254.0.24/29"]
   region2_interconnect2_vlan_tag8021q     = "3934"
   region2_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
   region2_interconnect2_location          = "lax-zone1-403"
-  region2_interconnect2_onprem_dc         = "onprem-dc-4"
+  region2_interconnect2_onprem_dc         = "onprem-dc4"
 
   peer_asn  = "64515"
   peer_name = "interconnect-peer"

--- a/3-networks-dual-svpc/envs/shared/main.tf
+++ b/3-networks-dual-svpc/envs/shared/main.tf
@@ -17,6 +17,7 @@
 locals {
   env                        = "common"
   environment_code           = "c"
+  dns_bgp_asn_number         = var.enable_partner_interconnect ? "16550" : var.bgp_asn_dns
   default_region1            = "us-west1"
   default_region2            = "us-central1"
   folder_prefix              = data.terraform_remote_state.bootstrap.outputs.common_config.folder_prefix

--- a/3-networks-dual-svpc/envs/shared/main.tf
+++ b/3-networks-dual-svpc/envs/shared/main.tf
@@ -17,7 +17,6 @@
 locals {
   env                        = "common"
   environment_code           = "c"
-  bgp_asn_number             = var.enable_partner_interconnect ? "16550" : "64514"
   default_region1            = "us-west1"
   default_region2            = "us-central1"
   folder_prefix              = data.terraform_remote_state.bootstrap.outputs.common_config.folder_prefix

--- a/3-networks-dual-svpc/envs/shared/partner_interconnect.tf.example
+++ b/3-networks-dual-svpc/envs/shared/partner_interconnect.tf.example
@@ -19,20 +19,23 @@ module "shared_restricted_interconnect" {
 
   attachment_project_id = local.restricted_net_hub_project_id
   vpc_name              = "${local.environment_code}-shared-restricted"
-  vpc_type              = "restricted"
   preactivate           = var.preactivate_partner_interconnect
 
-  region1                        = local.default_region1
-  region1_router1_name           = module.restricted_shared_vpc[0].region1_router1.router.name
-  region1_interconnect1_location = "las-zone1-770"
-  region1_router2_name           = module.restricted_shared_vpc[0].region1_router2.router.name
-  region1_interconnect2_location = "las-zone1-770"
+  region1                         = local.default_region1
+  region1_router1_name            = module.restricted_shared_vpc[0].region1_router1.router.name
+  region1_interconnect1_location  = "las-zone1-770"
+  region1_interconnect1_onprem_dc = "onprem-dc-1"
+  region1_router2_name            = module.restricted_shared_vpc[0].region1_router2.router.name
+  region1_interconnect2_location  = "las-zone1-770"
+  region1_interconnect2_onprem_dc = "onprem-dc-2"
 
-  region2                        = local.default_region2
-  region2_router1_name           = module.restricted_shared_vpc[0].region2_router1.router.name
-  region2_interconnect1_location = "lax-zone2-19"
-  region2_router2_name           = module.restricted_shared_vpc[0].region2_router2.router.name
-  region2_interconnect2_location = "lax-zone1-403"
+  region2                         = local.default_region2
+  region2_router1_name            = module.restricted_shared_vpc[0].region2_router1.router.name
+  region2_interconnect1_location  = "lax-zone2-19"
+  region2_interconnect1_onprem_dc = "onprem-dc-3"
+  region2_router2_name            = module.restricted_shared_vpc[0].region2_router2.router.name
+  region2_interconnect2_location  = "lax-zone1-403"
+  region2_interconnect2_onprem_dc = "onprem-dc-4"
 
   cloud_router_labels = {
     vlan_1 = "cr5",
@@ -47,20 +50,23 @@ module "shared_base_interconnect" {
 
   attachment_project_id = local.base_net_hub_project_id
   vpc_name              = "${local.environment_code}-shared-base"
-  vpc_type              = "base"
   preactivate           = var.preactivate_partner_interconnect
 
-  region1                        = local.default_region1
-  region1_router1_name           = module.base_shared_vpc[0].region1_router1.router.name
-  region1_interconnect1_location = "las-zone1-770"
-  region1_router2_name           = module.base_shared_vpc[0].region1_router2.router.name
-  region1_interconnect2_location = "las-zone1-770"
+  region1                         = local.default_region1
+  region1_router1_name            = module.base_shared_vpc[0].region1_router1.router.name
+  region1_interconnect1_location  = "las-zone1-770"
+  region1_interconnect1_onprem_dc = "onprem-dc-1"
+  region1_router2_name            = module.base_shared_vpc[0].region1_router2.router.name
+  region1_interconnect2_location  = "las-zone1-770"
+  region1_interconnect2_onprem_dc = "onprem-dc-2"
 
-  region2                        = local.default_region2
-  region2_router1_name           = module.base_shared_vpc[0].region2_router1.router.name
-  region2_interconnect1_location = "lax-zone2-19"
-  region2_router2_name           = module.base_shared_vpc[0].region2_router2.router.name
-  region2_interconnect2_location = "lax-zone1-403"
+  region2                         = local.default_region2
+  region2_router1_name            = module.base_shared_vpc[0].region2_router1.router.name
+  region2_interconnect1_location  = "lax-zone2-19"
+  region2_interconnect1_onprem_dc = "onprem-dc-3"
+  region2_router2_name            = module.base_shared_vpc[0].region2_router2.router.name
+  region2_interconnect2_location  = "lax-zone1-403"
+  region2_interconnect2_onprem_dc = "onprem-dc-4"
 
   cloud_router_labels = {
     vlan_1 = "cr1",

--- a/3-networks-dual-svpc/envs/shared/partner_interconnect.tf.example
+++ b/3-networks-dual-svpc/envs/shared/partner_interconnect.tf.example
@@ -24,18 +24,18 @@ module "shared_restricted_interconnect" {
   region1                         = local.default_region1
   region1_router1_name            = module.restricted_shared_vpc[0].region1_router1.router.name
   region1_interconnect1_location  = "las-zone1-770"
-  region1_interconnect1_onprem_dc = "onprem-dc-1"
+  region1_interconnect1_onprem_dc = "onprem-dc1"
   region1_router2_name            = module.restricted_shared_vpc[0].region1_router2.router.name
   region1_interconnect2_location  = "las-zone1-770"
-  region1_interconnect2_onprem_dc = "onprem-dc-2"
+  region1_interconnect2_onprem_dc = "onprem-dc2"
 
   region2                         = local.default_region2
   region2_router1_name            = module.restricted_shared_vpc[0].region2_router1.router.name
   region2_interconnect1_location  = "lax-zone2-19"
-  region2_interconnect1_onprem_dc = "onprem-dc-3"
+  region2_interconnect1_onprem_dc = "onprem-dc3"
   region2_router2_name            = module.restricted_shared_vpc[0].region2_router2.router.name
   region2_interconnect2_location  = "lax-zone1-403"
-  region2_interconnect2_onprem_dc = "onprem-dc-4"
+  region2_interconnect2_onprem_dc = "onprem-dc4"
 
   cloud_router_labels = {
     vlan_1 = "cr5",
@@ -55,18 +55,18 @@ module "shared_base_interconnect" {
   region1                         = local.default_region1
   region1_router1_name            = module.base_shared_vpc[0].region1_router1.router.name
   region1_interconnect1_location  = "las-zone1-770"
-  region1_interconnect1_onprem_dc = "onprem-dc-1"
+  region1_interconnect1_onprem_dc = "onprem-dc1"
   region1_router2_name            = module.base_shared_vpc[0].region1_router2.router.name
   region1_interconnect2_location  = "las-zone1-770"
-  region1_interconnect2_onprem_dc = "onprem-dc-2"
+  region1_interconnect2_onprem_dc = "onprem-dc2"
 
   region2                         = local.default_region2
   region2_router1_name            = module.base_shared_vpc[0].region2_router1.router.name
   region2_interconnect1_location  = "lax-zone2-19"
-  region2_interconnect1_onprem_dc = "onprem-dc-3"
+  region2_interconnect1_onprem_dc = "onprem-dc3"
   region2_router2_name            = module.base_shared_vpc[0].region2_router2.router.name
   region2_interconnect2_location  = "lax-zone1-403"
-  region2_interconnect2_onprem_dc = "onprem-dc-4"
+  region2_interconnect2_onprem_dc = "onprem-dc4"
 
   cloud_router_labels = {
     vlan_1 = "cr1",

--- a/3-networks-dual-svpc/modules/base_env/interconnect.tf.example
+++ b/3-networks-dual-svpc/modules/base_env/interconnect.tf.example
@@ -26,13 +26,13 @@ module "shared_restricted_interconnect" {
   region1_interconnect1_vlan_tag8021q     = "3901"
   region1_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
   region1_interconnect1_location          = "las-zone1-770"
-  region1_interconnect1_onprem_dc         = "onprem-dc-1"
+  region1_interconnect1_onprem_dc         = "onprem-dc1"
   region1_router2_name                    = module.restricted_shared_vpc.region1_router2.router.name
   region1_interconnect2_candidate_subnets = ["169.254.0.168/29"]
   region1_interconnect2_vlan_tag8021q     = "3902"
   region1_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
   region1_interconnect2_location          = "las-zone1-770"
-  region1_interconnect2_onprem_dc         = "onprem-dc-2"
+  region1_interconnect2_onprem_dc         = "onprem-dc2"
 
   region2                                 = var.default_region2
   region2_router1_name                    = module.restricted_shared_vpc.region2_router1.router.name
@@ -40,13 +40,13 @@ module "shared_restricted_interconnect" {
   region2_interconnect1_vlan_tag8021q     = "3903"
   region2_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
   region2_interconnect1_location          = "lax-zone2-19"
-  region2_interconnect1_onprem_dc         = "onprem-dc-3"
+  region2_interconnect1_onprem_dc         = "onprem-dc3"
   region2_router2_name                    = module.restricted_shared_vpc.region2_router2.router.name
   region2_interconnect2_candidate_subnets = ["169.254.0.184/29"]
   region2_interconnect2_vlan_tag8021q     = "3904"
   region2_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
   region2_interconnect2_location          = "lax-zone1-403"
-  region2_interconnect2_onprem_dc         = "onprem-dc-4"
+  region2_interconnect2_onprem_dc         = "onprem-dc4"
 
   peer_asn  = "64515"
   peer_name = "interconnect-peer"
@@ -75,13 +75,13 @@ module "shared_base_interconnect" {
   region1_interconnect1_vlan_tag8021q     = "3905"
   region1_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
   region1_interconnect1_location          = "las-zone1-770"
-  region1_interconnect1_onprem_dc         = "onprem-dc-1"
+  region1_interconnect1_onprem_dc         = "onprem-dc1"
   region1_router2_name                    = module.base_shared_vpc.region1_router2.router.name
   region1_interconnect2_candidate_subnets = ["169.254.0.200/29"]
   region1_interconnect2_vlan_tag8021q     = "3906"
   region1_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
   region1_interconnect2_location          = "las-zone1-770"
-  region1_interconnect2_onprem_dc         = "onprem-dc-2"
+  region1_interconnect2_onprem_dc         = "onprem-dc2"
 
   region2                                 = var.default_region2
   region2_router1_name                    = module.base_shared_vpc.region2_router1.router.name
@@ -89,13 +89,13 @@ module "shared_base_interconnect" {
   region2_interconnect1_vlan_tag8021q     = "3907"
   region2_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
   region2_interconnect1_location          = "lax-zone2-19"
-  region2_interconnect1_onprem_dc         = "onprem-dc-3"
+  region2_interconnect1_onprem_dc         = "onprem-dc3"
   region2_router2_name                    = module.base_shared_vpc.region2_router2.router.name
   region2_interconnect2_candidate_subnets = ["169.254.0.216/29"]
   region2_interconnect2_vlan_tag8021q     = "3908"
   region2_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
   region2_interconnect2_location          = "lax-zone1-403"
-  region2_interconnect2_onprem_dc         = "onprem-dc-4"
+  region2_interconnect2_onprem_dc         = "onprem-dc4"
 
 
   peer_asn  = "64515"

--- a/3-networks-dual-svpc/modules/base_env/interconnect.tf.example
+++ b/3-networks-dual-svpc/modules/base_env/interconnect.tf.example
@@ -26,11 +26,13 @@ module "shared_restricted_interconnect" {
   region1_interconnect1_vlan_tag8021q     = "3901"
   region1_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
   region1_interconnect1_location          = "las-zone1-770"
+  region1_interconnect1_onprem_dc         = "onprem-dc-1"
   region1_router2_name                    = module.restricted_shared_vpc.region1_router2.router.name
   region1_interconnect2_candidate_subnets = ["169.254.0.168/29"]
   region1_interconnect2_vlan_tag8021q     = "3902"
   region1_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
   region1_interconnect2_location          = "las-zone1-770"
+  region1_interconnect2_onprem_dc         = "onprem-dc-2"
 
   region2                                 = var.default_region2
   region2_router1_name                    = module.restricted_shared_vpc.region2_router1.router.name
@@ -38,11 +40,13 @@ module "shared_restricted_interconnect" {
   region2_interconnect1_vlan_tag8021q     = "3903"
   region2_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
   region2_interconnect1_location          = "lax-zone2-19"
+  region2_interconnect1_onprem_dc         = "onprem-dc-3"
   region2_router2_name                    = module.restricted_shared_vpc.region2_router2.router.name
   region2_interconnect2_candidate_subnets = ["169.254.0.184/29"]
   region2_interconnect2_vlan_tag8021q     = "3904"
   region2_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
   region2_interconnect2_location          = "lax-zone1-403"
+  region2_interconnect2_onprem_dc         = "onprem-dc-4"
 
   peer_asn  = "64515"
   peer_name = "interconnect-peer"
@@ -71,11 +75,13 @@ module "shared_base_interconnect" {
   region1_interconnect1_vlan_tag8021q     = "3905"
   region1_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
   region1_interconnect1_location          = "las-zone1-770"
+  region1_interconnect1_onprem_dc         = "onprem-dc-1"
   region1_router2_name                    = module.base_shared_vpc.region1_router2.router.name
   region1_interconnect2_candidate_subnets = ["169.254.0.200/29"]
   region1_interconnect2_vlan_tag8021q     = "3906"
   region1_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
   region1_interconnect2_location          = "las-zone1-770"
+  region1_interconnect2_onprem_dc         = "onprem-dc-2"
 
   region2                                 = var.default_region2
   region2_router1_name                    = module.base_shared_vpc.region2_router1.router.name
@@ -83,11 +89,13 @@ module "shared_base_interconnect" {
   region2_interconnect1_vlan_tag8021q     = "3907"
   region2_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
   region2_interconnect1_location          = "lax-zone2-19"
+  region2_interconnect1_onprem_dc         = "onprem-dc-3"
   region2_router2_name                    = module.base_shared_vpc.region2_router2.router.name
   region2_interconnect2_candidate_subnets = ["169.254.0.216/29"]
   region2_interconnect2_vlan_tag8021q     = "3908"
   region2_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
   region2_interconnect2_location          = "lax-zone1-403"
+  region2_interconnect2_onprem_dc         = "onprem-dc-4"
 
 
   peer_asn  = "64515"

--- a/3-networks-dual-svpc/modules/base_env/partner_interconnect.tf.example
+++ b/3-networks-dual-svpc/modules/base_env/partner_interconnect.tf.example
@@ -24,18 +24,18 @@ module "shared_restricted_interconnect" {
   region1                         = var.default_region1
   region1_router1_name            = module.restricted_shared_vpc.region1_router1.router.name
   region1_interconnect1_location  = "las-zone1-770"
-  region1_interconnect1_onprem_dc = "onprem-dc-1"
+  region1_interconnect1_onprem_dc = "onprem-dc1"
   region1_router2_name            = module.restricted_shared_vpc.region1_router2.router.name
   region1_interconnect2_location  = "las-zone1-770"
-  region1_interconnect2_onprem_dc = "onprem-dc-2"
+  region1_interconnect2_onprem_dc = "onprem-dc2"
 
   region2                         = var.default_region2
   region2_router1_name            = module.restricted_shared_vpc.region2_router1.router.name
   region2_interconnect1_location  = "lax-zone2-19"
-  region2_interconnect1_onprem_dc = "onprem-dc-3"
+  region2_interconnect1_onprem_dc = "onprem-dc3"
   region2_router2_name            = module.restricted_shared_vpc.region2_router2.router.name
   region2_interconnect2_location  = "lax-zone1-403"
-  region2_interconnect2_onprem_dc = "onprem-dc-4"
+  region2_interconnect2_onprem_dc = "onprem-dc4"
 
   cloud_router_labels = {
     vlan_1 = "cr5",
@@ -59,18 +59,18 @@ module "shared_base_interconnect" {
   region1                         = var.default_region1
   region1_router1_name            = module.base_shared_vpc.region1_router1.router.name
   region1_interconnect1_location  = "las-zone1-770"
-  region1_interconnect1_onprem_dc = "onprem-dc-1"
+  region1_interconnect1_onprem_dc = "onprem-dc1"
   region1_router2_name            = module.base_shared_vpc.region1_router2.router.name
   region1_interconnect2_location  = "las-zone1-770"
-  region1_interconnect2_onprem_dc = "onprem-dc-2"
+  region1_interconnect2_onprem_dc = "onprem-dc2"
 
   region2                         = var.default_region2
   region2_router1_name            = module.base_shared_vpc.region2_router1.router.name
   region2_interconnect1_location  = "lax-zone2-19"
-  region2_interconnect1_onprem_dc = "onprem-dc-3"
+  region2_interconnect1_onprem_dc = "onprem-dc3"
   region2_router2_name            = module.base_shared_vpc.region2_router2.router.name
   region2_interconnect2_location  = "lax-zone1-403"
-  region2_interconnect2_onprem_dc = "onprem-dc-4"
+  region2_interconnect2_onprem_dc = "onprem-dc4"
 
 
   cloud_router_labels = {

--- a/3-networks-dual-svpc/modules/base_env/partner_interconnect.tf.example
+++ b/3-networks-dual-svpc/modules/base_env/partner_interconnect.tf.example
@@ -19,20 +19,23 @@ module "shared_restricted_interconnect" {
 
   attachment_project_id = local.restricted_project_id
   vpc_name              = "${var.environment_code}-shared-restricted"
-  vpc_type              = "restricted"
   preactivate           = true
 
-  region1                        = var.default_region1
-  region1_router1_name           = module.restricted_shared_vpc.region1_router1.router.name
-  region1_interconnect1_location = "las-zone1-770"
-  region1_router2_name           = module.restricted_shared_vpc.region1_router2.router.name
-  region1_interconnect2_location = "las-zone1-770"
+  region1                         = var.default_region1
+  region1_router1_name            = module.restricted_shared_vpc.region1_router1.router.name
+  region1_interconnect1_location  = "las-zone1-770"
+  region1_interconnect1_onprem_dc = "onprem-dc-1"
+  region1_router2_name            = module.restricted_shared_vpc.region1_router2.router.name
+  region1_interconnect2_location  = "las-zone1-770"
+  region1_interconnect2_onprem_dc = "onprem-dc-2"
 
-  region2                        = var.default_region2
-  region2_router1_name           = module.restricted_shared_vpc.region2_router1.router.name
-  region2_interconnect1_location = "lax-zone2-19"
-  region2_router2_name           = module.restricted_shared_vpc.region2_router2.router.name
-  region2_interconnect2_location = "lax-zone1-403"
+  region2                         = var.default_region2
+  region2_router1_name            = module.restricted_shared_vpc.region2_router1.router.name
+  region2_interconnect1_location  = "lax-zone2-19"
+  region2_interconnect1_onprem_dc = "onprem-dc-3"
+  region2_router2_name            = module.restricted_shared_vpc.region2_router2.router.name
+  region2_interconnect2_location  = "lax-zone1-403"
+  region2_interconnect2_onprem_dc = "onprem-dc-4"
 
   cloud_router_labels = {
     vlan_1 = "cr5",
@@ -51,20 +54,23 @@ module "shared_base_interconnect" {
 
   attachment_project_id = local.base_project_id
   vpc_name              = "${var.environment_code}-shared-base"
-  vpc_type              = "base"
   preactivate           = true
 
-  region1                        = var.default_region1
-  region1_router1_name           = module.base_shared_vpc.region1_router1.router.name
-  region1_interconnect1_location = "las-zone1-770"
-  region1_router2_name           = module.base_shared_vpc.region1_router2.router.name
-  region1_interconnect2_location = "las-zone1-770"
+  region1                         = var.default_region1
+  region1_router1_name            = module.base_shared_vpc.region1_router1.router.name
+  region1_interconnect1_location  = "las-zone1-770"
+  region1_interconnect1_onprem_dc = "onprem-dc-1"
+  region1_router2_name            = module.base_shared_vpc.region1_router2.router.name
+  region1_interconnect2_location  = "las-zone1-770"
+  region1_interconnect2_onprem_dc = "onprem-dc-2"
 
-  region2                        = var.default_region2
-  region2_router1_name           = module.base_shared_vpc.region2_router1.router.name
-  region2_interconnect1_location = "lax-zone2-19"
-  region2_router2_name           = module.base_shared_vpc.region2_router2.router.name
-  region2_interconnect2_location = "lax-zone1-403"
+  region2                         = var.default_region2
+  region2_router1_name            = module.base_shared_vpc.region2_router1.router.name
+  region2_interconnect1_location  = "lax-zone2-19"
+  region2_interconnect1_onprem_dc = "onprem-dc-3"
+  region2_router2_name            = module.base_shared_vpc.region2_router2.router.name
+  region2_interconnect2_location  = "lax-zone1-403"
+  region2_interconnect2_onprem_dc = "onprem-dc-4"
 
 
   cloud_router_labels = {

--- a/3-networks-dual-svpc/modules/dedicated_interconnect/README.md
+++ b/3-networks-dual-svpc/modules/dedicated_interconnect/README.md
@@ -26,10 +26,12 @@ This module implements the recommendation proposed in [Establishing 99.99% Avail
 | region1\_interconnect1 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | `string` | n/a | yes |
 | region1\_interconnect1\_candidate\_subnets | Up to 16 candidate prefixes that can be used to restrict the allocation of cloudRouterIpAddress and customerRouterIpAddress for this attachment. All prefixes must be within link-local address space (169.254.0.0/16) and must be /29 or shorter (/28, /27, etc). | `list(string)` | `null` | no |
 | region1\_interconnect1\_location | Name of the interconnect location used in the creation of the Interconnect for the first location of region1 | `string` | n/a | yes |
+| region1\_interconnect1\_onprem\_dc | Name of the on premisses data center used in the creation of the Interconnect for the first location of region1. | `string` | n/a | yes |
 | region1\_interconnect1\_vlan\_tag8021q | The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4094. | `string` | `null` | no |
 | region1\_interconnect2 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | `string` | n/a | yes |
 | region1\_interconnect2\_candidate\_subnets | Up to 16 candidate prefixes that can be used to restrict the allocation of cloudRouterIpAddress and customerRouterIpAddress for this attachment. All prefixes must be within link-local address space (169.254.0.0/16) and must be /29 or shorter (/28, /27, etc). | `list(string)` | `null` | no |
 | region1\_interconnect2\_location | Name of the interconnect location used in the creation of the Interconnect for the second location of region1 | `string` | n/a | yes |
+| region1\_interconnect2\_onprem\_dc | Name of the on premisses data center used in the creation of the Interconnect for the second location of region1. | `string` | n/a | yes |
 | region1\_interconnect2\_vlan\_tag8021q | The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4094. | `string` | `null` | no |
 | region1\_router1\_name | Name of the Router 1 for Region 1 where the attachment resides. | `string` | n/a | yes |
 | region1\_router2\_name | Name of the Router 2 for Region 1 where the attachment resides. | `string` | n/a | yes |
@@ -37,10 +39,12 @@ This module implements the recommendation proposed in [Establishing 99.99% Avail
 | region2\_interconnect1 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | `string` | n/a | yes |
 | region2\_interconnect1\_candidate\_subnets | Up to 16 candidate prefixes that can be used to restrict the allocation of cloudRouterIpAddress and customerRouterIpAddress for this attachment. All prefixes must be within link-local address space (169.254.0.0/16) and must be /29 or shorter (/28, /27, etc). | `list(string)` | `null` | no |
 | region2\_interconnect1\_location | Name of the interconnect location used in the creation of the Interconnect for the first location of region2 | `string` | n/a | yes |
+| region2\_interconnect1\_onprem\_dc | Name of the on premisses data center used in the creation of the Interconnect for the first location of region2. | `string` | n/a | yes |
 | region2\_interconnect1\_vlan\_tag8021q | The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4094. | `string` | `null` | no |
 | region2\_interconnect2 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | `string` | n/a | yes |
 | region2\_interconnect2\_candidate\_subnets | Up to 16 candidate prefixes that can be used to restrict the allocation of cloudRouterIpAddress and customerRouterIpAddress for this attachment. All prefixes must be within link-local address space (169.254.0.0/16) and must be /29 or shorter (/28, /27, etc). | `list(string)` | `null` | no |
 | region2\_interconnect2\_location | Name of the interconnect location used in the creation of the Interconnect for the second location of region2 | `string` | n/a | yes |
+| region2\_interconnect2\_onprem\_dc | Name of the on premisses data center used in the creation of the Interconnect for the second location of region2. | `string` | n/a | yes |
 | region2\_interconnect2\_vlan\_tag8021q | The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4094. | `string` | `null` | no |
 | region2\_router1\_name | Name of the Router 1 for Region 2 where the attachment resides. | `string` | n/a | yes |
 | region2\_router2\_name | Name of the Router 2 for Region 2 where the attachment resides | `string` | n/a | yes |

--- a/3-networks-dual-svpc/modules/dedicated_interconnect/main.tf
+++ b/3-networks-dual-svpc/modules/dedicated_interconnect/main.tf
@@ -25,7 +25,7 @@ module "interconnect_attachment1_region1" {
   source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
   version = "~> 3.0"
 
-  name    = "vl-${var.region1_interconnect1_location}-${var.vpc_name}-${var.region1}-${local.suffix1}"
+  name    = "vl-${var.region1_interconnect1_onprem_dc}-${var.region1_interconnect1_location}-${var.vpc_name}-${var.region1}-${local.suffix1}"
   project = var.interconnect_project_id
   region  = var.region1
   router  = var.region1_router1_name
@@ -48,7 +48,7 @@ module "interconnect_attachment2_region1" {
   source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
   version = "~> 3.0"
 
-  name    = "vl-${var.region1_interconnect2_location}-${var.vpc_name}-${var.region1}-${local.suffix2}"
+  name    = "vl-${var.region1_interconnect2_onprem_dc}-${var.region1_interconnect2_location}-${var.vpc_name}-${var.region1}-${local.suffix2}"
   project = var.interconnect_project_id
   region  = var.region1
   router  = var.region1_router2_name
@@ -71,7 +71,7 @@ module "interconnect_attachment1_region2" {
   source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
   version = "~> 3.0"
 
-  name    = "vl-${var.region2_interconnect1_location}-${var.vpc_name}-${var.region2}-${local.suffix3}"
+  name    = "vl-${var.region2_interconnect1_onprem_dc}-${var.region2_interconnect1_location}-${var.vpc_name}-${var.region2}-${local.suffix3}"
   project = var.interconnect_project_id
   region  = var.region2
   router  = var.region2_router1_name
@@ -94,7 +94,7 @@ module "interconnect_attachment2_region2" {
   source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
   version = "~> 3.0"
 
-  name    = "vl-${var.region2_interconnect2_location}-${var.vpc_name}-${var.region2}-${local.suffix4}"
+  name    = "vl-${var.region2_interconnect2_onprem_dc}-${var.region2_interconnect2_location}-${var.vpc_name}-${var.region2}-${local.suffix4}"
   project = var.interconnect_project_id
   region  = var.region2
   router  = var.region2_router2_name

--- a/3-networks-dual-svpc/modules/dedicated_interconnect/variables.tf
+++ b/3-networks-dual-svpc/modules/dedicated_interconnect/variables.tf
@@ -44,6 +44,26 @@ variable "peer_asn" {
   description = "Peer BGP Autonomous System Number (ASN)."
 }
 
+variable "region1_interconnect1_onprem_dc" {
+  type        = string
+  description = "Name of the on premisses data center used in the creation of the Interconnect for the first location of region1."
+}
+
+variable "region1_interconnect2_onprem_dc" {
+  type        = string
+  description = "Name of the on premisses data center used in the creation of the Interconnect for the second location of region1."
+}
+
+variable "region2_interconnect1_onprem_dc" {
+  type        = string
+  description = "Name of the on premisses data center used in the creation of the Interconnect for the first location of region2."
+}
+
+variable "region2_interconnect2_onprem_dc" {
+  type        = string
+  description = "Name of the on premisses data center used in the creation of the Interconnect for the second location of region2."
+}
+
 variable "region1_interconnect1_location" {
   type        = string
   description = "Name of the interconnect location used in the creation of the Interconnect for the first location of region1"

--- a/3-networks-dual-svpc/modules/partner_interconnect/README.md
+++ b/3-networks-dual-svpc/modules/partner_interconnect/README.md
@@ -25,16 +25,19 @@ Without Hub and Spoke enabled VLAN attachments will be created in `prj-{p|n|d}-s
 | preactivate | Preactivate Partner Interconnect attachments, works only for level3 Partner Interconnect | `string` | `false` | no |
 | region1 | First subnet region. The Partner Interconnect module only configures two regions. | `string` | n/a | yes |
 | region1\_interconnect1\_location | Name of the interconnect location used in the creation of the Interconnect for the first location of region1 | `string` | n/a | yes |
+| region1\_interconnect1\_onprem\_dc | Name of the on premisses data center used in the creation of the Interconnect for the first location of region1. | `string` | n/a | yes |
 | region1\_interconnect2\_location | Name of the interconnect location used in the creation of the Interconnect for the second location of region1 | `string` | n/a | yes |
+| region1\_interconnect2\_onprem\_dc | Name of the on premisses data center used in the creation of the Interconnect for the second location of region1. | `string` | n/a | yes |
 | region1\_router1\_name | Name of the Router 1 for Region 1 where the attachment resides. | `string` | n/a | yes |
 | region1\_router2\_name | Name of the Router 2 for Region 1 where the attachment resides. | `string` | n/a | yes |
 | region2 | Second subnet region. The Partner Interconnect module only configures two regions. | `string` | n/a | yes |
 | region2\_interconnect1\_location | Name of the interconnect location used in the creation of the Interconnect for the first location of region2 | `string` | n/a | yes |
+| region2\_interconnect1\_onprem\_dc | Name of the on premisses data center used in the creation of the Interconnect for the first location of region2. | `string` | n/a | yes |
 | region2\_interconnect2\_location | Name of the interconnect location used in the creation of the Interconnect for the second location of region2 | `string` | n/a | yes |
+| region2\_interconnect2\_onprem\_dc | Name of the on premisses data center used in the creation of the Interconnect for the second location of region2. | `string` | n/a | yes |
 | region2\_router1\_name | Name of the Router 1 for Region 2 where the attachment resides. | `string` | n/a | yes |
 | region2\_router2\_name | Name of the Router 2 for Region 2 where the attachment resides | `string` | n/a | yes |
 | vpc\_name | Label to identify the VPC associated with shared VPC that will use the Interconnect. | `string` | n/a | yes |
-| vpc\_type | To which Shared VPC Host attach the Partner Interconnect - base/restricted | `string` | `null` | no |
 
 ## Outputs
 

--- a/3-networks-dual-svpc/modules/partner_interconnect/main.tf
+++ b/3-networks-dual-svpc/modules/partner_interconnect/main.tf
@@ -22,7 +22,7 @@ locals {
 }
 
 resource "google_compute_interconnect_attachment" "interconnect_attachment1_region1" {
-  name    = "vl-${var.region1_interconnect1_location}-${var.vpc_name}-${var.region1}-${local.suffix1}"
+  name    = "vl-${var.region1_interconnect1_onprem_dc}-${var.region1_interconnect1_location}-${var.vpc_name}-${var.region1}-${local.suffix1}"
   project = var.attachment_project_id
   region  = var.region1
   router  = var.region1_router1_name
@@ -33,7 +33,7 @@ resource "google_compute_interconnect_attachment" "interconnect_attachment1_regi
 }
 
 resource "google_compute_interconnect_attachment" "interconnect_attachment2_region1" {
-  name    = "vl-${var.region1_interconnect2_location}-${var.vpc_name}-${var.region1}-${local.suffix2}"
+  name    = "vl-${var.region1_interconnect2_onprem_dc}-${var.region1_interconnect2_location}-${var.vpc_name}-${var.region1}-${local.suffix2}"
   project = var.attachment_project_id
   region  = var.region1
   router  = var.region1_router2_name
@@ -44,7 +44,7 @@ resource "google_compute_interconnect_attachment" "interconnect_attachment2_regi
 }
 
 resource "google_compute_interconnect_attachment" "interconnect_attachment1_region2" {
-  name    = "vl-${var.region2_interconnect1_location}-${var.vpc_name}-${var.region2}-${local.suffix1}"
+  name    = "vl-${var.region2_interconnect1_onprem_dc}-${var.region2_interconnect1_location}-${var.vpc_name}-${var.region2}-${local.suffix1}"
   project = var.attachment_project_id
   region  = var.region2
   router  = var.region2_router1_name
@@ -55,7 +55,7 @@ resource "google_compute_interconnect_attachment" "interconnect_attachment1_regi
 }
 
 resource "google_compute_interconnect_attachment" "interconnect_attachment2_region2" {
-  name    = "vl-${var.region2_interconnect2_location}-${var.vpc_name}-${var.region2}-${local.suffix2}"
+  name    = "vl-${var.region2_interconnect2_onprem_dc}-${var.region2_interconnect2_location}-${var.vpc_name}-${var.region2}-${local.suffix2}"
   project = var.attachment_project_id
   region  = var.region2
   router  = var.region2_router2_name

--- a/3-networks-dual-svpc/modules/partner_interconnect/variables.tf
+++ b/3-networks-dual-svpc/modules/partner_interconnect/variables.tf
@@ -34,6 +34,26 @@ variable "region2" {
   description = "Second subnet region. The Partner Interconnect module only configures two regions."
 }
 
+variable "region1_interconnect1_onprem_dc" {
+  type        = string
+  description = "Name of the on premisses data center used in the creation of the Interconnect for the first location of region1."
+}
+
+variable "region1_interconnect2_onprem_dc" {
+  type        = string
+  description = "Name of the on premisses data center used in the creation of the Interconnect for the second location of region1."
+}
+
+variable "region2_interconnect1_onprem_dc" {
+  type        = string
+  description = "Name of the on premisses data center used in the creation of the Interconnect for the first location of region2."
+}
+
+variable "region2_interconnect2_onprem_dc" {
+  type        = string
+  description = "Name of the on premisses data center used in the creation of the Interconnect for the second location of region2."
+}
+
 variable "region1_interconnect1_location" {
   type        = string
   description = "Name of the interconnect location used in the creation of the Interconnect for the first location of region1"
@@ -90,10 +110,4 @@ variable "preactivate" {
   description = "Preactivate Partner Interconnect attachments, works only for level3 Partner Interconnect"
   type        = string
   default     = false
-}
-
-variable "vpc_type" {
-  description = "To which Shared VPC Host attach the Partner Interconnect - base/restricted"
-  type        = string
-  default     = null
 }

--- a/3-networks-hub-and-spoke/envs/shared/interconnect.tf.example
+++ b/3-networks-hub-and-spoke/envs/shared/interconnect.tf.example
@@ -26,11 +26,13 @@ module "dns_hub_interconnect" {
   region1_interconnect1_vlan_tag8021q     = "3931"
   region1_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
   region1_interconnect1_location          = "las-zone1-770"
+  region1_interconnect1_onprem_dc         = "onprem-dc-1"
   region1_router2_name                    = module.dns_hub_region1_router2.router.name
   region1_interconnect2_candidate_subnets = ["169.254.0.8/29"]
   region1_interconnect2_vlan_tag8021q     = "3932"
   region1_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
   region1_interconnect2_location          = "las-zone1-770"
+  region1_interconnect2_onprem_dc         = "onprem-dc-2"
 
   region2                                 = local.default_region2
   region2_router1_name                    = module.dns_hub_region2_router1.router.name
@@ -38,11 +40,13 @@ module "dns_hub_interconnect" {
   region2_interconnect1_vlan_tag8021q     = "3933"
   region2_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
   region2_interconnect1_location          = "lax-zone2-19"
+  region2_interconnect1_onprem_dc         = "onprem-dc-3"
   region2_router2_name                    = module.dns_hub_region2_router2.router.name
   region2_interconnect2_candidate_subnets = ["169.254.0.24/29"]
   region2_interconnect2_vlan_tag8021q     = "3934"
   region2_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
   region2_interconnect2_location          = "lax-zone1-403"
+  region2_interconnect2_onprem_dc         = "onprem-dc-4"
 
   peer_asn  = "64515"
   peer_name = "interconnect-peer"

--- a/3-networks-hub-and-spoke/envs/shared/interconnect.tf.example
+++ b/3-networks-hub-and-spoke/envs/shared/interconnect.tf.example
@@ -26,13 +26,13 @@ module "dns_hub_interconnect" {
   region1_interconnect1_vlan_tag8021q     = "3931"
   region1_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
   region1_interconnect1_location          = "las-zone1-770"
-  region1_interconnect1_onprem_dc         = "onprem-dc-1"
+  region1_interconnect1_onprem_dc         = "onprem-dc1"
   region1_router2_name                    = module.dns_hub_region1_router2.router.name
   region1_interconnect2_candidate_subnets = ["169.254.0.8/29"]
   region1_interconnect2_vlan_tag8021q     = "3932"
   region1_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
   region1_interconnect2_location          = "las-zone1-770"
-  region1_interconnect2_onprem_dc         = "onprem-dc-2"
+  region1_interconnect2_onprem_dc         = "onprem-dc2"
 
   region2                                 = local.default_region2
   region2_router1_name                    = module.dns_hub_region2_router1.router.name
@@ -40,13 +40,13 @@ module "dns_hub_interconnect" {
   region2_interconnect1_vlan_tag8021q     = "3933"
   region2_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
   region2_interconnect1_location          = "lax-zone2-19"
-  region2_interconnect1_onprem_dc         = "onprem-dc-3"
+  region2_interconnect1_onprem_dc         = "onprem-dc3"
   region2_router2_name                    = module.dns_hub_region2_router2.router.name
   region2_interconnect2_candidate_subnets = ["169.254.0.24/29"]
   region2_interconnect2_vlan_tag8021q     = "3934"
   region2_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
   region2_interconnect2_location          = "lax-zone1-403"
-  region2_interconnect2_onprem_dc         = "onprem-dc-4"
+  region2_interconnect2_onprem_dc         = "onprem-dc4"
 
   peer_asn  = "64515"
   peer_name = "interconnect-peer"

--- a/3-networks-hub-and-spoke/envs/shared/partner_interconnect.tf.example
+++ b/3-networks-hub-and-spoke/envs/shared/partner_interconnect.tf.example
@@ -19,20 +19,23 @@ module "shared_restricted_interconnect" {
 
   attachment_project_id = local.restricted_net_hub_project_id
   vpc_name              = "${local.environment_code}-shared-restricted"
-  vpc_type              = "restricted"
   preactivate           = var.preactivate_partner_interconnect
 
-  region1                        = local.default_region1
-  region1_router1_name           = module.restricted_shared_vpc[0].region1_router1.router.name
-  region1_interconnect1_location = "las-zone1-770"
-  region1_router2_name           = module.restricted_shared_vpc[0].region1_router2.router.name
-  region1_interconnect2_location = "las-zone1-770"
+  region1                         = local.default_region1
+  region1_router1_name            = module.restricted_shared_vpc[0].region1_router1.router.name
+  region1_interconnect1_location  = "las-zone1-770"
+  region1_interconnect1_onprem_dc = "onprem-dc-1"
+  region1_router2_name            = module.restricted_shared_vpc[0].region1_router2.router.name
+  region1_interconnect2_location  = "las-zone1-770"
+  region1_interconnect2_onprem_dc = "onprem-dc-2"
 
-  region2                        = local.default_region2
-  region2_router1_name           = module.restricted_shared_vpc[0].region2_router1.router.name
-  region2_interconnect1_location = "lax-zone2-19"
-  region2_router2_name           = module.restricted_shared_vpc[0].region2_router2.router.name
-  region2_interconnect2_location = "lax-zone1-403"
+  region2                         = local.default_region2
+  region2_router1_name            = module.restricted_shared_vpc[0].region2_router1.router.name
+  region2_interconnect1_location  = "lax-zone2-19"
+  region2_interconnect1_onprem_dc = "onprem-dc-3"
+  region2_router2_name            = module.restricted_shared_vpc[0].region2_router2.router.name
+  region2_interconnect2_location  = "lax-zone1-403"
+  region2_interconnect2_onprem_dc = "onprem-dc-4"
 
   cloud_router_labels = {
     vlan_1 = "cr5",
@@ -47,20 +50,23 @@ module "shared_base_interconnect" {
 
   attachment_project_id = local.base_net_hub_project_id
   vpc_name              = "${local.environment_code}-shared-base"
-  vpc_type              = "base"
   preactivate           = var.preactivate_partner_interconnect
 
-  region1                        = local.default_region1
-  region1_router1_name           = module.base_shared_vpc[0].region1_router1.router.name
-  region1_interconnect1_location = "las-zone1-770"
-  region1_router2_name           = module.base_shared_vpc[0].region1_router2.router.name
-  region1_interconnect2_location = "las-zone1-770"
+  region1                         = local.default_region1
+  region1_router1_name            = module.base_shared_vpc[0].region1_router1.router.name
+  region1_interconnect1_location  = "las-zone1-770"
+  region1_interconnect1_onprem_dc = "onprem-dc-1"
+  region1_router2_name            = module.base_shared_vpc[0].region1_router2.router.name
+  region1_interconnect2_location  = "las-zone1-770"
+  region1_interconnect2_onprem_dc = "onprem-dc-2"
 
-  region2                        = local.default_region2
-  region2_router1_name           = module.base_shared_vpc[0].region2_router1.router.name
-  region2_interconnect1_location = "lax-zone2-19"
-  region2_router2_name           = module.base_shared_vpc[0].region2_router2.router.name
-  region2_interconnect2_location = "lax-zone1-403"
+  region2                         = local.default_region2
+  region2_router1_name            = module.base_shared_vpc[0].region2_router1.router.name
+  region2_interconnect1_location  = "lax-zone2-19"
+  region2_interconnect1_onprem_dc = "onprem-dc-3"
+  region2_router2_name            = module.base_shared_vpc[0].region2_router2.router.name
+  region2_interconnect2_location  = "lax-zone1-403"
+  region2_interconnect2_onprem_dc = "onprem-dc-4"
 
   cloud_router_labels = {
     vlan_1 = "cr1",

--- a/3-networks-hub-and-spoke/envs/shared/partner_interconnect.tf.example
+++ b/3-networks-hub-and-spoke/envs/shared/partner_interconnect.tf.example
@@ -22,18 +22,18 @@ module "shared_restricted_interconnect" {
   preactivate           = var.preactivate_partner_interconnect
 
   region1                         = local.default_region1
-  region1_router1_name            = module.restricted_shared_vpc[0].region1_router1.router.name
+  region1_router1_name            = module.restricted_shared_vpc.region1_router1.router.name
   region1_interconnect1_location  = "las-zone1-770"
   region1_interconnect1_onprem_dc = "onprem-dc-1"
-  region1_router2_name            = module.restricted_shared_vpc[0].region1_router2.router.name
+  region1_router2_name            = module.restricted_shared_vpc.region1_router2.router.name
   region1_interconnect2_location  = "las-zone1-770"
   region1_interconnect2_onprem_dc = "onprem-dc-2"
 
   region2                         = local.default_region2
-  region2_router1_name            = module.restricted_shared_vpc[0].region2_router1.router.name
+  region2_router1_name            = module.restricted_shared_vpc.region2_router1.router.name
   region2_interconnect1_location  = "lax-zone2-19"
   region2_interconnect1_onprem_dc = "onprem-dc-3"
-  region2_router2_name            = module.restricted_shared_vpc[0].region2_router2.router.name
+  region2_router2_name            = module.restricted_shared_vpc.region2_router2.router.name
   region2_interconnect2_location  = "lax-zone1-403"
   region2_interconnect2_onprem_dc = "onprem-dc-4"
 
@@ -53,18 +53,18 @@ module "shared_base_interconnect" {
   preactivate           = var.preactivate_partner_interconnect
 
   region1                         = local.default_region1
-  region1_router1_name            = module.base_shared_vpc[0].region1_router1.router.name
+  region1_router1_name            = module.base_shared_vpc.region1_router1.router.name
   region1_interconnect1_location  = "las-zone1-770"
   region1_interconnect1_onprem_dc = "onprem-dc-1"
-  region1_router2_name            = module.base_shared_vpc[0].region1_router2.router.name
+  region1_router2_name            = module.base_shared_vpc.region1_router2.router.name
   region1_interconnect2_location  = "las-zone1-770"
   region1_interconnect2_onprem_dc = "onprem-dc-2"
 
   region2                         = local.default_region2
-  region2_router1_name            = module.base_shared_vpc[0].region2_router1.router.name
+  region2_router1_name            = module.base_shared_vpc.region2_router1.router.name
   region2_interconnect1_location  = "lax-zone2-19"
   region2_interconnect1_onprem_dc = "onprem-dc-3"
-  region2_router2_name            = module.base_shared_vpc[0].region2_router2.router.name
+  region2_router2_name            = module.base_shared_vpc.region2_router2.router.name
   region2_interconnect2_location  = "lax-zone1-403"
   region2_interconnect2_onprem_dc = "onprem-dc-4"
 

--- a/3-networks-hub-and-spoke/envs/shared/partner_interconnect.tf.example
+++ b/3-networks-hub-and-spoke/envs/shared/partner_interconnect.tf.example
@@ -24,18 +24,18 @@ module "shared_restricted_interconnect" {
   region1                         = local.default_region1
   region1_router1_name            = module.restricted_shared_vpc.region1_router1.router.name
   region1_interconnect1_location  = "las-zone1-770"
-  region1_interconnect1_onprem_dc = "onprem-dc-1"
+  region1_interconnect1_onprem_dc = "onprem-dc1"
   region1_router2_name            = module.restricted_shared_vpc.region1_router2.router.name
   region1_interconnect2_location  = "las-zone1-770"
-  region1_interconnect2_onprem_dc = "onprem-dc-2"
+  region1_interconnect2_onprem_dc = "onprem-dc2"
 
   region2                         = local.default_region2
   region2_router1_name            = module.restricted_shared_vpc.region2_router1.router.name
   region2_interconnect1_location  = "lax-zone2-19"
-  region2_interconnect1_onprem_dc = "onprem-dc-3"
+  region2_interconnect1_onprem_dc = "onprem-dc3"
   region2_router2_name            = module.restricted_shared_vpc.region2_router2.router.name
   region2_interconnect2_location  = "lax-zone1-403"
-  region2_interconnect2_onprem_dc = "onprem-dc-4"
+  region2_interconnect2_onprem_dc = "onprem-dc4"
 
   cloud_router_labels = {
     vlan_1 = "cr5",
@@ -55,18 +55,18 @@ module "shared_base_interconnect" {
   region1                         = local.default_region1
   region1_router1_name            = module.base_shared_vpc.region1_router1.router.name
   region1_interconnect1_location  = "las-zone1-770"
-  region1_interconnect1_onprem_dc = "onprem-dc-1"
+  region1_interconnect1_onprem_dc = "onprem-dc1"
   region1_router2_name            = module.base_shared_vpc.region1_router2.router.name
   region1_interconnect2_location  = "las-zone1-770"
-  region1_interconnect2_onprem_dc = "onprem-dc-2"
+  region1_interconnect2_onprem_dc = "onprem-dc2"
 
   region2                         = local.default_region2
   region2_router1_name            = module.base_shared_vpc.region2_router1.router.name
   region2_interconnect1_location  = "lax-zone2-19"
-  region2_interconnect1_onprem_dc = "onprem-dc-3"
+  region2_interconnect1_onprem_dc = "onprem-dc3"
   region2_router2_name            = module.base_shared_vpc.region2_router2.router.name
   region2_interconnect2_location  = "lax-zone1-403"
-  region2_interconnect2_onprem_dc = "onprem-dc-4"
+  region2_interconnect2_onprem_dc = "onprem-dc4"
 
   cloud_router_labels = {
     vlan_1 = "cr1",

--- a/3-networks-hub-and-spoke/modules/base_env/interconnect.tf.example
+++ b/3-networks-hub-and-spoke/modules/base_env/interconnect.tf.example
@@ -26,13 +26,13 @@ module "shared_restricted_interconnect" {
   region1_interconnect1_vlan_tag8021q     = "3901"
   region1_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
   region1_interconnect1_location          = "las-zone1-770"
-  region1_interconnect1_onprem_dc         = "onprem-dc-1"
+  region1_interconnect1_onprem_dc         = "onprem-dc1"
   region1_router2_name                    = module.restricted_shared_vpc.region1_router2.router.name
   region1_interconnect2_candidate_subnets = ["169.254.0.168/29"]
   region1_interconnect2_vlan_tag8021q     = "3902"
   region1_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
   region1_interconnect2_location          = "las-zone1-770"
-  region1_interconnect2_onprem_dc         = "onprem-dc-2"
+  region1_interconnect2_onprem_dc         = "onprem-dc2"
 
   region2                                 = var.default_region2
   region2_router1_name                    = module.restricted_shared_vpc.region2_router1.router.name
@@ -40,13 +40,13 @@ module "shared_restricted_interconnect" {
   region2_interconnect1_vlan_tag8021q     = "3903"
   region2_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
   region2_interconnect1_location          = "lax-zone2-19"
-  region2_interconnect1_onprem_dc         = "onprem-dc-3"
+  region2_interconnect1_onprem_dc         = "onprem-dc3"
   region2_router2_name                    = module.restricted_shared_vpc.region2_router2.router.name
   region2_interconnect2_candidate_subnets = ["169.254.0.184/29"]
   region2_interconnect2_vlan_tag8021q     = "3904"
   region2_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
   region2_interconnect2_location          = "lax-zone1-403"
-  region2_interconnect2_onprem_dc         = "onprem-dc-4"
+  region2_interconnect2_onprem_dc         = "onprem-dc4"
 
   peer_asn  = "64515"
   peer_name = "interconnect-peer"
@@ -75,13 +75,13 @@ module "shared_base_interconnect" {
   region1_interconnect1_vlan_tag8021q     = "3905"
   region1_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
   region1_interconnect1_location          = "las-zone1-770"
-  region1_interconnect1_onprem_dc         = "onprem-dc-1"
+  region1_interconnect1_onprem_dc         = "onprem-dc1"
   region1_router2_name                    = module.base_shared_vpc.region1_router2.router.name
   region1_interconnect2_candidate_subnets = ["169.254.0.200/29"]
   region1_interconnect2_vlan_tag8021q     = "3906"
   region1_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
   region1_interconnect2_location          = "las-zone1-770"
-  region1_interconnect2_onprem_dc         = "onprem-dc-2"
+  region1_interconnect2_onprem_dc         = "onprem-dc2"
 
   region2                                 = var.default_region2
   region2_router1_name                    = module.base_shared_vpc.region2_router1.router.name
@@ -89,13 +89,13 @@ module "shared_base_interconnect" {
   region2_interconnect1_vlan_tag8021q     = "3907"
   region2_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
   region2_interconnect1_location          = "lax-zone2-19"
-  region2_interconnect1_onprem_dc         = "onprem-dc-3"
+  region2_interconnect1_onprem_dc         = "onprem-dc3"
   region2_router2_name                    = module.base_shared_vpc.region2_router2.router.name
   region2_interconnect2_candidate_subnets = ["169.254.0.216/29"]
   region2_interconnect2_vlan_tag8021q     = "3908"
   region2_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
   region2_interconnect2_location          = "lax-zone1-403"
-  region2_interconnect2_onprem_dc         = "onprem-dc-4"
+  region2_interconnect2_onprem_dc         = "onprem-dc4"
 
 
   peer_asn  = "64515"

--- a/3-networks-hub-and-spoke/modules/base_env/interconnect.tf.example
+++ b/3-networks-hub-and-spoke/modules/base_env/interconnect.tf.example
@@ -17,7 +17,8 @@
 module "shared_restricted_interconnect" {
   source = "../dedicated_interconnect"
 
-  vpc_name = "${var.environment_code}-shared-restricted"
+  vpc_name                = "${var.environment_code}-shared-restricted"
+  interconnect_project_id = local.interconnect_project_id
 
   region1                                 = var.default_region1
   region1_router1_name                    = module.restricted_shared_vpc.region1_router1.router.name
@@ -25,11 +26,13 @@ module "shared_restricted_interconnect" {
   region1_interconnect1_vlan_tag8021q     = "3901"
   region1_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
   region1_interconnect1_location          = "las-zone1-770"
+  region1_interconnect1_onprem_dc         = "onprem-dc-1"
   region1_router2_name                    = module.restricted_shared_vpc.region1_router2.router.name
   region1_interconnect2_candidate_subnets = ["169.254.0.168/29"]
   region1_interconnect2_vlan_tag8021q     = "3902"
   region1_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
   region1_interconnect2_location          = "las-zone1-770"
+  region1_interconnect2_onprem_dc         = "onprem-dc-2"
 
   region2                                 = var.default_region2
   region2_router1_name                    = module.restricted_shared_vpc.region2_router1.router.name
@@ -37,11 +40,13 @@ module "shared_restricted_interconnect" {
   region2_interconnect1_vlan_tag8021q     = "3903"
   region2_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
   region2_interconnect1_location          = "lax-zone2-19"
+  region2_interconnect1_onprem_dc         = "onprem-dc-3"
   region2_router2_name                    = module.restricted_shared_vpc.region2_router2.router.name
   region2_interconnect2_candidate_subnets = ["169.254.0.184/29"]
   region2_interconnect2_vlan_tag8021q     = "3904"
   region2_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
   region2_interconnect2_location          = "lax-zone1-403"
+  region2_interconnect2_onprem_dc         = "onprem-dc-4"
 
   peer_asn  = "64515"
   peer_name = "interconnect-peer"
@@ -70,11 +75,13 @@ module "shared_base_interconnect" {
   region1_interconnect1_vlan_tag8021q     = "3905"
   region1_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-1"
   region1_interconnect1_location          = "las-zone1-770"
+  region1_interconnect1_onprem_dc         = "onprem-dc-1"
   region1_router2_name                    = module.base_shared_vpc.region1_router2.router.name
   region1_interconnect2_candidate_subnets = ["169.254.0.200/29"]
   region1_interconnect2_vlan_tag8021q     = "3906"
   region1_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-2"
   region1_interconnect2_location          = "las-zone1-770"
+  region1_interconnect2_onprem_dc         = "onprem-dc-2"
 
   region2                                 = var.default_region2
   region2_router1_name                    = module.base_shared_vpc.region2_router1.router.name
@@ -82,11 +89,13 @@ module "shared_base_interconnect" {
   region2_interconnect1_vlan_tag8021q     = "3907"
   region2_interconnect1                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-3"
   region2_interconnect1_location          = "lax-zone2-19"
+  region2_interconnect1_onprem_dc         = "onprem-dc-3"
   region2_router2_name                    = module.base_shared_vpc.region2_router2.router.name
   region2_interconnect2_candidate_subnets = ["169.254.0.216/29"]
   region2_interconnect2_vlan_tag8021q     = "3908"
   region2_interconnect2                   = "https://www.googleapis.com/compute/v1/projects/example-interconnect-project/global/interconnects/example-interconnect-4"
   region2_interconnect2_location          = "lax-zone1-403"
+  region2_interconnect2_onprem_dc         = "onprem-dc-4"
 
 
   peer_asn  = "64515"

--- a/3-networks-hub-and-spoke/modules/base_env/partner_interconnect.tf.example
+++ b/3-networks-hub-and-spoke/modules/base_env/partner_interconnect.tf.example
@@ -24,18 +24,18 @@ module "shared_restricted_interconnect" {
   region1                         = var.default_region1
   region1_router1_name            = module.restricted_shared_vpc.region1_router1.router.name
   region1_interconnect1_location  = "las-zone1-770"
-  region1_interconnect1_onprem_dc = "onprem-dc-1"
+  region1_interconnect1_onprem_dc = "onprem-dc1"
   region1_router2_name            = module.restricted_shared_vpc.region1_router2.router.name
   region1_interconnect2_location  = "las-zone1-770"
-  region1_interconnect2_onprem_dc = "onprem-dc-2"
+  region1_interconnect2_onprem_dc = "onprem-dc2"
 
   region2                         = var.default_region2
   region2_router1_name            = module.restricted_shared_vpc.region2_router1.router.name
   region2_interconnect1_location  = "lax-zone2-19"
-  region2_interconnect1_onprem_dc = "onprem-dc-3"
+  region2_interconnect1_onprem_dc = "onprem-dc3"
   region2_router2_name            = module.restricted_shared_vpc.region2_router2.router.name
   region2_interconnect2_location  = "lax-zone1-403"
-  region2_interconnect2_onprem_dc = "onprem-dc-4"
+  region2_interconnect2_onprem_dc = "onprem-dc4"
 
   cloud_router_labels = {
     vlan_1 = "cr5",
@@ -59,18 +59,18 @@ module "shared_base_interconnect" {
   region1                         = var.default_region1
   region1_router1_name            = module.base_shared_vpc.region1_router1.router.name
   region1_interconnect1_location  = "las-zone1-770"
-  region1_interconnect1_onprem_dc = "onprem-dc-1"
+  region1_interconnect1_onprem_dc = "onprem-dc1"
   region1_router2_name            = module.base_shared_vpc.region1_router2.router.name
   region1_interconnect2_location  = "las-zone1-770"
-  region1_interconnect2_onprem_dc = "onprem-dc-2"
+  region1_interconnect2_onprem_dc = "onprem-dc2"
 
   region2                         = var.default_region2
   region2_router1_name            = module.base_shared_vpc.region2_router1.router.name
   region2_interconnect1_location  = "lax-zone2-19"
-  region2_interconnect1_onprem_dc = "onprem-dc-3"
+  region2_interconnect1_onprem_dc = "onprem-dc3"
   region2_router2_name            = module.base_shared_vpc.region2_router2.router.name
   region2_interconnect2_location  = "lax-zone1-403"
-  region2_interconnect2_onprem_dc = "onprem-dc-4"
+  region2_interconnect2_onprem_dc = "onprem-dc4"
 
 
   cloud_router_labels = {

--- a/3-networks-hub-and-spoke/modules/base_env/partner_interconnect.tf.example
+++ b/3-networks-hub-and-spoke/modules/base_env/partner_interconnect.tf.example
@@ -19,20 +19,23 @@ module "shared_restricted_interconnect" {
 
   attachment_project_id = local.restricted_net_hub_project_id
   vpc_name              = "${var.environment_code}-shared-restricted"
-  vpc_type              = "restricted"
   preactivate           = true
 
-  region1                        = var.default_region1
-  region1_router1_name           = module.restricted_shared_vpc.region1_router1.router.name
-  region1_interconnect1_location = "las-zone1-770"
-  region1_router2_name           = module.restricted_shared_vpc.region1_router2.router.name
-  region1_interconnect2_location = "las-zone1-770"
+  region1                         = var.default_region1
+  region1_router1_name            = module.restricted_shared_vpc.region1_router1.router.name
+  region1_interconnect1_location  = "las-zone1-770"
+  region1_interconnect1_onprem_dc = "onprem-dc-1"
+  region1_router2_name            = module.restricted_shared_vpc.region1_router2.router.name
+  region1_interconnect2_location  = "las-zone1-770"
+  region1_interconnect2_onprem_dc = "onprem-dc-2"
 
-  region2                        = var.default_region2
-  region2_router1_name           = module.restricted_shared_vpc.region2_router1.router.name
-  region2_interconnect1_location = "lax-zone2-19"
-  region2_router2_name           = module.restricted_shared_vpc.region2_router2.router.name
-  region2_interconnect2_location = "lax-zone1-403"
+  region2                         = var.default_region2
+  region2_router1_name            = module.restricted_shared_vpc.region2_router1.router.name
+  region2_interconnect1_location  = "lax-zone2-19"
+  region2_interconnect1_onprem_dc = "onprem-dc-3"
+  region2_router2_name            = module.restricted_shared_vpc.region2_router2.router.name
+  region2_interconnect2_location  = "lax-zone1-403"
+  region2_interconnect2_onprem_dc = "onprem-dc-4"
 
   cloud_router_labels = {
     vlan_1 = "cr5",
@@ -51,20 +54,23 @@ module "shared_base_interconnect" {
 
   attachment_project_id = local.base_net_hub_project_id
   vpc_name              = "${var.environment_code}-shared-base"
-  vpc_type              = "base"
   preactivate           = true
 
-  region1                        = var.default_region1
-  region1_router1_name           = module.base_shared_vpc.region1_router1.router.name
-  region1_interconnect1_location = "las-zone1-770"
-  region1_router2_name           = module.base_shared_vpc.region1_router2.router.name
-  region1_interconnect2_location = "las-zone1-770"
+  region1                         = var.default_region1
+  region1_router1_name            = module.base_shared_vpc.region1_router1.router.name
+  region1_interconnect1_location  = "las-zone1-770"
+  region1_interconnect1_onprem_dc = "onprem-dc-1"
+  region1_router2_name            = module.base_shared_vpc.region1_router2.router.name
+  region1_interconnect2_location  = "las-zone1-770"
+  region1_interconnect2_onprem_dc = "onprem-dc-2"
 
-  region2                        = var.default_region2
-  region2_router1_name           = module.base_shared_vpc.region2_router1.router.name
-  region2_interconnect1_location = "lax-zone2-19"
-  region2_router2_name           = module.base_shared_vpc.region2_router2.router.name
-  region2_interconnect2_location = "lax-zone1-403"
+  region2                         = var.default_region2
+  region2_router1_name            = module.base_shared_vpc.region2_router1.router.name
+  region2_interconnect1_location  = "lax-zone2-19"
+  region2_interconnect1_onprem_dc = "onprem-dc-3"
+  region2_router2_name            = module.base_shared_vpc.region2_router2.router.name
+  region2_interconnect2_location  = "lax-zone1-403"
+  region2_interconnect2_onprem_dc = "onprem-dc-4"
 
 
   cloud_router_labels = {

--- a/3-networks-hub-and-spoke/modules/base_shared_vpc/README.md
+++ b/3-networks-hub-and-spoke/modules/base_shared_vpc/README.md
@@ -35,6 +35,10 @@
 |------|-------------|
 | network\_name | The name of the VPC being created |
 | network\_self\_link | The URI of the VPC being created |
+| region1\_router1 | Router 1 for Region 1 |
+| region1\_router2 | Router 2 for Region 1 |
+| region2\_router1 | Router 1 for Region 2 |
+| region2\_router2 | Router 2 for Region 2 |
 | subnets\_flow\_logs | Whether the subnets have VPC flow logs enabled |
 | subnets\_ips | The IPs and CIDRs of the subnets being created |
 | subnets\_names | The names of the subnets being created |

--- a/3-networks-hub-and-spoke/modules/base_shared_vpc/outputs.tf
+++ b/3-networks-hub-and-spoke/modules/base_shared_vpc/outputs.tf
@@ -58,3 +58,23 @@ output "subnets_secondary_ranges" {
   value       = module.main.subnets_secondary_ranges
   description = "The secondary ranges associated with these subnets"
 }
+
+output "region1_router1" {
+  value       = try(module.region1_router1[0], null)
+  description = "Router 1 for Region 1"
+}
+
+output "region1_router2" {
+  value       = try(module.region1_router2[0], null)
+  description = "Router 2 for Region 1"
+}
+
+output "region2_router1" {
+  value       = try(module.region2_router1[0], null)
+  description = "Router 1 for Region 2"
+}
+
+output "region2_router2" {
+  value       = try(module.region2_router2[0], null)
+  description = "Router 2 for Region 2"
+}

--- a/3-networks-hub-and-spoke/modules/dedicated_interconnect/README.md
+++ b/3-networks-hub-and-spoke/modules/dedicated_interconnect/README.md
@@ -25,10 +25,12 @@ This module implements the recommendation proposed in [Establishing 99.99% Avail
 | region1\_interconnect1 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | `string` | n/a | yes |
 | region1\_interconnect1\_candidate\_subnets | Up to 16 candidate prefixes that can be used to restrict the allocation of cloudRouterIpAddress and customerRouterIpAddress for this attachment. All prefixes must be within link-local address space (169.254.0.0/16) and must be /29 or shorter (/28, /27, etc). | `list(string)` | `null` | no |
 | region1\_interconnect1\_location | Name of the interconnect location used in the creation of the Interconnect for the first location of region1 | `string` | n/a | yes |
+| region1\_interconnect1\_onprem\_dc | Name of the on premisses data center used in the creation of the Interconnect for the first location of region1. | `string` | n/a | yes |
 | region1\_interconnect1\_vlan\_tag8021q | The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4094. | `string` | `null` | no |
 | region1\_interconnect2 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | `string` | n/a | yes |
 | region1\_interconnect2\_candidate\_subnets | Up to 16 candidate prefixes that can be used to restrict the allocation of cloudRouterIpAddress and customerRouterIpAddress for this attachment. All prefixes must be within link-local address space (169.254.0.0/16) and must be /29 or shorter (/28, /27, etc). | `list(string)` | `null` | no |
 | region1\_interconnect2\_location | Name of the interconnect location used in the creation of the Interconnect for the second location of region1 | `string` | n/a | yes |
+| region1\_interconnect2\_onprem\_dc | Name of the on premisses data center used in the creation of the Interconnect for the second location of region1. | `string` | n/a | yes |
 | region1\_interconnect2\_vlan\_tag8021q | The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4094. | `string` | `null` | no |
 | region1\_router1\_name | Name of the Router 1 for Region 1 where the attachment resides. | `string` | n/a | yes |
 | region1\_router2\_name | Name of the Router 2 for Region 1 where the attachment resides. | `string` | n/a | yes |
@@ -36,10 +38,12 @@ This module implements the recommendation proposed in [Establishing 99.99% Avail
 | region2\_interconnect1 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | `string` | n/a | yes |
 | region2\_interconnect1\_candidate\_subnets | Up to 16 candidate prefixes that can be used to restrict the allocation of cloudRouterIpAddress and customerRouterIpAddress for this attachment. All prefixes must be within link-local address space (169.254.0.0/16) and must be /29 or shorter (/28, /27, etc). | `list(string)` | `null` | no |
 | region2\_interconnect1\_location | Name of the interconnect location used in the creation of the Interconnect for the first location of region2 | `string` | n/a | yes |
+| region2\_interconnect1\_onprem\_dc | Name of the on premisses data center used in the creation of the Interconnect for the first location of region2. | `string` | n/a | yes |
 | region2\_interconnect1\_vlan\_tag8021q | The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4094. | `string` | `null` | no |
 | region2\_interconnect2 | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | `string` | n/a | yes |
 | region2\_interconnect2\_candidate\_subnets | Up to 16 candidate prefixes that can be used to restrict the allocation of cloudRouterIpAddress and customerRouterIpAddress for this attachment. All prefixes must be within link-local address space (169.254.0.0/16) and must be /29 or shorter (/28, /27, etc). | `list(string)` | `null` | no |
 | region2\_interconnect2\_location | Name of the interconnect location used in the creation of the Interconnect for the second location of region2 | `string` | n/a | yes |
+| region2\_interconnect2\_onprem\_dc | Name of the on premisses data center used in the creation of the Interconnect for the second location of region2. | `string` | n/a | yes |
 | region2\_interconnect2\_vlan\_tag8021q | The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4094. | `string` | `null` | no |
 | region2\_router1\_name | Name of the Router 1 for Region 2 where the attachment resides. | `string` | n/a | yes |
 | region2\_router2\_name | Name of the Router 2 for Region 2 where the attachment resides | `string` | n/a | yes |

--- a/3-networks-hub-and-spoke/modules/dedicated_interconnect/main.tf
+++ b/3-networks-hub-and-spoke/modules/dedicated_interconnect/main.tf
@@ -25,7 +25,7 @@ module "interconnect_attachment1_region1" {
   source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
   version = "~> 3.0"
 
-  name    = "vl-${var.region1_interconnect1_location}-${var.vpc_name}-${var.region1}-${local.suffix1}"
+  name    = "vl-${var.region1_interconnect1_onprem_dc}-${var.region1_interconnect1_location}-${var.vpc_name}-${var.region1}-${local.suffix1}"
   project = var.interconnect_project_id
   region  = var.region1
   router  = var.region1_router1_name
@@ -48,7 +48,7 @@ module "interconnect_attachment2_region1" {
   source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
   version = "~> 3.0"
 
-  name    = "vl-${var.region1_interconnect2_location}-${var.vpc_name}-${var.region1}-${local.suffix2}"
+  name    = "vl-${var.region1_interconnect2_onprem_dc}-${var.region1_interconnect2_location}-${var.vpc_name}-${var.region1}-${local.suffix2}"
   project = var.interconnect_project_id
   region  = var.region1
   router  = var.region1_router2_name
@@ -71,7 +71,7 @@ module "interconnect_attachment1_region2" {
   source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
   version = "~> 3.0"
 
-  name    = "vl-${var.region2_interconnect1_location}-${var.vpc_name}-${var.region2}-${local.suffix3}"
+  name    = "vl-${var.region2_interconnect1_onprem_dc}-${var.region2_interconnect1_location}-${var.vpc_name}-${var.region2}-${local.suffix3}"
   project = var.interconnect_project_id
   region  = var.region2
   router  = var.region2_router1_name
@@ -94,7 +94,7 @@ module "interconnect_attachment2_region2" {
   source  = "terraform-google-modules/cloud-router/google//modules/interconnect_attachment"
   version = "~> 3.0"
 
-  name    = "vl-${var.region2_interconnect2_location}-${var.vpc_name}-${var.region2}-${local.suffix4}"
+  name    = "vl-${var.region2_interconnect2_onprem_dc}-${var.region2_interconnect2_location}-${var.vpc_name}-${var.region2}-${local.suffix4}"
   project = var.interconnect_project_id
   region  = var.region2
   router  = var.region2_router2_name

--- a/3-networks-hub-and-spoke/modules/dedicated_interconnect/variables.tf
+++ b/3-networks-hub-and-spoke/modules/dedicated_interconnect/variables.tf
@@ -44,6 +44,26 @@ variable "peer_asn" {
   description = "Peer BGP Autonomous System Number (ASN)."
 }
 
+variable "region1_interconnect1_onprem_dc" {
+  type        = string
+  description = "Name of the on premisses data center used in the creation of the Interconnect for the first location of region1."
+}
+
+variable "region1_interconnect2_onprem_dc" {
+  type        = string
+  description = "Name of the on premisses data center used in the creation of the Interconnect for the second location of region1."
+}
+
+variable "region2_interconnect1_onprem_dc" {
+  type        = string
+  description = "Name of the on premisses data center used in the creation of the Interconnect for the first location of region2."
+}
+
+variable "region2_interconnect2_onprem_dc" {
+  type        = string
+  description = "Name of the on premisses data center used in the creation of the Interconnect for the second location of region2."
+}
+
 variable "region1_interconnect1_location" {
   type        = string
   description = "Name of the interconnect location used in the creation of the Interconnect for the first location of region1"

--- a/3-networks-hub-and-spoke/modules/partner_interconnect/README.md
+++ b/3-networks-hub-and-spoke/modules/partner_interconnect/README.md
@@ -24,16 +24,19 @@ Without Hub and Spoke enabled VLAN attachments will be created in `prj-{p|n|d}-s
 | preactivate | Preactivate Partner Interconnect attachments, works only for level3 Partner Interconnect | `string` | `false` | no |
 | region1 | First subnet region. The Partner Interconnect module only configures two regions. | `string` | n/a | yes |
 | region1\_interconnect1\_location | Name of the interconnect location used in the creation of the Interconnect for the first location of region1 | `string` | n/a | yes |
+| region1\_interconnect1\_onprem\_dc | Name of the on premisses data center used in the creation of the Interconnect for the first location of region1. | `string` | n/a | yes |
 | region1\_interconnect2\_location | Name of the interconnect location used in the creation of the Interconnect for the second location of region1 | `string` | n/a | yes |
+| region1\_interconnect2\_onprem\_dc | Name of the on premisses data center used in the creation of the Interconnect for the second location of region1. | `string` | n/a | yes |
 | region1\_router1\_name | Name of the Router 1 for Region 1 where the attachment resides. | `string` | n/a | yes |
 | region1\_router2\_name | Name of the Router 2 for Region 1 where the attachment resides. | `string` | n/a | yes |
 | region2 | Second subnet region. The Partner Interconnect module only configures two regions. | `string` | n/a | yes |
 | region2\_interconnect1\_location | Name of the interconnect location used in the creation of the Interconnect for the first location of region2 | `string` | n/a | yes |
+| region2\_interconnect1\_onprem\_dc | Name of the on premisses data center used in the creation of the Interconnect for the first location of region2. | `string` | n/a | yes |
 | region2\_interconnect2\_location | Name of the interconnect location used in the creation of the Interconnect for the second location of region2 | `string` | n/a | yes |
+| region2\_interconnect2\_onprem\_dc | Name of the on premisses data center used in the creation of the Interconnect for the second location of region2. | `string` | n/a | yes |
 | region2\_router1\_name | Name of the Router 1 for Region 2 where the attachment resides. | `string` | n/a | yes |
 | region2\_router2\_name | Name of the Router 2 for Region 2 where the attachment resides | `string` | n/a | yes |
 | vpc\_name | Label to identify the VPC associated with shared VPC that will use the Interconnect. | `string` | n/a | yes |
-| vpc\_type | To which Shared VPC Host attach the Partner Interconnect - base/restricted | `string` | `null` | no |
 
 ## Outputs
 

--- a/3-networks-hub-and-spoke/modules/partner_interconnect/main.tf
+++ b/3-networks-hub-and-spoke/modules/partner_interconnect/main.tf
@@ -23,7 +23,7 @@ locals {
 
 
 resource "google_compute_interconnect_attachment" "interconnect_attachment1_region1" {
-  name    = "vl-${var.region1_interconnect1_location}-${var.vpc_name}-${var.region1}-${local.suffix1}"
+  name    = "vl-${var.region1_interconnect1_onprem_dc}-${var.region1_interconnect1_location}-${var.vpc_name}-${var.region1}-${local.suffix1}"
   project = var.attachment_project_id
   region  = var.region1
   router  = var.region1_router1_name
@@ -34,7 +34,7 @@ resource "google_compute_interconnect_attachment" "interconnect_attachment1_regi
 }
 
 resource "google_compute_interconnect_attachment" "interconnect_attachment2_region1" {
-  name    = "vl-${var.region1_interconnect2_location}-${var.vpc_name}-${var.region1}-${local.suffix2}"
+  name    = "vl-${var.region1_interconnect2_onprem_dc}-${var.region1_interconnect2_location}-${var.vpc_name}-${var.region1}-${local.suffix2}"
   project = var.attachment_project_id
   region  = var.region1
   router  = var.region1_router2_name
@@ -45,7 +45,7 @@ resource "google_compute_interconnect_attachment" "interconnect_attachment2_regi
 }
 
 resource "google_compute_interconnect_attachment" "interconnect_attachment1_region2" {
-  name    = "vl-${var.region2_interconnect1_location}-${var.vpc_name}-${var.region2}-${local.suffix1}"
+  name    = "vl-${var.region2_interconnect1_onprem_dc}-${var.region2_interconnect1_location}-${var.vpc_name}-${var.region2}-${local.suffix1}"
   project = var.attachment_project_id
   region  = var.region2
   router  = var.region2_router1_name
@@ -56,7 +56,7 @@ resource "google_compute_interconnect_attachment" "interconnect_attachment1_regi
 }
 
 resource "google_compute_interconnect_attachment" "interconnect_attachment2_region2" {
-  name    = "vl-${var.region2_interconnect2_location}-${var.vpc_name}-${var.region2}-${local.suffix2}"
+  name    = "vl-${var.region2_interconnect2_onprem_dc}-${var.region2_interconnect2_location}-${var.vpc_name}-${var.region2}-${local.suffix2}"
   project = var.attachment_project_id
   region  = var.region2
   router  = var.region2_router2_name

--- a/3-networks-hub-and-spoke/modules/partner_interconnect/variables.tf
+++ b/3-networks-hub-and-spoke/modules/partner_interconnect/variables.tf
@@ -34,6 +34,26 @@ variable "region2" {
   description = "Second subnet region. The Partner Interconnect module only configures two regions."
 }
 
+variable "region1_interconnect1_onprem_dc" {
+  type        = string
+  description = "Name of the on premisses data center used in the creation of the Interconnect for the first location of region1."
+}
+
+variable "region1_interconnect2_onprem_dc" {
+  type        = string
+  description = "Name of the on premisses data center used in the creation of the Interconnect for the second location of region1."
+}
+
+variable "region2_interconnect1_onprem_dc" {
+  type        = string
+  description = "Name of the on premisses data center used in the creation of the Interconnect for the first location of region2."
+}
+
+variable "region2_interconnect2_onprem_dc" {
+  type        = string
+  description = "Name of the on premisses data center used in the creation of the Interconnect for the second location of region2."
+}
+
 variable "region1_interconnect1_location" {
   type        = string
   description = "Name of the interconnect location used in the creation of the Interconnect for the first location of region1"
@@ -84,10 +104,4 @@ variable "preactivate" {
   description = "Preactivate Partner Interconnect attachments, works only for level3 Partner Interconnect"
   type        = string
   default     = false
-}
-
-variable "vpc_type" {
-  description = "To which Shared VPC Host attach the Partner Interconnect - base/restricted"
-  type        = string
-  default     = null
 }

--- a/3-networks-hub-and-spoke/modules/restricted_shared_vpc/README.md
+++ b/3-networks-hub-and-spoke/modules/restricted_shared_vpc/README.md
@@ -42,6 +42,10 @@
 | access\_level\_name | Access context manager access level name |
 | network\_name | The name of the VPC being created |
 | network\_self\_link | The URI of the VPC being created |
+| region1\_router1 | Router 1 for Region 1 |
+| region1\_router2 | Router 2 for Region 1 |
+| region2\_router1 | Router 1 for Region 2 |
+| region2\_router2 | Router 2 for Region 2 |
 | service\_perimeter\_name | Access context manager service perimeter name |
 | subnets\_ips | The IPs and CIDRs of the subnets being created |
 | subnets\_names | The names of the subnets being created |

--- a/3-networks-hub-and-spoke/modules/restricted_shared_vpc/outputs.tf
+++ b/3-networks-hub-and-spoke/modules/restricted_shared_vpc/outputs.tf
@@ -58,3 +58,23 @@ output "service_perimeter_name" {
   value       = local.perimeter_name
   description = "Access context manager service perimeter name "
 }
+
+output "region1_router1" {
+  value       = try(module.region1_router1[0], null)
+  description = "Router 1 for Region 1"
+}
+
+output "region1_router2" {
+  value       = try(module.region1_router2[0], null)
+  description = "Router 2 for Region 1"
+}
+
+output "region2_router1" {
+  value       = try(module.region2_router1[0], null)
+  description = "Router 1 for Region 2"
+}
+
+output "region2_router2" {
+  value       = try(module.region2_router2[0], null)
+  description = "Router 2 for Region 2"
+}


### PR DESCRIPTION
Add `onprem_dc` variable for dedicated and partner interconnect and add missing routers outputs in hub and spoke base and restricted modules