### PR TITLE
chore: fix broken lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,12 +43,6 @@ jobs:
             REGISTRY=$(grep "REGISTRY_URL := " $MAKEFILE | cut -d\  -f3)
             echo dev-tools=${REGISTRY}/${IMAGE}:${VERSION} >> "$GITHUB_OUTPUT"
           fi
-      - run: docker run --rm -e DISABLE_TFLINT -e ENABLE_PARALLEL -e EXCLUDE_LINT_DIRS -v ${{ github.workspace }}:/workspace ${{ steps.variables.outputs.dev-tools }} module-swapper
-        env:
-          DISABLE_TFLINT: 1
-          ENABLE_PARALLEL: 0
-          EXCLUDE_LINT_DIRS: \./3-networks/modules/transitivity/assets
-
       - run: docker run --rm -e DISABLE_TFLINT -e ENABLE_PARALLEL -e EXCLUDE_LINT_DIRS -v ${{ github.workspace }}:/workspace ${{ steps.variables.outputs.dev-tools }} /usr/local/bin/test_lint.sh
         env:
           DISABLE_TFLINT: 1


### PR DESCRIPTION
We don't need swapper anyway since this is not a published module. I will look into either relaxing swapper constraints to exit without err or add a flag for these kind of repos. cc @daniel-cit @apeabody 