### PR TITLE
chore(golang): invalid Go toolchain version

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.21
+go 1.21.0
 
 use (
   ./test/integration

--- a/helpers/foundation-deployer/README.md
+++ b/helpers/foundation-deployer/README.md
@@ -14,7 +14,7 @@ Helper tool to deploy the Terraform example foundation using Cloud Build and Clo
 
 ### Validate required tools
 
-- Check if required tools, Go 1.18+, Terraform 1.3.0+, gcloud 393.0.0+, and Git 2.28.0+, are installed:
+- Check if required tools, Go 1.21.0+, Terraform 1.3.0+, gcloud 393.0.0+, and Git 2.28.0+, are installed:
 
     ```bash
     go version

--- a/helpers/foundation-deployer/go.mod
+++ b/helpers/foundation-deployer/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-google-modules/terraform-example-foundation/helpers/foundation-deployer
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.11.1

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-google-modules/terraform-example-foundation/test/integration
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.12.1


### PR DESCRIPTION
Address security issue raised by codeQL, "invalid Go toolchain version".

>As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version).
1.21 in test/integration/go.mod does not match this syntax and there is no additional toolchain directive, which may cause some go commands to fail.