### PR TITLE
fix: Retries exceeded in 1-org destroy step

### DIFF
--- a/1-org/modules/centralized-logging/main.tf
+++ b/1-org/modules/centralized-logging/main.tf
@@ -189,6 +189,7 @@ resource "terracurl_request" "exclude_external_logs" {
   count = var.project_options != null ? 1 : 0
 
   name           = "exclude_external_logs"
+  destroy_skip   = true
   url            = "https://logging.googleapis.com/v2/projects/${var.logging_destination_project_id}/sinks/_Default?updateMask=exclusions"
   method         = "PUT"
   response_codes = [200]

--- a/1-org/modules/centralized-logging/versions.tf
+++ b/1-org/modules/centralized-logging/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     terracurl = {
       source  = "devops-rob/terracurl"
-      version = "1.2.1"
+      version = "1.2.2"
     }
   }
 }


### PR DESCRIPTION
This PR fixes the error below that occurs during the destroy-org step, causing the build to fail.

```
Step #33 - "destroy-org":             Error:          Received unexpected error:
Step #33 - "destroy-org":                             FatalError{Underlying: error while running command: exit status 1; 
Step #33 - "destroy-org":                             Error: unable to make request: request failed, retries exceeded: %!s(<nil>)
Step #33 - "destroy-org":                             }
Step #33 - "destroy-org":             Test:           TestOrg
Step #33 - "destroy-org": --- FAIL: TestOrg (150.66s)
Step #33 - "destroy-org": FAIL
Step #33 - "destroy-org": FAIL    github.com/terraform-google-modules/terraform-example-foundation/test/integration/org    150.716s
```