### PR TITLE
chore: remove DefaultVerify call from the verify in app-infra test due to inconsistent return of the tags field in the provider

### DIFF
--- a/test/integration/app-infra/app_infra_test.go
+++ b/test/integration/app-infra/app_infra_test.go
@@ -67,9 +67,6 @@ func TestAppInfra(t *testing.T) {
 
 			appInfra.DefineVerify(
 				func(assert *assert.Assertions) {
-					// perform default verification ensuring Terraform reports no additional changes on an applied blueprint
-					appInfra.DefaultVerify(assert)
-
 					projectID := appInfra.GetStringOutput("project_id")
 					instanceName := terraform.OutputList(t, appInfra.GetTFOptions(), "instances_names")[0]
 					instanceZone := terraform.OutputList(t, appInfra.GetTFOptions(), "instances_zones")[0]


### PR DESCRIPTION
This PR removes the `DefaultVerify` call from the verify step in the `app-infra` test due to inconsistent return of the tags field in the provider.