### PR TITLE
fix: Pipeline (bootstrap SA) does not have permission to enable an api on b-cicd project (#978)

### DIFF
--- a/0-bootstrap/sa.tf
+++ b/0-bootstrap/sa.tf
@@ -93,6 +93,7 @@ locals {
   // Roles required to manage resources in the Seed project
   granular_sa_seed_project = {
     "bootstrap" = [
+      "roles/owner",
       "roles/storage.admin",
       "roles/iam.serviceAccountAdmin",
       "roles/resourcemanager.projectDeleter",
@@ -114,6 +115,7 @@ locals {
   // Roles required to manage resources in the CI/CD project
   granular_sa_cicd_project = {
     "bootstrap" = [
+      "roles/owner",
       "roles/storage.admin",
       "roles/compute.networkAdmin",
       "roles/cloudbuild.builds.editor",


### PR DESCRIPTION
solution for #978

Adds `roles/owner` instead of a more limited role like `roles/serviceusage.serviceUsageAdmin` because all other step's service accounts are owner of the projects that that service account created.
So adding "roles/owner" is more consistent.