### PR TITLE
fix: show output of vet failures in github actions

### DIFF
--- a/build/github-tf-pull-request.yaml
+++ b/build/github-tf-pull-request.yaml
@@ -65,7 +65,7 @@ jobs:
 
       - id: plan-validate-all
         run: |
-          ${GITHUB_WORKSPACE}/tf-wrapper.sh plan_validate_all "${GITHUB_REF_NAME}" "${GITHUB_WORKSPACE}/policy-library" "${PROJECT_ID}" "FILESYSTEM" "GITHUB" > ${GITHUB_WORKSPACE}/plan.out
+          ${GITHUB_WORKSPACE}/tf-wrapper.sh plan_validate_all "${GITHUB_REF_NAME}" "${GITHUB_WORKSPACE}/policy-library" "${PROJECT_ID}" "FILESYSTEM" "GITHUB" | tee ${GITHUB_WORKSPACE}/plan.out
 
       - uses: actions/github-script@v6
         if: github.event_name == 'pull_request'

--- a/build/github-tf-pull-request.yaml
+++ b/build/github-tf-pull-request.yaml
@@ -65,6 +65,7 @@ jobs:
 
       - id: plan-validate-all
         run: |
+          set -o pipefail
           ${GITHUB_WORKSPACE}/tf-wrapper.sh plan_validate_all "${GITHUB_REF_NAME}" "${GITHUB_WORKSPACE}/policy-library" "${PROJECT_ID}" "FILESYSTEM" "GITHUB" | tee ${GITHUB_WORKSPACE}/plan.out
 
       - uses: actions/github-script@v6


### PR DESCRIPTION
Similar to: https://github.com/terraform-google-modules/terraform-example-foundation/issues/1109 and https://github.com/terraform-google-modules/terraform-example-foundation/pull/1113

I was having trouble seeing the reason for failures of "gcloud beta terraform vet" and was just seeing exit code 33 in the github actions output.

This PR addresses the lack of detailed error outputs for Terraform plan_validate_all failures within our GitHub Actions, which previously necessitated running it locally to diagnose issues (which is tough).

This changes the github actions run of `plan_validate_all` to display detailed error information from plan_validate_all directly in the GitHub Actions logs, removing the need for local execution to identify errors.

This allows immediate visibility into "gcloud beta terraform vet" failures within the CI pipeline and reduces diagnostic time for issues detected.