### PR TITLE
feat: gitlab depreciation warning

### DIFF
--- a/0-bootstrap/README-GitLab.md
+++ b/0-bootstrap/README-GitLab.md
@@ -1,3 +1,5 @@
+*Warning: the guidance for deploying with GitLab is no longer actively tested or maintained. While we have left the guidance available for users who prefer GitLab, we make no guarantees about its quality, and you might be responsible for troubleshooting and modifying the directions.*
+
 # Deploying a GitLab CI/CD compatible environment
 
 The objective of the following instructions is to configure the infrastructure that allows CI/CD deployments using

--- a/0-bootstrap/README.md
+++ b/0-bootstrap/README.md
@@ -191,6 +191,8 @@ Using GitHub Actions requires manual creation of the GitHub repositories used in
 
 ## Deploying with GitLab Pipelines
 
+*Warning: the guidance for deploying with GitLab Pipelines is no longer actively tested or maintained. While we have left the guidance available for users who prefer GitLab Pipelines, we make no guarantees about its quality, and you might be responsible for troubleshooting and modifying the directions.*
+
 If you are deploying using [GitLab Pipelines](https://docs.gitlab.com/ee/ci/pipelines/), see [README-GitLab.md](./README-GitLab.md)
 for requirements and instructions on how to run the 0-bootstrap step.
 Using GitLab Pipeline requires manual creation of the GitLab projects (repositories) used in each stage.


### PR DESCRIPTION
Updates documentation to mark GitLab guidance as deprecated.
We will stop testing this integration immediately, and the code will be removed in the near future.

**DEPRECATED**: GitLab deployment instructions.