### PR TITLE
fix: fix location variables for step 4-projects in deploy helper

### DIFF
--- a/helpers/foundation-deployer/README.md
+++ b/helpers/foundation-deployer/README.md
@@ -11,6 +11,7 @@ Helper tool to deploy the Terraform example foundation using Cloud Build and Clo
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) version 2.28.0 or later
 - [Terraform](https://www.terraform.io/downloads.html) version 1.5.7 or later
 - See `0-bootstrap` README for additional IAM [requirements](../../0-bootstrap/README.md#prerequisites) on the user deploying the Foundation.
+- To enable Security Command Center, choose a Security Command Center tier and create and grant permissions for the Security Command Center service account as described in [Setting up Security Command Center](https://cloud.google.com/security-command-center/docs/quickstart-security-command-center).
 
 Your environment need to use the same [Terraform](https://www.terraform.io/downloads.html) version used on the build pipeline.
 Otherwise, you might experience Terraform state snapshot lock errors.

--- a/helpers/foundation-deployer/global.tfvars.example
+++ b/helpers/foundation-deployer/global.tfvars.example
@@ -142,5 +142,5 @@ target_name_server_addresses = [
 // Can be used to override the default region set in 0-bootstrap
 // See https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/4-projects/business_unit_1/production/README.md#outputs
 
-gcs_location = "US"
-kms_location = "us"
+location_kms = "us"
+location_gcs = "US"

--- a/helpers/foundation-deployer/stages/apply.go
+++ b/helpers/foundation-deployer/stages/apply.go
@@ -338,8 +338,8 @@ func DeployProjectsStage(t testing.TB, s steps.Steps, tfvars GlobalTFVars, outpu
 	}
 	//for each environment
 	envTfvars := ProjEnvTfvars{
-		ProjectsKMSLocation: tfvars.ProjectsKMSLocation,
-		ProjectsGCSLocation: tfvars.ProjectsGCSLocation,
+		LocationKMS: tfvars.LocationKMS,
+		LocationGCS: tfvars.LocationGCS,
 	}
 	for _, envfile := range []string{
 		"development.auto.tfvars",

--- a/helpers/foundation-deployer/stages/data.go
+++ b/helpers/foundation-deployer/stages/data.go
@@ -152,8 +152,8 @@ type GlobalTFVars struct {
 	EnableHubAndSpoke                     bool            `hcl:"enable_hub_and_spoke"`
 	EnableHubAndSpokeTransitivity         bool            `hcl:"enable_hub_and_spoke_transitivity"`
 	CreateUniqueTagKey                    bool            `hcl:"create_unique_tag_key"`
-	ProjectsKMSLocation                   string          `hcl:"projects_kms_location"`
-	ProjectsGCSLocation                   string          `hcl:"projects_gcs_location"`
+	LocationKMS                           string          `hcl:"location_kms"`
+	LocationGCS                           string          `hcl:"location_gcs"`
 	CodeCheckoutPath                      string          `hcl:"code_checkout_path"`
 	FoundationCodePath                    string          `hcl:"foundation_code_path"`
 	ValidatorProjectId                    *string         `hcl:"validator_project_id"`
@@ -250,8 +250,8 @@ type ProjSharedTfvars struct {
 }
 
 type ProjEnvTfvars struct {
-	ProjectsKMSLocation string `hcl:"projects_kms_location"`
-	ProjectsGCSLocation string `hcl:"projects_gcs_location"`
+	LocationKMS string `hcl:"location_kms"`
+	LocationGCS string `hcl:"location_gcs"`
 }
 
 type AppInfraCommonTfvars struct {


### PR DESCRIPTION
This PR fixes the two location variables (KMS and GCS) for step 4-projects in the deploy helper.
Instructions about enablement of the Security Command Center  to the Helper README were also added.