### PR TITLE
fix: Fix missing Terraform module attribution

### DIFF
--- a/2-environments/modules/env_baseline/versions.tf
+++ b/2-environments/modules/env_baseline/versions.tf
@@ -28,10 +28,10 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-example-foundation:org/v3.0.0"
+    module_name = "blueprints/terraform/terraform-example-foundation:environments/v3.0.0"
   }
 
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-example-foundation:org/v3.0.0"
+    module_name = "blueprints/terraform/terraform-example-foundation:environments/v3.0.0"
   }
 }

--- a/3-networks-dual-svpc/modules/base_env/versions.tf
+++ b/3-networks-dual-svpc/modules/base_env/versions.tf
@@ -26,4 +26,12 @@ terraform {
       version = ">= 3.50"
     }
   }
+
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-example-foundation:networks-dual-svpc/v3.0.0"
+  }
+
+  provider_meta "google-beta" {
+    module_name = "blueprints/terraform/terraform-example-foundation:networks-dual-svpc/v3.0.0"
+  }
 }

--- a/3-networks-hub-and-spoke/modules/base_env/versions.tf
+++ b/3-networks-hub-and-spoke/modules/base_env/versions.tf
@@ -26,4 +26,12 @@ terraform {
       version = ">= 3.50"
     }
   }
+
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-example-foundation:networks-hub-and-spoke/v3.0.0"
+  }
+
+  provider_meta "google-beta" {
+    module_name = "blueprints/terraform/terraform-example-foundation:networks-hub-and-spoke/v3.0.0"
+  }
 }

--- a/4-projects/modules/base_env/versions.tf
+++ b/4-projects/modules/base_env/versions.tf
@@ -22,4 +22,11 @@ terraform {
     }
   }
 
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-example-foundation:projects/v3.0.0"
+  }
+
+  provider_meta "google-beta" {
+    module_name = "blueprints/terraform/terraform-example-foundation:projects/v3.0.0"
+  }
 }


### PR DESCRIPTION
This pull request adds missing Terraform module attribution in steps
- `3-networks-dual-svpc`
- `3-networks-hub-and-spoke`
- `4-projects`

And fixes the Terraform module attribution for `2-environments` step