### PR TITLE
Rename identifiers replacing dashes with underscores

### DIFF
--- a/0-bootstrap/cb.tf
+++ b/0-bootstrap/cb.tf
@@ -209,7 +209,7 @@ module "tf_workspace" {
   cloudbuild_plan_filename  = "cloudbuild-tf-plan.yaml"
   cloudbuild_apply_filename = "cloudbuild-tf-apply.yaml"
   tf_repo_uri               = module.tf_source.csr_repos[local.cb_config[each.key].source].url
-  cloudbuild_sa             = google_service_account.terraform-env-sa[each.key].id
+  cloudbuild_sa             = google_service_account.terraform_env_sa[each.key].id
   create_cloudbuild_sa      = false
   diff_sa_project           = true
   create_state_bucket       = false
@@ -240,7 +240,7 @@ resource "google_artifact_registry_repository_iam_member" "terraform_sa_artifact
   location   = var.default_region
   repository = local.gar_repository
   role       = "roles/artifactregistry.reader"
-  member     = "serviceAccount:${google_service_account.terraform-env-sa[each.key].email}"
+  member     = "serviceAccount:${google_service_account.terraform_env_sa[each.key].email}"
 }
 
 resource "google_sourcerepo_repository_iam_member" "member" {
@@ -249,5 +249,5 @@ resource "google_sourcerepo_repository_iam_member" "member" {
   project    = module.tf_source.cloudbuild_project_id
   repository = module.tf_source.csr_repos["gcp-policies"].name
   role       = "roles/viewer"
-  member     = "serviceAccount:${google_service_account.terraform-env-sa[each.key].email}"
+  member     = "serviceAccount:${google_service_account.terraform_env_sa[each.key].email}"
 }

--- a/0-bootstrap/jenkins.tf.example
+++ b/0-bootstrap/jenkins.tf.example
@@ -15,7 +15,7 @@
  */
 
 locals {
-  sa_names = { for k, v in google_service_account.terraform-env-sa : k => v.id }
+  sa_names = { for k, v in google_service_account.terraform_env_sa : k => v.id }
 
   cicd_project_id = module.jenkins_bootstrap.cicd_project_id
 }

--- a/0-bootstrap/main.tf
+++ b/0-bootstrap/main.tf
@@ -22,11 +22,11 @@ locals {
   // in the list "org_project_creators" will have the Project Creator role,
   // so the granular service accounts for each step need to be added to the list.
   step_terraform_sa = [
-    "serviceAccount:${google_service_account.terraform-env-sa["bootstrap"].email}",
-    "serviceAccount:${google_service_account.terraform-env-sa["org"].email}",
-    "serviceAccount:${google_service_account.terraform-env-sa["env"].email}",
-    "serviceAccount:${google_service_account.terraform-env-sa["net"].email}",
-    "serviceAccount:${google_service_account.terraform-env-sa["proj"].email}",
+    "serviceAccount:${google_service_account.terraform_env_sa["bootstrap"].email}",
+    "serviceAccount:${google_service_account.terraform_env_sa["org"].email}",
+    "serviceAccount:${google_service_account.terraform_env_sa["env"].email}",
+    "serviceAccount:${google_service_account.terraform_env_sa["net"].email}",
+    "serviceAccount:${google_service_account.terraform_env_sa["proj"].email}",
   ]
   org_project_creators = distinct(concat(var.org_project_creators, local.step_terraform_sa))
   parent               = var.parent_folder != "" ? "folders/${var.parent_folder}" : "organizations/${var.org_id}"

--- a/0-bootstrap/outputs.tf
+++ b/0-bootstrap/outputs.tf
@@ -21,27 +21,27 @@ output "seed_project_id" {
 
 output "bootstrap_step_terraform_service_account_email" {
   description = "Bootstrap Step Terraform Account"
-  value       = google_service_account.terraform-env-sa["bootstrap"].email
+  value       = google_service_account.terraform_env_sa["bootstrap"].email
 }
 
 output "projects_step_terraform_service_account_email" {
   description = "Projects Step Terraform Account"
-  value       = google_service_account.terraform-env-sa["proj"].email
+  value       = google_service_account.terraform_env_sa["proj"].email
 }
 
 output "networks_step_terraform_service_account_email" {
   description = "Networks Step Terraform Account"
-  value       = google_service_account.terraform-env-sa["net"].email
+  value       = google_service_account.terraform_env_sa["net"].email
 }
 
 output "environment_step_terraform_service_account_email" {
   description = "Environment Step Terraform Account"
-  value       = google_service_account.terraform-env-sa["env"].email
+  value       = google_service_account.terraform_env_sa["env"].email
 }
 
 output "organization_step_terraform_service_account_email" {
   description = "Organization Step Terraform Account"
-  value       = google_service_account.terraform-env-sa["org"].email
+  value       = google_service_account.terraform_env_sa["org"].email
 }
 
 output "gcs_bucket_tfstate" {

--- a/0-bootstrap/sa.tf
+++ b/0-bootstrap/sa.tf
@@ -133,7 +133,7 @@ locals {
   }
 }
 
-resource "google_service_account" "terraform-env-sa" {
+resource "google_service_account" "terraform_env_sa" {
   for_each = local.granular_sa
 
   project      = module.seed_bootstrap.seed_project_id
@@ -145,7 +145,7 @@ module "org_iam_member" {
   source   = "./modules/parent-iam-member"
   for_each = local.granular_sa_org_level_roles
 
-  member      = "serviceAccount:${google_service_account.terraform-env-sa[each.key].email}"
+  member      = "serviceAccount:${google_service_account.terraform_env_sa[each.key].email}"
   parent_type = "organization"
   parent_id   = var.org_id
   roles       = each.value
@@ -155,7 +155,7 @@ module "parent_iam_member" {
   source   = "./modules/parent-iam-member"
   for_each = local.granular_sa_parent_level_roles
 
-  member      = "serviceAccount:${google_service_account.terraform-env-sa[each.key].email}"
+  member      = "serviceAccount:${google_service_account.terraform_env_sa[each.key].email}"
   parent_type = local.parent_type
   parent_id   = local.parent_id
   roles       = each.value
@@ -165,7 +165,7 @@ module "seed_project_iam_member" {
   source   = "./modules/parent-iam-member"
   for_each = local.granular_sa_seed_project
 
-  member      = "serviceAccount:${google_service_account.terraform-env-sa[each.key].email}"
+  member      = "serviceAccount:${google_service_account.terraform_env_sa[each.key].email}"
   parent_type = "project"
   parent_id   = module.seed_bootstrap.seed_project_id
   roles       = each.value
@@ -175,7 +175,7 @@ module "cicd_project_iam_member" {
   source   = "./modules/parent-iam-member"
   for_each = local.granular_sa_cicd_project
 
-  member      = "serviceAccount:${google_service_account.terraform-env-sa[each.key].email}"
+  member      = "serviceAccount:${google_service_account.terraform_env_sa[each.key].email}"
   parent_type = "project"
   parent_id   = local.cicd_project_id
   roles       = each.value
@@ -205,10 +205,10 @@ resource "google_billing_account_iam_member" "tf_billing_user" {
 
   billing_account_id = var.billing_account
   role               = "roles/billing.user"
-  member             = "serviceAccount:${google_service_account.terraform-env-sa[each.key].email}"
+  member             = "serviceAccount:${google_service_account.terraform_env_sa[each.key].email}"
 
   depends_on = [
-    google_service_account.terraform-env-sa
+    google_service_account.terraform_env_sa
   ]
 }
 
@@ -217,7 +217,7 @@ resource "google_billing_account_iam_member" "billing_admin_user" {
 
   billing_account_id = var.billing_account
   role               = "roles/billing.admin"
-  member             = "serviceAccount:${google_service_account.terraform-env-sa[each.key].email}"
+  member             = "serviceAccount:${google_service_account.terraform_env_sa[each.key].email}"
 
   depends_on = [
     google_billing_account_iam_member.tf_billing_user

--- a/4-projects/modules/infra_pipelines/main.tf
+++ b/4-projects/modules/infra_pipelines/main.tf
@@ -96,7 +96,7 @@ module "tf_workspace" {
   Cloud Build - IAM
  ***********************************************/
 
-resource "google_artifact_registry_repository_iam_member" "terraform-image-iam" {
+resource "google_artifact_registry_repository_iam_member" "terraform_image_iam" {
   provider = google-beta
   for_each = toset(var.app_infra_repos)
 


### PR DESCRIPTION
Renamed two identifiers to use underscores instead of dashes to be consistent with other identifiers:
 - "terraform-env-sa" to "terraform_env_sa" and
 - "terraform-image-iam" to "terraform_image_iam"