### PR TITLE
chore(deps): update tfc-oidc module to v0.2.0

### DIFF
--- a/0-bootstrap/terraform_cloud.tf.example
+++ b/0-bootstrap/terraform_cloud.tf.example
@@ -257,7 +257,7 @@ module "tfc_cicd" {
 
 module "tfc-oidc" {
   source  = "GoogleCloudPlatform/tf-cloud-agents/google//modules/tfc-oidc"
-  version = "0.1.0"
+  version = "0.2.0"
 
   project_id            = module.tfc_cicd.project_id
   pool_id               = "foundation-pool"


### PR DESCRIPTION
version 0.1.0 has a google provider version constraint < v5
it prevented terraform init to find a proper gcp provider version