### PR TITLE
chore(tfvars): fix broken symlinks

### DIFF
--- a/2-environments/envs/nonproduction/terraform.tfvars
+++ b/2-environments/envs/nonproduction/terraform.tfvars
@@ -1,1 +1,1 @@
-../../terraform.example.tfvars
+../../terraform.tfvars

--- a/4-projects/business_unit_1/nonproduction/nonproduction.auto.tfvars
+++ b/4-projects/business_unit_1/nonproduction/nonproduction.auto.tfvars
@@ -1,1 +1,1 @@
-../../nonproduction.auto.example.tfvars
+../../nonproduction.auto.tfvars

--- a/4-projects/business_unit_2/nonproduction/nonproduction.auto.tfvars
+++ b/4-projects/business_unit_2/nonproduction/nonproduction.auto.tfvars
@@ -1,1 +1,1 @@
-../../nonproduction.auto.example.tfvars
+../../nonproduction.auto.tfvars


### PR DESCRIPTION
Fix broken symlinks. Instructions on github are to replace all *.example.tfvars with *.tfvars. Most symlinks for tfvars correctly point to a the *.tfvars files, so that a user following the instructions as written does not need to modify any symlinks.

A small number of files have symlinks to point to *.example.tfvars, which causes deployment errors related to undefined variables and requires troubleshooting to identify and fix. I've corrected these broken symlinks.