### PR TITLE
fix: change priority of 'allow-google-apis' firewall rules to prevent collision with the deny all rule

### DIFF
--- a/3-networks-dual-svpc/modules/base_shared_vpc/firewall.tf
+++ b/3-networks-dual-svpc/modules/base_shared_vpc/firewall.tf
@@ -44,11 +44,11 @@ resource "google_compute_firewall" "deny_all_egress" {
 
 
 resource "google_compute_firewall" "allow_private_api_egress" {
-  name      = "fw-${var.environment_code}-shared-base-65530-e-a-allow-google-apis-all-tcp-443"
+  name      = "fw-${var.environment_code}-shared-base-65430-e-a-allow-google-apis-all-tcp-443"
   network   = module.main.network_name
   project   = var.project_id
   direction = "EGRESS"
-  priority  = 65530
+  priority  = 65430
 
   dynamic "log_config" {
     for_each = var.firewall_enable_logging == true ? [{

--- a/3-networks-dual-svpc/modules/restricted_shared_vpc/firewall.tf
+++ b/3-networks-dual-svpc/modules/restricted_shared_vpc/firewall.tf
@@ -43,11 +43,11 @@ resource "google_compute_firewall" "deny_all_egress" {
 }
 
 resource "google_compute_firewall" "allow_restricted_api_egress" {
-  name      = "fw-${var.environment_code}-shared-restricted-65530-e-a-allow-google-apis-all-tcp-443"
+  name      = "fw-${var.environment_code}-shared-restricted-65430-e-a-allow-google-apis-all-tcp-443"
   network   = module.main.network_name
   project   = var.project_id
   direction = "EGRESS"
-  priority  = 65530
+  priority  = 65430
 
   dynamic "log_config" {
     for_each = var.firewall_enable_logging == true ? [{

--- a/3-networks-hub-and-spoke/modules/base_shared_vpc/firewall.tf
+++ b/3-networks-hub-and-spoke/modules/base_shared_vpc/firewall.tf
@@ -44,11 +44,11 @@ resource "google_compute_firewall" "deny_all_egress" {
 
 
 resource "google_compute_firewall" "allow_private_api_egress" {
-  name      = "fw-${var.environment_code}-shared-base-65530-e-a-allow-google-apis-all-tcp-443"
+  name      = "fw-${var.environment_code}-shared-base-65430-e-a-allow-google-apis-all-tcp-443"
   network   = module.main.network_name
   project   = var.project_id
   direction = "EGRESS"
-  priority  = 65530
+  priority  = 65430
 
   dynamic "log_config" {
     for_each = var.firewall_enable_logging == true ? [{

--- a/3-networks-hub-and-spoke/modules/restricted_shared_vpc/firewall.tf
+++ b/3-networks-hub-and-spoke/modules/restricted_shared_vpc/firewall.tf
@@ -43,11 +43,11 @@ resource "google_compute_firewall" "deny_all_egress" {
 }
 
 resource "google_compute_firewall" "allow_restricted_api_egress" {
-  name      = "fw-${var.environment_code}-shared-restricted-65530-e-a-allow-google-apis-all-tcp-443"
+  name      = "fw-${var.environment_code}-shared-restricted-65430-e-a-allow-google-apis-all-tcp-443"
   network   = module.main.network_name
   project   = var.project_id
   direction = "EGRESS"
-  priority  = 65530
+  priority  = 65430
 
   dynamic "log_config" {
     for_each = var.firewall_enable_logging == true ? [{

--- a/4-projects/modules/base_env/example_peering_project.tf
+++ b/4-projects/modules/base_env/example_peering_project.tf
@@ -118,11 +118,11 @@ resource "google_compute_firewall" "deny_all_egress" {
 
 
 resource "google_compute_firewall" "allow_private_api_egress" {
-  name      = "fw-${local.env_code}-peering-base-65530-e-a-allow-google-apis-all-tcp-443"
+  name      = "fw-${local.env_code}-peering-base-65430-e-a-allow-google-apis-all-tcp-443"
   network   = module.peering_network.network_name
   project   = module.peering_project.project_id
   direction = "EGRESS"
-  priority  = 65530
+  priority  = 65430
 
   dynamic "log_config" {
     for_each = var.firewall_enable_logging == true ? [{

--- a/test/integration/networks/networks_test.go
+++ b/test/integration/networks/networks_test.go
@@ -54,7 +54,7 @@ func getNetworkResourceNames(envCode string, networkMode string) map[string]map[
 			"region2_router1":       fmt.Sprintf("cr-%s-shared-base%s-us-central1-cr3", envCode, networkMode),
 			"region2_router2":       fmt.Sprintf("cr-%s-shared-base%s-us-central1-cr4", envCode, networkMode),
 			"fw_deny_all_egress":    fmt.Sprintf("fw-%s-shared-base-65530-e-d-all-all-all", envCode),
-			"fw_allow_api_egress":   fmt.Sprintf("fw-%s-shared-base-65530-e-a-allow-google-apis-all-tcp-443", envCode),
+			"fw_allow_api_egress":   fmt.Sprintf("fw-%s-shared-base-65430-e-a-allow-google-apis-all-tcp-443", envCode),
 		},
 		"restricted": {
 			"network_name":          fmt.Sprintf("vpc-%s-shared-restricted%s", envCode, networkMode),
@@ -71,7 +71,7 @@ func getNetworkResourceNames(envCode string, networkMode string) map[string]map[
 			"region2_router1":       fmt.Sprintf("cr-%s-shared-restricted%s-us-central1-cr7", envCode, networkMode),
 			"region2_router2":       fmt.Sprintf("cr-%s-shared-restricted%s-us-central1-cr8", envCode, networkMode),
 			"fw_deny_all_egress":    fmt.Sprintf("fw-%s-shared-restricted-65530-e-d-all-all-all", envCode),
-			"fw_allow_api_egress":   fmt.Sprintf("fw-%s-shared-restricted-65530-e-a-allow-google-apis-all-tcp-443", envCode),
+			"fw_allow_api_egress":   fmt.Sprintf("fw-%s-shared-restricted-65430-e-a-allow-google-apis-all-tcp-443", envCode),
 		},
 	}
 }


### PR DESCRIPTION
This pull request changes the priority of the 'allow-google-apis' firewall rules to prevent collision with the deny all rule. 
See [priority order for firewall rules](https://cloud.google.com/firewall/docs/firewalls#priority_order_for_firewall_rules)

> A rule with a deny action overrides another with an allow action only if the two rules have the same priority. 