### PR TITLE
fix: remove LOG_EXECUTION_ID from environment variables

### DIFF
--- a/1-org/modules/cai-monitoring/main.tf
+++ b/1-org/modules/cai-monitoring/main.tf
@@ -164,7 +164,6 @@ module "cloud_function" {
     runtime_env_variables = {
       ROLES            = join(",", var.roles_to_monitor)
       SOURCE_ID        = google_scc_source.cai_monitoring.id
-      LOG_EXECUTION_ID = "true"
     }
   }
 


### PR DESCRIPTION
This PR removes the `LOG_EXECUTION_ID` previously added to the  environment variables of the Cloud Function gen2 used in step `1-org`