### PR TITLE
fix: correct github-tf-pull-request comment detection

### DIFF
--- a/build/github-tf-pull-request.yaml
+++ b/build/github-tf-pull-request.yaml
@@ -78,7 +78,7 @@ jobs:
               issue_number: context.issue.number,
             })
             const botComment = comments.find(comment => {
-              return comment.user.type === 'Bot' && comment.body.includes('Terraform Initialization')
+              return comment.user.type === 'Bot' && comment.body.includes('Terraform Plan Validate All')
             })
 
             const run_url = process.env.GITHUB_SERVER_URL + '/' + process.env.GITHUB_REPOSITORY + '/actions/runs/' + process.env.GITHUB_RUN_ID


### PR DESCRIPTION
Hi, I noticed the action was creating duplicate comments because it couldn’t detect the existing bot comment. This update adjusts the matching logic so the workflow can properly find and update the previous comment. Let me know if anything should be adjusted.