### PR TITLE
chore: update perimeter_additional_members instructions

### DIFF
--- a/3-networks-dual-svpc/README.md
+++ b/3-networks-dual-svpc/README.md
@@ -189,6 +189,7 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
 
    sed -i "s/REMOTE_STATE_BUCKET/${backend_bucket}/" ./common.auto.tfvars
    ```
+   **Note:** Make sure that you update the `perimeter_additional_members` variable with your e-mail in order to be able to view/access resources in the project protected by the VPC service controls.
 
 1. Commit changes
 

--- a/3-networks-dual-svpc/common.auto.example.tfvars
+++ b/3-networks-dual-svpc/common.auto.example.tfvars
@@ -17,9 +17,9 @@
 // The DNS name of peering managed zone. Must end with a period.
 domain = "example.com."
 
-// Uncomment the following line and add you email in the perimeter_additional_members list.
+// Update the following line and add you email in the perimeter_additional_members list.
 // You must be in this list to be able to view/access resources in the project protected by the VPC service controls.
 
-//perimeter_additional_members = ["user:YOUR-USER-EMAIL@example.com"]
+perimeter_additional_members = ["user:YOUR-USER-EMAIL@example.com"]
 
 remote_state_bucket = "REMOTE_STATE_BUCKET"

--- a/3-networks-hub-and-spoke/README.md
+++ b/3-networks-hub-and-spoke/README.md
@@ -193,6 +193,7 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
 
    sed -i "s/REMOTE_STATE_BUCKET/${backend_bucket}/" ./common.auto.tfvars
    ```
+   **Note:** Make sure that you update the `perimeter_additional_members` variable with your e-mail in order to be able to view/access resources in the project protected by the VPC service controls.
 
 1. Commit changes
 

--- a/3-networks-hub-and-spoke/common.auto.example.tfvars
+++ b/3-networks-hub-and-spoke/common.auto.example.tfvars
@@ -17,10 +17,10 @@
 // The DNS name of peering managed zone. Must end with a period.
 domain = "example.com."
 
-// Uncomment the following line and add you email in the perimeter_additional_members list.
+// Update the following line and add you email in the perimeter_additional_members list.
 // You must be in this list to be able to view/access resources in the project protected by the VPC service controls.
 
-//perimeter_additional_members = ["user:YOUR-USER-EMAIL@example.com"]
+perimeter_additional_members = ["user:YOUR-USER-EMAIL@example.com"]
 
 remote_state_bucket = "REMOTE_STATE_BUCKET"
 


### PR DESCRIPTION
This PR implements an update on `perimeter_additional_members` variable declaration in both 3-networks steps.

Basically, we want to avoid a situation where the user forget to uncomment a .tfvars line and don't have access to a project protected by the VPC service controls. With this change, if the user forgets to fulfil the variable, an error will be raised during deploy process.