### PR TITLE
fix(bootstrap): correct backend bucket mapping for project pipeline secrets

### DIFF
--- a/0-bootstrap/build_github.tf.example
+++ b/0-bootstrap/build_github.tf.example
@@ -41,19 +41,33 @@ locals {
   common_secrets = {
     "PROJECT_ID" : module.gh_cicd.project_id,
     "WIF_PROVIDER_NAME" : module.gh_oidc.provider_name,
-    "TF_BACKEND" : module.seed_bootstrap.gcs_bucket_tfstate,
     "TF_VAR_gh_token" : var.gh_token,
   }
 
+  backend_buckets = {
+    "bootstrap" = module.seed_bootstrap.gcs_bucket_tfstate
+    "org"       = module.seed_bootstrap.gcs_bucket_tfstate
+    "env"       = module.seed_bootstrap.gcs_bucket_tfstate
+    "net"       = module.seed_bootstrap.gcs_bucket_tfstate
+    "proj"      = module.gcp_projects_state_bucket.bucket.name
+  }
+
   secrets_list = flatten([
-    for k, v in local.gh_config : [
+    for k, v in local.gh_config : concat([
       for secret, plaintext in local.common_secrets : {
         config          = k
         secret_name     = secret
         plaintext_value = plaintext
         repository      = v
       }
-    ]
+      ], [
+      {
+        config          = k
+        secret_name     = "TF_BACKEND"
+        plaintext_value = local.backend_buckets[k]
+        repository      = v
+      }
+    ])
   ])
 
   sa_secrets = [for k, v in local.gh_config : {
@@ -95,10 +109,10 @@ module "gh_oidc" {
   source  = "terraform-google-modules/github-actions-runners/google//modules/gh-oidc"
   version = "~> 4.0"
 
-  project_id  = module.gh_cicd.project_id
-  pool_id     = "foundation-pool"
-  provider_id = "foundation-gh-provider"
-  sa_mapping  = local.sa_mapping
+  project_id          = module.gh_cicd.project_id
+  pool_id             = "foundation-pool"
+  provider_id         = "foundation-gh-provider"
+  sa_mapping          = local.sa_mapping
   attribute_condition = "assertion.repository_owner=='${var.gh_repos.owner}'"
 }
 

--- a/0-bootstrap/build_gitlab.tf.example
+++ b/0-bootstrap/build_gitlab.tf.example
@@ -48,19 +48,33 @@ locals {
     "PROJECT_ID" : module.gitlab_cicd.project_id,
     "CICD_RUNNER_REPO" : var.gl_repos.cicd_runner,
     "WIF_PROVIDER_NAME" : module.gitlab_oidc.provider_name,
-    "TF_BACKEND" : module.seed_bootstrap.gcs_bucket_tfstate,
     "TF_VAR_gitlab_token" : var.gitlab_token,
   }
 
+  backend_buckets = {
+    "bootstrap" = module.seed_bootstrap.gcs_bucket_tfstate
+    "org"       = module.seed_bootstrap.gcs_bucket_tfstate
+    "env"       = module.seed_bootstrap.gcs_bucket_tfstate
+    "net"       = module.seed_bootstrap.gcs_bucket_tfstate
+    "proj"      = module.gcp_projects_state_bucket.bucket.name
+  }
+
   vars_list = flatten([
-    for k, v in local.gl_config : [
+    for k, v in local.gl_config : concat([
       for name, value in local.common_vars : {
         config     = k
         name       = name
         value      = value
         repository = v
       }
-    ]
+      ], [
+      {
+        config     = k
+        name       = "TF_BACKEND"
+        value      = local.backend_buckets[k]
+        repository = v
+      }
+    ])
   ])
 
   sa_vars = [for k, v in local.gl_config : {


### PR DESCRIPTION
Currently, the TF_BACKEND secret for the 4-projects repository is mapped to the foundational bucket (`gcs_bucket_tfstate`) in both the GitHub and GitLab examples. 
This causes Step 4 to incorrectly store its state in the foundational bucket instead of its dedicated projects bucket (`projects_gcs_bucket_tfstate`), breaking the state isolation principle and causing downstream failures for Step 5.

This commit introduces a mapping to ensure the 4-projects repository receives the correct backend bucket.