### PR TITLE
chore: Increase build timeout for the integration build

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-timeout: 12600s
+timeout: 14400s
 steps:
 
 - id: prepare


### PR DESCRIPTION
This PR increases the build timeout for the integration build form 3.5 hours (12600s) to 4 hours (4400s) because of builds failing due to timeout.

Failed build example:

```
Build id b69c1f4a-8887-48e9-b291-0d4509e543ae
Status Timed out
Region global
Timing
  Created November 14, 2023 at 6:05:22 PM UTC-3
  Started November 14, 2023 at 6:05:23 PM UTC-3
  Finished November 14, 2023 at 9:35:24 PM UTC-3
  Queued time 0 sec
  Total build time 3 hr 30 min
    Fetch source 1 sec
    Build step(s) 3 hr 29 min
    Push -
Timeout 3 hr 30 min
```


