### PR TITLE
test: skip CI/CD resources creation in 0-bootstrap integration tests

### DIFF
--- a/test/integration/bootstrap/bootstrap_test.go
+++ b/test/integration/bootstrap/bootstrap_test.go
@@ -33,18 +33,21 @@ import (
 	"github.com/terraform-google-modules/terraform-example-foundation/test/integration/testutils"
 )
 
-// envBootstrapBuildType selects which bootstrap variant the integration test expects.
-// Empty or "cb" (default): full Cloud Build assertions — requires 0-bootstrap in cb mode
-// (active build_cb.tf, outputs_cb.tf, versions_cb.tf), as in a clean clone / CI.
-// "local": skips Cloud Build / CSR / trigger checks — use after ./scripts/choose_build_type.sh local
-// and the same terraform.tfvars you would use for a local-only apply.
+// envBootstrapBuildType selects which bootstrap variant the integration test runs.
+// "local" (default): no Cloud Build / CSR / trigger resources are created. The test
+// switches 0-bootstrap to the local variant before applying and restores the original
+// build type on teardown. This is the cheap path and works for new organizations that
+// cannot use the discontinued Cloud Source Repositories.
+// "cb" (opt-in via BOOTSTRAP_BUILD_TYPE=cb): full Cloud Build assertions — requires
+// 0-bootstrap already in cb mode (active build_cb.tf, outputs_cb.tf, versions_cb.tf),
+// as in a clean clone / CI. No file switching is performed in this mode.
 const envBootstrapBuildType = "BOOTSTRAP_BUILD_TYPE"
 
 func bootstrapBuildType() string {
 	if v := strings.TrimSpace(os.Getenv(envBootstrapBuildType)); v != "" {
 		return strings.ToLower(v)
 	}
-	return "cb"
+	return "local"
 }
 
 func isLocalBootstrapBuild() bool {
@@ -64,6 +67,27 @@ func fileExists(filePath string) (bool, error) {
 }
 
 func TestBootstrap(t *testing.T) {
+
+	// When running in the default "local" build type, switch 0-bootstrap to the local
+	// variant (no CSR / Cloud Build) before any terraform init reads the files. Record
+	// the original build type and register a t.Cleanup restore so the shared checkout is
+	// returned to its original state no matter how the test exits — t.Cleanup runs even
+	// if the blueprint-test teardown is skipped (e.g. TEARDOWN not enabled) or fails.
+	const bootstrapDir = "../../../0-bootstrap"
+	var originalBuildType string
+	if isLocalBootstrapBuild() {
+		var err error
+		originalBuildType, err = testutils.CurrentBuildType(bootstrapDir)
+		require.NoError(t, err)
+		if originalBuildType != "" && originalBuildType != "local" {
+			require.NoError(t, testutils.RenameBuildFiles(bootstrapDir, "local"))
+			t.Cleanup(func() {
+				if err := testutils.RenameBuildFiles(bootstrapDir, originalBuildType); err != nil {
+					t.Errorf("failed to restore 0-bootstrap build type to %q: %v", originalBuildType, err)
+				}
+			})
+		}
+	}
 
 	vars := map[string]interface{}{
 		"bucket_force_destroy":             true,
@@ -178,6 +202,12 @@ func TestBootstrap(t *testing.T) {
 				seedProjectID := bootstrap.GetStringOutput("seed_project_id")
 				cicdProjectID := bootstrap.GetStringOutput("cicd_project_id")
 				assert.Equal(seedProjectID, cicdProjectID, "local bootstrap should reuse seed as cicd_project_id")
+
+				// guarantee no Cloud Build / CSR variant is active
+				activeBuild, err := testutils.CurrentBuildType(bootstrapDir)
+				require.NoError(t, err)
+				assert.Equal("local", activeBuild, "0-bootstrap should be on the local build type (no CSR / Cloud Build)")
+
 				projectsStateBucket := bootstrap.GetStringOutput("projects_gcs_bucket_tfstate")
 				seedAlphaOpts := gcloud.WithCommonArgs([]string{"--project", seedProjectID, "--json"})
 				projStateBktList := gcloud.Run(t, fmt.Sprintf("alpha storage ls --buckets gs://%s", projectsStateBucket), seedAlphaOpts).Array()

--- a/test/integration/testutils/files.go
+++ b/test/integration/testutils/files.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// disableFileSuffix marks a build-type file as inactive (e.g. build_cb.tf.example).
+const disableFileSuffix = ".example"
+
+// AllowedBuildTypes are the CI/CD variants supported by 0-bootstrap. This mirrors
+// helpers/foundation-deployer/utils/files.go and 0-bootstrap/scripts/choose_build_type.sh,
+// with "local" added so the integration tests can switch the bootstrap into the
+// no-CI/CD variant (no Cloud Source Repositories, no Cloud Build) before applying.
+var AllowedBuildTypes = []string{"cb", "github", "gitlab", "terraform_cloud", "local"}
+
+// CurrentBuildType returns the build type currently active in basePath, detected
+// by the active build_<type>.tf file (i.e. without the .example suffix). It returns
+// an empty string if no build type is active. Callers use it to record the original
+// state so it can be restored on teardown, keeping the checkout non-destructive.
+func CurrentBuildType(basePath string) (string, error) {
+	for _, bt := range AllowedBuildTypes {
+		active, err := fileExists(filepath.Join(basePath, fmt.Sprintf("build_%s.tf", bt)))
+		if err != nil {
+			return "", err
+		}
+		if active {
+			return bt, nil
+		}
+	}
+	return "", nil
+}
+
+// RenameBuildFiles activates the targetBuild variant in basePath and deactivates
+// every other variant, by renaming *_<type>.tf <-> *_<type>.tf.example. It is
+// idempotent (re-running with an already-active target is a no-op) and mirrors the
+// logic of 0-bootstrap/scripts/choose_build_type.sh. Base files without a
+// _<type> suffix (main.tf, sa.tf, variables.tf, outputs.tf, ...) are never touched.
+//
+// NOTE: this mutates the working tree at basePath. When used against the shared
+// ../../../0-bootstrap checkout, callers must restore the original build type on
+// teardown. An abrupt interruption (panic/kill) before teardown can leave the tree
+// switched, the same caveat as disable_tf_files.sh / restore_tf_files.sh.
+func RenameBuildFiles(basePath, targetBuild string) error {
+	if !isAllowedBuildType(targetBuild) {
+		return fmt.Errorf("invalid build type %q, must be one of: %s", targetBuild, strings.Join(AllowedBuildTypes, ", "))
+	}
+
+	// Deactivate all other build types: *_<type>.tf -> *_<type>.tf.example
+	for _, bt := range AllowedBuildTypes {
+		if bt == targetBuild {
+			continue
+		}
+		pattern := filepath.Join(basePath, fmt.Sprintf("*_%s.tf", bt))
+		files, err := filepath.Glob(pattern)
+		if err != nil {
+			return fmt.Errorf("finding files to deactivate for build type %q: %w", bt, err)
+		}
+		for _, file := range files {
+			newName := file + disableFileSuffix
+			if err := os.Rename(file, newName); err != nil {
+				return fmt.Errorf("deactivating %q: %w", file, err)
+			}
+		}
+	}
+
+	// Activate the target: *_<target>.tf.example -> *_<target>.tf
+	pattern := filepath.Join(basePath, fmt.Sprintf("*_%s.tf%s", targetBuild, disableFileSuffix))
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		return fmt.Errorf("finding files to activate for build type %q: %w", targetBuild, err)
+	}
+	for _, file := range files {
+		newName := strings.TrimSuffix(file, disableFileSuffix)
+		if err := os.Rename(file, newName); err != nil {
+			return fmt.Errorf("activating %q: %w", file, err)
+		}
+	}
+	return nil
+}
+
+func isAllowedBuildType(bt string) bool {
+	for _, v := range AllowedBuildTypes {
+		if v == bt {
+			return true
+		}
+	}
+	return false
+}
+
+// fileExists reports whether path exists.
+func fileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}


### PR DESCRIPTION
Title: test: skip CI/CD resources creation in 0-bootstrap integration tests

Description:

Context
The 0-bootstrap integration tests unnecessarily provision Cloud Source Repositories (CSR) and Cloud Build triggers. Since we don't validate the pipeline execution itself, creating these resources showed to be unecessary on multiple cases.

Solution
To speed up tests this PR introduces a dynamic "local" mode managed entirely within the Go test layer.

Changes
Env Var: Added BOOTSTRAP_BUILD_TYPE (defaults to local) to control CI/CD provisioning.
Dynamic Toggle: Added testutils.RenameBuildFiles to temporarily disable CI/CD .tf files (by appending .example) before running Terraform.
Assertions: Skipped CSR and Cloud Build API validations in bootstrap_test.go when running in local mode.
Safety: Added a t.Cleanup hook to guarantee the 0-bootstrap directory is restored to its original state after the test, even if it panics.
**How to test**
Run the fast test (skips CSR/Cloud Build):

**make test_integration_bootstrap**

Run the full test (legacy behavior, provisions CSR):

**BOOTSTRAP_BUILD_TYPE=cb make test_integration_bootstrap**