### PR TITLE
fix(docs): Update 3-networks-dual-svpc README after accidental change

### DIFF
--- a/3-networks-dual-svpc/README.md
+++ b/3-networks-dual-svpc/README.md
@@ -59,7 +59,7 @@ For an overview of the architecture and the parts, see the
 The purpose of this step is to:
 
 - Set up the global [DNS Hub](https://cloud.google.com/blog/products/networking/cloud-forwarding-peering-and-zones).
-- Set up base and restricted Hubs and it corresponding Spokes. With default DNS, NAT (optional), Private Service networking, VPC Service Controls (optional), on-premises Dedicated or Partner Interconnect, and baseline firewall rules for each environment.
+- Set up base and restricted shared VPCs with default DNS, NAT (optional), Private Service networking, VPC Service Controls (optional), on-premises Dedicated or Partner Interconnect, and baseline firewall rules for each environment.
 
 ## Prerequisites
 


### PR DESCRIPTION
I believe this was accidentally changed in when updating README here: https://github.com/terraform-google-modules/terraform-example-foundation/pull/1210/files#diff-103694d8c8f2d87c3ec2f998d3bee4062552b630380365062470339c52531465L61