### PR TITLE
fix: increase google provider request_timeout

### DIFF
--- a/0-bootstrap/provider.tf
+++ b/0-bootstrap/provider.tf
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 
+provider "google" {
+  request_timeout = "5m"
+}
+
 provider "google-beta" {
   user_project_override = true
   billing_project       = var.groups.billing_project
+  request_timeout       = "5m"
 }
 
 # If you are using Terraform Cloud Agents, un-comment this block after the first apply according README instructions


### PR DESCRIPTION
This PR  increases the  Google provider [request_timeout](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#request_timeout) in step bootstrap to 5 minutes 