### PR TITLE
fix: bump terraform version from 1.3.10 to 1.5.7 

### DIFF
--- a/0-bootstrap/Dockerfile
+++ b/0-bootstrap/Dockerfile
@@ -15,7 +15,7 @@
 FROM gcr.io/cloud-builders/gcloud-slim
 
 # Use ARG so that values can be overriden by user/cloudbuild
-ARG TERRAFORM_VERSION=1.3.10
+ARG TERRAFORM_VERSION=1.5.7
 
 ENV ENV_TERRAFORM_VERSION=$TERRAFORM_VERSION
 

--- a/0-bootstrap/README-GitHub.md
+++ b/0-bootstrap/README-GitHub.md
@@ -17,6 +17,9 @@ To run the instructions described in this document, install the following:
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) version 2.28.0 or later
 - [Terraform](https://www.terraform.io/downloads.html) version 1.5.7  or later
 
+For the manual steps described in this document, you need to use the same [Terraform](https://www.terraform.io/downloads.html) version used on the build pipeline.
+Otherwise, you might experience Terraform state snapshot lock errors.
+
 Version 1.5.7 is the last version before the license model change. To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
 
 - 0-bootstrap/modules/jenkins-agent/variables.tf

--- a/0-bootstrap/README-GitHub.md
+++ b/0-bootstrap/README-GitHub.md
@@ -17,7 +17,7 @@ To run the instructions described in this document, install the following:
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) version 2.28.0 or later
 - [Terraform](https://www.terraform.io/downloads.html) version 1.5.7  or later
 
-To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
+Version 1.5.7 is the last version before the license model change. To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
 
 - 0-bootstrap/modules/jenkins-agent/variables.tf
    ```

--- a/0-bootstrap/README-GitHub.md
+++ b/0-bootstrap/README-GitHub.md
@@ -15,7 +15,40 @@ To run the instructions described in this document, install the following:
 - [Google Cloud SDK](https://cloud.google.com/sdk/install) version 393.0.0 or later
     - [terraform-tools](https://cloud.google.com/docs/terraform/policy-validation/validate-policies#install) component
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) version 2.28.0 or later
-- [Terraform](https://www.terraform.io/downloads.html) version 1.3.10  or later
+- [Terraform](https://www.terraform.io/downloads.html) version 1.5.7  or later
+
+To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
+
+- 0-bootstrap/modules/jenkins-agent/variables.tf
+   ```
+   default     = "1.5.7"
+   ```
+
+- 0-bootstrap/cb.tf
+   ```
+   terraform_version = "1.5.7"
+   ```
+
+- scripts/validate-requirements.sh
+   ```
+   TF_VERSION="1.5.7"
+   ```
+
+- build/github-tf-apply.yaml
+   ```
+   terraform_version: '1.5.7'
+   ```
+
+- github-tf-pull-request.yaml
+
+   ```
+   terraform_version: "1.5.7"
+   ```
+
+- 0-bootstrap/Dockerfile
+   ```
+   ARG TERRAFORM_VERSION=1.5.7
+   ```
 
 Also make sure that you have the following:
 

--- a/0-bootstrap/README-GitLab.md
+++ b/0-bootstrap/README-GitLab.md
@@ -13,8 +13,41 @@ To run the instructions described in this document, install the following:
 - [Google Cloud SDK](https://cloud.google.com/sdk/install) version 393.0.0 or later
     - [terraform-tools](https://cloud.google.com/docs/terraform/policy-validation/validate-policies#install) component
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) version 2.28.0 or later
-- [Terraform](https://www.terraform.io/downloads.html) version 1.3.10 or later
+- [Terraform](https://www.terraform.io/downloads.html) version 1.5.7 or later
 - [jq](https://jqlang.github.io/jq/) version 1.6 or later.
+
+To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
+
+- 0-bootstrap/modules/jenkins-agent/variables.tf
+   ```
+   default     = "1.5.7"
+   ```
+
+- 0-bootstrap/cb.tf
+   ```
+   terraform_version = "1.5.7"
+   ```
+
+- scripts/validate-requirements.sh
+   ```
+   TF_VERSION="1.5.7"
+   ```
+
+- build/github-tf-apply.yaml
+   ```
+   terraform_version: '1.5.7'
+   ```
+
+- github-tf-pull-request.yaml
+
+   ```
+   terraform_version: "1.5.7"
+   ```
+
+- 0-bootstrap/Dockerfile
+   ```
+   ARG TERRAFORM_VERSION=1.5.7
+   ```
 
 Also make sure that you have the following:
 

--- a/0-bootstrap/README-GitLab.md
+++ b/0-bootstrap/README-GitLab.md
@@ -16,7 +16,7 @@ To run the instructions described in this document, install the following:
 - [Terraform](https://www.terraform.io/downloads.html) version 1.5.7 or later
 - [jq](https://jqlang.github.io/jq/) version 1.6 or later.
 
-To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
+Version 1.5.7 is the last version before the license model change. To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
 
 - 0-bootstrap/modules/jenkins-agent/variables.tf
    ```

--- a/0-bootstrap/README-GitLab.md
+++ b/0-bootstrap/README-GitLab.md
@@ -16,6 +16,9 @@ To run the instructions described in this document, install the following:
 - [Terraform](https://www.terraform.io/downloads.html) version 1.5.7 or later
 - [jq](https://jqlang.github.io/jq/) version 1.6 or later.
 
+For the manual steps described in this document, you need to use the same [Terraform](https://www.terraform.io/downloads.html) version used on the build pipeline.
+Otherwise, you might experience Terraform state snapshot lock errors.
+
 Version 1.5.7 is the last version before the license model change. To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
 
 - 0-bootstrap/modules/jenkins-agent/variables.tf

--- a/0-bootstrap/README-Jenkins.md
+++ b/0-bootstrap/README-Jenkins.md
@@ -196,8 +196,42 @@ You arrived to these instructions because you are using the `jenkins_bootstrap` 
 ### II. Create the SEED and CI/CD projects using Terraform
 
 - Required information:
-  - Terraform version 1.3.10 - See [Requirements](#requirements) section for more details.
+  - Terraform version 1.5.7 - See [Requirements](#requirements) section for more details.
   - The `terraform.tfvars` file with all the necessary values.
+
+To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
+
+- 0-bootstrap/modules/jenkins-agent/variables.tf
+   ```
+   default     = "1.5.7"
+   ```
+
+- 0-bootstrap/cb.tf
+   ```
+   terraform_version = "1.5.7"
+   ```
+
+- scripts/validate-requirements.sh
+   ```
+   TF_VERSION="1.5.7"
+   ```
+
+- build/github-tf-apply.yaml
+   ```
+   terraform_version: '1.5.7'
+   ```
+
+- github-tf-pull-request.yaml
+
+   ```
+   terraform_version: "1.5.7"
+   ```
+
+- 0-bootstrap/Dockerfile
+   ```
+   ARG TERRAFORM_VERSION=1.5.7
+   ```
+
 
 1. Get the appropriate credentials: run the following command with an account that has the [necessary permissions](./modules/jenkins-agent/README.md#permissions).
 
@@ -209,7 +243,7 @@ You arrived to these instructions because you are using the `jenkins_bootstrap` 
 
 1. Run terraform commands.
    - After the credentials are configured, we will create the `prj-b-seed` project (which contains the GCS state bucket and Terraform custom service account) and the `prj-b-cicd` project (which contains the Jenkins Agent, its custom service account and where we will add VPN configuration)
-   - **Use Terraform 1.3.10** to run the terraform script with the commands below
+   - **Use Terraform 1.5.7** to run the terraform script with the commands below
 
    ```bash
    terraform init

--- a/0-bootstrap/README-Jenkins.md
+++ b/0-bootstrap/README-Jenkins.md
@@ -199,7 +199,7 @@ You arrived to these instructions because you are using the `jenkins_bootstrap` 
   - Terraform version 1.5.7 - See [Requirements](#requirements) section for more details.
   - The `terraform.tfvars` file with all the necessary values.
 
-To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
+Version 1.5.7 is the last version before the license model change. To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
 
 - 0-bootstrap/modules/jenkins-agent/variables.tf
    ```

--- a/0-bootstrap/README-Jenkins.md
+++ b/0-bootstrap/README-Jenkins.md
@@ -199,6 +199,9 @@ You arrived to these instructions because you are using the `jenkins_bootstrap` 
   - Terraform version 1.5.7 - See [Requirements](#requirements) section for more details.
   - The `terraform.tfvars` file with all the necessary values.
 
+For the manual steps described in this document, you need to use the same [Terraform](https://www.terraform.io/downloads.html) version used on the build pipeline.
+Otherwise, you might experience Terraform state snapshot lock errors.
+
 Version 1.5.7 is the last version before the license model change. To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
 
 - 0-bootstrap/modules/jenkins-agent/variables.tf

--- a/0-bootstrap/README-Terraform-Cloud.md
+++ b/0-bootstrap/README-Terraform-Cloud.md
@@ -17,7 +17,7 @@ To run the instructions described in this document, install the following:
 - [Google Cloud SDK](https://cloud.google.com/sdk/install) version 393.0.0 or later
     - [terraform-tools](https://cloud.google.com/docs/terraform/policy-validation/validate-policies#install) component
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) version 2.28.0 or later
-- [Terraform](https://www.terraform.io/downloads.html) version 1.3.10  or later
+- [Terraform](https://www.terraform.io/downloads.html) version 1.5.7 or later
 - [jq](https://jqlang.github.io/jq/download/) version 1.6.0 or later
 
 Also make sure that you have the following:

--- a/0-bootstrap/README-Terraform-Cloud.md
+++ b/0-bootstrap/README-Terraform-Cloud.md
@@ -20,6 +20,9 @@ To run the instructions described in this document, install the following:
 - [Terraform](https://www.terraform.io/downloads.html) version 1.5.7 or later
 - [jq](https://jqlang.github.io/jq/download/) version 1.6.0 or later
 
+For the manual steps described in this document, you need to use the same [Terraform](https://www.terraform.io/downloads.html) version used on the build pipeline.
+Otherwise, you might experience Terraform state snapshot lock errors.
+
 Also make sure that you have the following:
 
 - A [Terraform Cloud account](https://developer.hashicorp.com/terraform/tutorials/cloud-get-started/cloud-sign-up#create-an-account) for your User or [Organization](https://developer.hashicorp.com/terraform/tutorials/cloud-get-started/cloud-sign-up#create-an-organization).

--- a/0-bootstrap/README.md
+++ b/0-bootstrap/README.md
@@ -64,10 +64,43 @@ To run the commands described in this document, install the following:
 
 - [Google Cloud SDK](https://cloud.google.com/sdk/install) version 393.0.0 or later
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) version 2.28.0 or later
-- [Terraform](https://www.terraform.io/downloads.html) version 1.3.10
+- [Terraform](https://www.terraform.io/downloads.html) version 1.5.7
 - [jq](https://jqlang.github.io/jq/download/) version 1.6.0 or later
 
-**Note:** Make sure that you use version 1.3.10 of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
+**Note:** Make sure that you use version 1.5.7 of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
+
+To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
+
+- 0-bootstrap/modules/jenkins-agent/variables.tf
+   ```
+   default     = "1.5.7"
+   ```
+
+- 0-bootstrap/cb.tf
+   ```
+   terraform_version = "1.5.7"
+   ```
+
+- scripts/validate-requirements.sh
+   ```
+   TF_VERSION="1.5.7"
+   ```
+
+- build/github-tf-apply.yaml
+   ```
+   terraform_version: '1.5.7'
+   ```
+
+- github-tf-pull-request.yaml
+
+   ```
+   terraform_version: "1.5.7"
+   ```
+
+- 0-bootstrap/Dockerfile
+   ```
+   ARG TERRAFORM_VERSION=1.5.7
+   ```
 
 Also make sure that you've done the following:
 

--- a/0-bootstrap/README.md
+++ b/0-bootstrap/README.md
@@ -69,7 +69,7 @@ To run the commands described in this document, install the following:
 
 **Note:** Make sure that you use version 1.5.7 of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
 
-To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
+Version 1.5.7 is the last version before the license model change. To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
 
 - 0-bootstrap/modules/jenkins-agent/variables.tf
    ```

--- a/0-bootstrap/README.md
+++ b/0-bootstrap/README.md
@@ -67,7 +67,7 @@ To run the commands described in this document, install the following:
 - [Terraform](https://www.terraform.io/downloads.html) version 1.5.7
 - [jq](https://jqlang.github.io/jq/download/) version 1.6.0 or later
 
-**Note:** Make sure that you use version 1.5.7 of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
+**Note:** Make sure that you use the same version of [Terraform](https://www.terraform.io/downloads.html) throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
 
 Version 1.5.7 is the last version before the license model change. To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
 

--- a/0-bootstrap/cb.tf
+++ b/0-bootstrap/cb.tf
@@ -16,7 +16,7 @@
 
 locals {
   // terraform version image configuration
-  terraform_version = "1.3.10"
+  terraform_version = "1.5.7"
   // The version of the terraform docker image to be used in the workspace builds
   docker_tag_version_terraform = "v1"
 

--- a/0-bootstrap/modules/jenkins-agent/README.md
+++ b/0-bootstrap/modules/jenkins-agent/README.md
@@ -77,7 +77,7 @@ module "jenkins_bootstrap" {
 | storage\_bucket\_prefix | Name prefix to use for storage buckets. | `string` | `"bkt"` | no |
 | terraform\_sa\_names | Fully-qualified name of the Terraform Service Accounts. It must be supplied by the Seed Project | `map(string)` | n/a | yes |
 | terraform\_state\_bucket | Default state bucket, used in Cloud Build substitutions. It must be supplied by the Seed Project | `string` | n/a | yes |
-| terraform\_version | Default terraform version. | `string` | `"1.3.10"` | no |
+| terraform\_version | Default terraform version. | `string` | `"1.5.7"` | no |
 | terraform\_version\_sha256sum | sha256sum for default terraform version. | `string` | `"380ca822883176af928c80e5771d1c0ac9d69b13c6d746e6202482aedde7d457"` | no |
 | tunnel0\_bgp\_peer\_address | BGP peer address for tunnel 0 | `string` | n/a | yes |
 | tunnel0\_bgp\_session\_range | BGP session range for tunnel 0 | `string` | n/a | yes |
@@ -103,8 +103,8 @@ module "jenkins_bootstrap" {
 ### Software
 
 - [gcloud sdk](https://cloud.google.com/sdk/install) >= 393.0.0
-- [Terraform](https://www.terraform.io/downloads.html) = 1.3.10
-  - The scripts in this codebase use Terraform v1.3.10. You should use the same version in the manual steps to avoid [Terraform State Snapshot Lock](https://github.com/hashicorp/terraform/issues/23290) errors caused by differences in terraform versions.
+- [Terraform](https://www.terraform.io/downloads.html) = 1.5.7
+  - The scripts in this codebase use Terraform v1.5.7. You should use the same version in the manual steps to avoid [Terraform State Snapshot Lock](https://github.com/hashicorp/terraform/issues/23290) errors caused by differences in terraform versions.
 
 ### Infrastructure
 

--- a/0-bootstrap/modules/jenkins-agent/variables.tf
+++ b/0-bootstrap/modules/jenkins-agent/variables.tf
@@ -215,7 +215,7 @@ variable "folder_id" {
 variable "terraform_version" {
   description = "Default terraform version."
   type        = string
-  default     = "1.3.10"
+  default     = "1.5.7"
 }
 
 variable "terraform_version_sha256sum" {

--- a/3-networks-dual-svpc/README.md
+++ b/3-networks-dual-svpc/README.md
@@ -73,9 +73,8 @@ The purpose of this step is to:
    echo "access_context_manager_policy_id = ${ACCESS_CONTEXT_MANAGER_ID}"
    ```
 
-1. For the manual step described in this document, you need [Terraform](https://www.terraform.io/downloads.html) version 1.5.7 or later to be installed.
-
-**Note:** Make sure that you use version 1.5.7 or later of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
+1. For the manual step described in this document, you need to use the same [Terraform](https://www.terraform.io/downloads.html) version used on the build pipeline.
+Otherwise, you might experience Terraform state snapshot lock errors.
 
 ### Troubleshooting
 

--- a/3-networks-dual-svpc/README.md
+++ b/3-networks-dual-svpc/README.md
@@ -73,9 +73,9 @@ The purpose of this step is to:
    echo "access_context_manager_policy_id = ${ACCESS_CONTEXT_MANAGER_ID}"
    ```
 
-1. For the manual step described in this document, you need [Terraform](https://www.terraform.io/downloads.html) version 1.3.10 or later to be installed.
+1. For the manual step described in this document, you need [Terraform](https://www.terraform.io/downloads.html) version 1.5.7 or later to be installed.
 
-**Note:** Make sure that you use version 1.3.10 or later of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
+**Note:** Make sure that you use version 1.5.7 or later of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
 
 ### Troubleshooting
 

--- a/3-networks-hub-and-spoke/README.md
+++ b/3-networks-hub-and-spoke/README.md
@@ -73,9 +73,8 @@ The purpose of this step is to:
    echo "access_context_manager_policy_id = ${ACCESS_CONTEXT_MANAGER_ID}"
    ```
 
-1. For the manual step described in this document, you need [Terraform](https://www.terraform.io/downloads.html) version 1.5.7 or later to be installed.
-
-**Note:** Make sure that you use version 1.5.7 or later of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
+1. For the manual step described in this document, you need to use the same [Terraform](https://www.terraform.io/downloads.html) version used on the build pipeline.
+Otherwise, you might experience Terraform state snapshot lock errors.
 
 ### Troubleshooting
 

--- a/3-networks-hub-and-spoke/README.md
+++ b/3-networks-hub-and-spoke/README.md
@@ -73,9 +73,9 @@ The purpose of this step is to:
    echo "access_context_manager_policy_id = ${ACCESS_CONTEXT_MANAGER_ID}"
    ```
 
-1. For the manual step described in this document, you need [Terraform](https://www.terraform.io/downloads.html) version 1.3.10 or later to be installed.
+1. For the manual step described in this document, you need [Terraform](https://www.terraform.io/downloads.html) version 1.5.7 or later to be installed.
 
-**Note:** Make sure that you use version 1.3.10 or later of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
+**Note:** Make sure that you use version 1.5.7 or later of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
 
 ### Troubleshooting
 

--- a/4-projects/README.md
+++ b/4-projects/README.md
@@ -72,9 +72,9 @@ Other Workspaces can also be created to isolate deployments if needed.
 1. 2-environments executed successfully.
 1. 3-networks executed successfully.
 
-1. For the manual step described in this document, you need [Terraform](https://www.terraform.io/downloads.html) version 1.3.10 or later to be installed.
+1. For the manual step described in this document, you need [Terraform](https://www.terraform.io/downloads.html) version 1.5.7 or later to be installed.
 
-   **Note:** Make sure that you use version 1.3.10 or later of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
+   **Note:** Make sure that you use version 1.5.7 or later of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
 
    **Note 2:** As mentioned in 0-bootstrap [README note 2](../0-bootstrap/README.md#deploying-with-cloud-build) at the end of Cloud Build deploy section, make sure that you have requested at least 50 additional projects for the **projects step service account**, otherwise you may face a project quota exceeded error message during the following steps and you will need to apply the fix from [this entry](../docs/TROUBLESHOOTING.md#attempt-to-run-4-projects-step-without-enough-project-quota) of the Troubleshooting guide in order to continue.
 

--- a/4-projects/README.md
+++ b/4-projects/README.md
@@ -72,11 +72,10 @@ Other Workspaces can also be created to isolate deployments if needed.
 1. 2-environments executed successfully.
 1. 3-networks executed successfully.
 
-1. For the manual step described in this document, you need [Terraform](https://www.terraform.io/downloads.html) version 1.5.7 or later to be installed.
+1. For the manual step described in this document, you need to use the same [Terraform](https://www.terraform.io/downloads.html) version used on the build pipeline.
+Otherwise, you might experience Terraform state snapshot lock errors.
 
-   **Note:** Make sure that you use version 1.5.7 or later of Terraform throughout this series. Otherwise, you might experience Terraform state snapshot lock errors.
-
-   **Note 2:** As mentioned in 0-bootstrap [README note 2](../0-bootstrap/README.md#deploying-with-cloud-build) at the end of Cloud Build deploy section, make sure that you have requested at least 50 additional projects for the **projects step service account**, otherwise you may face a project quota exceeded error message during the following steps and you will need to apply the fix from [this entry](../docs/TROUBLESHOOTING.md#attempt-to-run-4-projects-step-without-enough-project-quota) of the Troubleshooting guide in order to continue.
+   **Note:** As mentioned in 0-bootstrap [README note 2](../0-bootstrap/README.md#deploying-with-cloud-build) at the end of Cloud Build deploy section, make sure that you have requested at least 50 additional projects for the **projects step service account**, otherwise you may face a project quota exceeded error message during the following steps and you will need to apply the fix from [this entry](../docs/TROUBLESHOOTING.md#attempt-to-run-4-projects-step-without-enough-project-quota) of the Troubleshooting guide in order to continue.
 
 ### Troubleshooting
 

--- a/build/github-tf-apply.yaml
+++ b/build/github-tf-apply.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - uses: 'hashicorp/setup-terraform@v2'
         with:
-          terraform_version: '1.3'
+          terraform_version: '1.5.7'
 
       - id: setup
         shell: bash

--- a/build/github-tf-pull-request.yaml
+++ b/build/github-tf-pull-request.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: "hashicorp/setup-terraform@v2"
         with:
-          terraform_version: "1.3"
+          terraform_version: "1.5.7"
 
       - id: setup
         shell: bash

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -90,12 +90,12 @@ This could be due to init.defaultBranch being set to something other than
 When running the build for the branch `production` in step 3-networks in your **Foundation CI/CD Pipeline** the build fails with:
 
 ```
-state snapshot was created by Terraform v1.x.x, which is newer than current v1.3.10; upgrade to Terraform v1.x.x or greater to work with this state
+state snapshot was created by Terraform v1.x.x, which is newer than current v1.5.7; upgrade to Terraform v1.x.x or greater to work with this state
 ```
 
 **Cause:**
 
-The manual deploy step for the shared environment in [3-networks](../3-networks#deploying-with-cloud-build) was executed with a Terraform version newer than version v1.3.10 used in the **Foundation CI/CD Pipeline**.
+The manual deploy step for the shared environment in [3-networks](../3-networks#deploying-with-cloud-build) was executed with a Terraform version newer than version v1.5.7 used in the **Foundation CI/CD Pipeline**.
 
 **Solution:**
 
@@ -103,7 +103,7 @@ You have two options:
 
 #### Downgrade your local Terraform version
 
-You will need to re-run the deploy of the 3-networks shared environment with Terraform v1.3.10.
+You will need to re-run the deploy of the 3-networks shared environment with Terraform v1.5.7.
 
 Steps:
 
@@ -111,8 +111,8 @@ Steps:
 - Update `backend.tf` with your bucket name from the 0-bootstrap step.
 - Run `terraform destroy` in the folder using the Terraform v1.x.x version.
 - Delete the Terraform state file in `gs://YOUR-TF-STATE-BUCKET/terraform/networks/envs/shared/default.tfstate`. This bucket is in your **Seed Project**.
-- Install Terraform v1.3.10.
-- Re-run the manual deploy of 3-networks shared environment using Terraform v1.3.10.
+- Install Terraform v1.5.7.
+- Re-run the manual deploy of 3-networks shared environment using Terraform v1.5.7.
 
 #### Upgrade your 0-bootstrap runner image Terraform version
 
@@ -120,7 +120,7 @@ Replace `1.x.x` with the actual version of your local Terraform version in the f
 
 - Go to folder `0-bootstrap`.
 - Edit the local `terraform_version` in the Terraform [cb.tf](../0-bootstrap/cb.tf) file:
-  - Upgrade local `terraform_version` from `"1.3.10"` to `"1.x.x"`
+  - Upgrade local `terraform_version` from `"1.5.7"` to `"1.x.x"`
 - Run `terraform init`.
 - Run `terraform plan` and review the output.
 - Run `terraform apply`.

--- a/helpers/foundation-deployer/README.md
+++ b/helpers/foundation-deployer/README.md
@@ -6,15 +6,48 @@ Helper tool to deploy the Terraform example foundation using Cloud Build and Clo
 
 ## Requirements
 
-- [Go](https://go.dev/doc/install) 1.21+
-- [Google Cloud SDK](https://cloud.google.com/sdk/install) version 393.0.0+
-- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) version 2.28.0+
-- [Terraform](https://www.terraform.io/downloads.html) version 1.3.10+
+- [Go](https://go.dev/doc/install) 1.21 or later
+- [Google Cloud SDK](https://cloud.google.com/sdk/install) version 393.0.0 or later
+- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) version 2.28.0 or later
+- [Terraform](https://www.terraform.io/downloads.html) version 1.5.7 or later
 - See `0-bootstrap` README for additional IAM [requirements](../../0-bootstrap/README.md#prerequisites) on the user deploying the Foundation.
+
+To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
+
+- 0-bootstrap/modules/jenkins-agent/variables.tf
+   ```
+   default     = "1.5.7"
+   ```
+
+- 0-bootstrap/cb.tf
+   ```
+   terraform_version = "1.5.7"
+   ```
+
+- scripts/validate-requirements.sh
+   ```
+   TF_VERSION="1.5.7"
+   ```
+
+- build/github-tf-apply.yaml
+   ```
+   terraform_version: '1.5.7'
+   ```
+
+- github-tf-pull-request.yaml
+
+   ```
+   terraform_version: "1.5.7"
+   ```
+
+- 0-bootstrap/Dockerfile
+   ```
+   ARG TERRAFORM_VERSION=1.5.7
+   ```
 
 ### Validate required tools
 
-- Check if required tools, Go 1.21.0+, Terraform 1.3.10+, gcloud 393.0.0+, and Git 2.28.0+, are installed:
+- Check if required tools, Go 1.21.0+, Terraform 1.5.7+, gcloud 393.0.0+, and Git 2.28.0+, are installed:
 
     ```bash
     go version

--- a/helpers/foundation-deployer/README.md
+++ b/helpers/foundation-deployer/README.md
@@ -12,6 +12,9 @@ Helper tool to deploy the Terraform example foundation using Cloud Build and Clo
 - [Terraform](https://www.terraform.io/downloads.html) version 1.5.7 or later
 - See `0-bootstrap` README for additional IAM [requirements](../../0-bootstrap/README.md#prerequisites) on the user deploying the Foundation.
 
+Your environment need to use the same [Terraform](https://www.terraform.io/downloads.html) version used on the build pipeline.
+Otherwise, you might experience Terraform state snapshot lock errors.
+
 Version 1.5.7 is the last version before the license model change. To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
 
 - 0-bootstrap/modules/jenkins-agent/variables.tf

--- a/helpers/foundation-deployer/README.md
+++ b/helpers/foundation-deployer/README.md
@@ -12,7 +12,7 @@ Helper tool to deploy the Terraform example foundation using Cloud Build and Clo
 - [Terraform](https://www.terraform.io/downloads.html) version 1.5.7 or later
 - See `0-bootstrap` README for additional IAM [requirements](../../0-bootstrap/README.md#prerequisites) on the user deploying the Foundation.
 
-To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
+Version 1.5.7 is the last version before the license model change. To use a later version of Terraform, ensure that the Terraform version used in the Operational System to manually execute part of the steps in `3-networks` and `4-projects` is the same version configured in the following code
 
 - 0-bootstrap/modules/jenkins-agent/variables.tf
    ```

--- a/helpers/foundation-deployer/README.md
+++ b/helpers/foundation-deployer/README.md
@@ -6,7 +6,7 @@ Helper tool to deploy the Terraform example foundation using Cloud Build and Clo
 
 ## Requirements
 
-- [Go](https://go.dev/doc/install) 1.21 or later
+- [Go](https://go.dev/doc/install) 1.22 or later
 - [Google Cloud SDK](https://cloud.google.com/sdk/install) version 393.0.0 or later
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) version 2.28.0 or later
 - [Terraform](https://www.terraform.io/downloads.html) version 1.5.7 or later
@@ -50,7 +50,7 @@ Version 1.5.7 is the last version before the license model change. To use a late
 
 ### Validate required tools
 
-- Check if required tools, Go 1.21.0+, Terraform 1.5.7+, gcloud 393.0.0+, and Git 2.28.0+, are installed:
+- Check if required tools, Go 1.22.0+, Terraform 1.5.7+, gcloud 393.0.0+, and Git 2.28.0+, are installed:
 
     ```bash
     go version

--- a/scripts/validate-requirements.sh
+++ b/scripts/validate-requirements.sh
@@ -19,7 +19,7 @@
 
 # -------------------------- Variables --------------------------
 # Expected versions of the installers
-TF_VERSION="1.3.10"
+TF_VERSION="1.5.7"
 # Version 393.0.0 due to terraform-tools 0.5.0 version that fixes the issue
 # mentioned in this PR https://github.com/terraform-google-modules/terraform-example-foundation/pull/729#discussion_r919427668
 GCLOUD_SDK_VERSION="393.0.0"


### PR DESCRIPTION
Bump Terrafom version from [1.3.10](https://github.com/hashicorp/terraform/tree/v1.3.10) to [1.5.7](https://github.com/hashicorp/terraform/tree/v1.5.7)

Version 1.5.7 is the last version before the License change from [Mozilla Public License, version 2.0](https://github.com/hashicorp/terraform/blob/v1.5.7/LICENSE) to [Business Source License 1.1](https://github.com/hashicorp/terraform/blob/main/LICENSE)
