### PR TITLE
fix: #1231 - align 1-org labels

### DIFF
--- a/1-org/envs/shared/projects.tf
+++ b/1-org/envs/shared/projects.tf
@@ -176,7 +176,7 @@ module "interconnect" {
 
   labels = {
     environment       = "network"
-    application_name  = "org-interconnect"
+    application_name  = "org-net-interconnect"
     billing_code      = "1234"
     primary_contact   = "example1"
     secondary_contact = "example2"
@@ -250,7 +250,7 @@ module "dns_hub" {
 
   labels = {
     environment       = "network"
-    application_name  = "org-dns-hub"
+    application_name  = "org-net-dns"
     billing_code      = "1234"
     primary_contact   = "example1"
     secondary_contact = "example2"


### PR DESCRIPTION
As part of #1231
discovered as part of 387 tef upstream sync