### PR TITLE
fix: bump version of terraform provider on cai-monitoring module

### DIFF
--- a/1-org/modules/cai-monitoring/main.tf
+++ b/1-org/modules/cai-monitoring/main.tf
@@ -162,9 +162,8 @@ module "cloud_function" {
   service_config = {
     service_account_email = google_service_account.cloudfunction.email
     runtime_env_variables = {
-      ROLES            = join(",", var.roles_to_monitor)
-      SOURCE_ID        = google_scc_source.cai_monitoring.id
-      LOG_EXECUTION_ID = "true"
+      ROLES     = join(",", var.roles_to_monitor)
+      SOURCE_ID = google_scc_source.cai_monitoring.id
     }
   }
 

--- a/1-org/modules/cai-monitoring/versions.tf
+++ b/1-org/modules/cai-monitoring/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.77, <=5.37"
+      version = ">= 5.42"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.77, <=5.37"
+      version = ">= 5.42"
     }
     random = {
       source = "hashicorp/random"


### PR DESCRIPTION
This PR bumps the version of the terraform provider on cai-monitoring module to `">= 5.42"` to fix #1306

Terraform provider `5.42.0` [release notes](https://github.com/hashicorp/terraform-provider-google/releases/tag/v5.42.0)