### PR TITLE
chore(CI): add go-test for helpers/foundation-deployer

### DIFF
--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: lint
+name: go-lint
 on:
   pull_request:
     branches:
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
   golangci:
-    name: lint
+    name: golangci-lint
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -44,8 +44,8 @@ jobs:
         go-version-file: ${{ matrix.folder }}/go.mod
         cache-dependency-path: ${{ matrix.folder }}/go.sum
     - run: |-
-        git config user.name 'Cloud Foundation Bot'
-        git config user.email 'cloud-foundation-bot@google.com'
+        git config --global user.name 'Cloud Foundation Bot'
+        git config --global user.email 'cloud-foundation-bot@google.com'
         go test ./... -v
       shell: bash
       working-directory: ${{ matrix.folder }}

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -3,7 +3,7 @@ name: go-test
 on:
   pull_request:
     branches:
-      - 'main'
+      - 'master'
     paths:
       - 'helpers/foundation-deployer/**'
       - '.github/workflows/go-test.yaml'

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  gotest:
-    name: ${{ matrix.folder }} go test
+  go-test:
+    name: go-test
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -1,0 +1,36 @@
+name: go-test
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'helpers/foundation-deployer/**'
+      - '.github/workflows/go-test.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: '${{github.workflow}}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  gotest:
+    name: ${{ matrix.folder }} go test
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        folder: [helpers/foundation-deployer]
+    steps:
+    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+    - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+      with:
+        go-version-file: ${{ matrix.folder }}/go.mod
+        cache-dependency-path: ${{ matrix.folder }}/go.sum
+    - run: |-
+        go test ./... -v
+      shell: bash
+      working-directory: ${{ matrix.folder }}
+      

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -44,6 +44,8 @@ jobs:
         go-version-file: ${{ matrix.folder }}/go.mod
         cache-dependency-path: ${{ matrix.folder }}/go.sum
     - run: |-
+        git config user.name 'Cloud Foundation Bot'
+        git config user.email 'cloud-foundation-bot@google.com'
         go test ./... -v
       shell: bash
       working-directory: ${{ matrix.folder }}

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: go-test
 
 on:
@@ -33,4 +47,3 @@ jobs:
         go test ./... -v
       shell: bash
       working-directory: ${{ matrix.folder }}
-      


### PR DESCRIPTION
- It seems reasonable to add a dedicated go-test workflow, and exclude helpers/foundation-deployer from the Integration tests