### PR TITLE
fix(cai-monitoring): update module.cloud_function's `function_location` input to `location`

### DIFF
--- a/1-org/modules/cai-monitoring/main.tf
+++ b/1-org/modules/cai-monitoring/main.tf
@@ -142,13 +142,13 @@ resource "google_scc_v2_organization_source" "cai_monitoring" {
 // Cloud Function
 module "cloud_function" {
   source  = "GoogleCloudPlatform/cloud-functions/google"
-  version = "~> 0.6"
+  version = "~> 0.8"
 
   function_name         = "caiMonitoring"
   description           = "Check on the Organization for members (users, groups and service accounts) that contains the IAM roles listed."
   project_id            = var.project_id
   labels                = var.labels
-  function_location     = var.location
+  location              = var.location
   runtime               = "nodejs20"
   entrypoint            = "caiMonitoring"
   docker_repository     = google_artifact_registry_repository.cloudfunction.id


### PR DESCRIPTION
The upstream module has made a breaking change to deprecate `function_location` to `location`, breaking this `cai-monitoring` module.

ref: https://github.com/GoogleCloudPlatform/terraform-google-cloud-functions/pull/194/changes