### PR TITLE
fix: update project-factory version in CI/CD projects

### DIFF
--- a/0-bootstrap/github.tf.example
+++ b/0-bootstrap/github.tf.example
@@ -70,7 +70,7 @@ locals {
 
 module "gh_cicd" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 12.0"
+  version = "~> 15.0"
 
   name              = "${var.project_prefix}-b-cicd-wif-gh"
   random_project_id = true

--- a/0-bootstrap/github.tf.example
+++ b/0-bootstrap/github.tf.example
@@ -42,7 +42,7 @@ locals {
     "PROJECT_ID" : module.gh_cicd.project_id,
     "WIF_PROVIDER_NAME" : module.gh_oidc.provider_name,
     "TF_BACKEND" : module.seed_bootstrap.gcs_bucket_tfstate,
-    "TF_VAR_gh_token": var.gh_token,
+    "TF_VAR_gh_token" : var.gh_token,
   }
 
   secrets_list = flatten([
@@ -90,7 +90,7 @@ module "gh_cicd" {
 }
 
 module "gh_oidc" {
-  source = "terraform-google-modules/github-actions-runners/google//modules/gh-oidc"
+  source  = "terraform-google-modules/github-actions-runners/google//modules/gh-oidc"
   version = "~> 3.1"
 
   project_id  = module.gh_cicd.project_id

--- a/0-bootstrap/gitlab.tf.example
+++ b/0-bootstrap/gitlab.tf.example
@@ -81,7 +81,7 @@ provider "gitlab" {
 
 module "gitlab_cicd" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 12.0"
+  version = "~> 15.0"
 
   name              = "${var.project_prefix}-b-cicd-wif-gl"
   random_project_id = true

--- a/0-bootstrap/modules/jenkins-agent/main.tf
+++ b/0-bootstrap/modules/jenkins-agent/main.tf
@@ -46,9 +46,10 @@ module "cicd_project" {
   Jenkins Agent GCE instance
 *******************************************/
 resource "google_service_account" "jenkins_agent_gce_sa" {
-  project      = module.cicd_project.project_id
-  account_id   = format("%s-%s", var.service_account_prefix, var.jenkins_agent_sa_email)
-  display_name = "Jenkins Agent (GCE instance) custom Service Account"
+  project                      = module.cicd_project.project_id
+  account_id                   = format("%s-%s", var.service_account_prefix, var.jenkins_agent_sa_email)
+  display_name                 = "Jenkins Agent (GCE instance) custom Service Account"
+  create_ignore_already_exists = true
 }
 
 data "template_file" "jenkins_agent_gce_startup_script" {

--- a/0-bootstrap/modules/tfc-agent-gke/main.tf
+++ b/0-bootstrap/modules/tfc-agent-gke/main.tf
@@ -82,10 +82,12 @@ module "network" {
  *****************************************/
 
 resource "google_service_account" "tfc_agent_service_account" {
-  count        = var.create_service_account ? 1 : 0
-  project      = var.project_id
-  account_id   = "tfc-agent-gke"
-  display_name = "Terraform Cloud agent GKE Service Account"
+  count = var.create_service_account ? 1 : 0
+
+  project                      = var.project_id
+  account_id                   = "tfc-agent-gke"
+  display_name                 = "Terraform Cloud agent GKE Service Account"
+  create_ignore_already_exists = true
 }
 
 /*****************************************

--- a/0-bootstrap/sa.tf
+++ b/0-bootstrap/sa.tf
@@ -140,9 +140,10 @@ locals {
 resource "google_service_account" "terraform-env-sa" {
   for_each = local.granular_sa
 
-  project      = module.seed_bootstrap.seed_project_id
-  account_id   = "sa-terraform-${each.key}"
-  display_name = each.value
+  project                      = module.seed_bootstrap.seed_project_id
+  account_id                   = "sa-terraform-${each.key}"
+  display_name                 = each.value
+  create_ignore_already_exists = true
 }
 
 module "org_iam_member" {

--- a/0-bootstrap/terraform_cloud.tf.example
+++ b/0-bootstrap/terraform_cloud.tf.example
@@ -52,25 +52,25 @@ locals {
       "1-shared" = { vcs_branch = "production", directory = "/envs/shared" }
     },
     "env" = {
-      "2-production"     = { vcs_branch = "production", directory = "/envs/production" },
+      "2-production"    = { vcs_branch = "production", directory = "/envs/production" },
       "2-nonproduction" = { vcs_branch = "nonproduction", directory = "/envs/nonproduction" },
-      "2-development"    = { vcs_branch = "development", directory = "/envs/development" },
+      "2-development"   = { vcs_branch = "development", directory = "/envs/development" },
     },
     "net" = {
-      "3-production"     = { vcs_branch = "production", directory = "/envs/production" },
+      "3-production"    = { vcs_branch = "production", directory = "/envs/production" },
       "3-nonproduction" = { vcs_branch = "nonproduction", directory = "/envs/nonproduction" },
-      "3-development"    = { vcs_branch = "development", directory = "/envs/development" },
-      "3-shared"         = { vcs_branch = "production", directory = "/envs/shared" },
+      "3-development"   = { vcs_branch = "development", directory = "/envs/development" },
+      "3-shared"        = { vcs_branch = "production", directory = "/envs/shared" },
     },
     "proj" = {
-      "4-bu1-production"     = { vcs_branch = "production", directory = "/business_unit_1/production" },
+      "4-bu1-production"    = { vcs_branch = "production", directory = "/business_unit_1/production" },
       "4-bu1-nonproduction" = { vcs_branch = "nonproduction", directory = "/business_unit_1/nonproduction" },
-      "4-bu1-development"    = { vcs_branch = "development", directory = "/business_unit_1/development" },
-      "4-bu1-shared"         = { vcs_branch = "production", directory = "/business_unit_1/shared" },
-      "4-bu2-production"     = { vcs_branch = "production", directory = "/business_unit_2/production" },
+      "4-bu1-development"   = { vcs_branch = "development", directory = "/business_unit_1/development" },
+      "4-bu1-shared"        = { vcs_branch = "production", directory = "/business_unit_1/shared" },
+      "4-bu2-production"    = { vcs_branch = "production", directory = "/business_unit_2/production" },
       "4-bu2-nonproduction" = { vcs_branch = "nonproduction", directory = "/business_unit_2/nonproduction" },
-      "4-bu2-development"    = { vcs_branch = "development", directory = "/business_unit_2/development" },
-      "4-bu2-shared"         = { vcs_branch = "production", directory = "/business_unit_2/shared" },
+      "4-bu2-development"   = { vcs_branch = "development", directory = "/business_unit_2/development" },
+      "4-bu2-shared"        = { vcs_branch = "production", directory = "/business_unit_2/shared" },
 
     },
   }

--- a/0-bootstrap/terraform_cloud.tf.example
+++ b/0-bootstrap/terraform_cloud.tf.example
@@ -230,7 +230,7 @@ resource "tfe_run_trigger" "projects_bu2_shared_production" {
 
 module "tfc_cicd" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 12.0"
+  version = "~> 15.0"
 
   name              = "${var.project_prefix}-b-cicd-wif-tfc"
   random_project_id = true

--- a/1-org/modules/cai-monitoring/iam.tf
+++ b/1-org/modules/cai-monitoring/iam.tf
@@ -57,8 +57,9 @@ resource "google_kms_crypto_key_iam_member" "encrypter_decrypter" {
 
 // Cloud Function SA
 resource "google_service_account" "cloudfunction" {
-  account_id = "cai-monitoring"
-  project    = var.project_id
+  account_id                   = "cai-monitoring"
+  project                      = var.project_id
+  create_ignore_already_exists = true
 }
 
 resource "google_organization_iam_member" "cloudfunction_findings_editor" {

--- a/5-app-infra/modules/env_base/main.tf
+++ b/5-app-infra/modules/env_base/main.tf
@@ -53,9 +53,10 @@ data "terraform_remote_state" "projects_env" {
 }
 
 resource "google_service_account" "compute_engine_service_account" {
-  project      = local.env_project_id
-  account_id   = "sa-example-app"
-  display_name = "Example app service Account"
+  project                      = local.env_project_id
+  account_id                   = "sa-example-app"
+  display_name                 = "Example app service Account"
+  create_ignore_already_exists = true
 }
 
 module "instance_template" {

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -56,9 +56,10 @@ resource "google_billing_account_iam_member" "billing_account_log_config" {
 }
 
 resource "google_service_account" "int_test" {
-  project      = module.project.project_id
-  account_id   = "ci-account"
-  display_name = "ci-account"
+  project                      = module.project.project_id
+  account_id                   = "ci-account"
+  display_name                 = "ci-account"
+  create_ignore_already_exists = true
 }
 
 resource "google_project_iam_member" "int_test" {


### PR DESCRIPTION
This PR updates the `project-factory` version in CI/CD projects and also adds the `create_ignore_already_exists` flag to the service accounts created in the foundation.
Fixes #1254 
