### PR TITLE
fix: typo in local name

### DIFF
--- a/1-org/envs/shared/org_policy.tf
+++ b/1-org/envs/shared/org_policy.tf
@@ -74,7 +74,7 @@ module "org_vm_external_ip_access" {
   constraint      = "constraints/compute.vmExternalIpAccess"
 }
 
-module "restrict_protocol_fowarding" {
+module "restrict_protocol_forwarding" {
   source  = "terraform-google-modules/org-policy/google"
   version = "~> 5.1"
 


### PR DESCRIPTION
The local name is only used once in the entire repo. 